### PR TITLE
Pass '--wait' to helm upgrade

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -18,6 +18,7 @@ def deploy(release):
         release,
         'jupyterhub/binderhub',
         '--version', config['version'],
+        '--wait',
         '-f', 'config/common.yaml',
         '-f', 'config/secret/common.yaml',
         '-f', os.path.join('config', release + '.yaml'),


### PR DESCRIPTION
This makes sure the deployment isn't marked as complete until
the pods are running & services are bound.