### PR TITLE
Set memory limits & guarantees

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -27,5 +27,9 @@ jupyterhub:
     https:
       enabled: true
       type: "kube-lego"
+  singleuser:
+    memory:
+      guarantee: 1G
+      limit: 4G
 
 repo2dockerImage: jupyter/repo2docker:v0.4.1


### PR DESCRIPTION
We lost a couple nodes to OOM because we hadn't had these set.
With this, users can still screw up nodes, but is harder since
it would require multiple users to do so!