### PR TITLE
bump binderhub chart

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0-010de6f
+version: 0.1.0-a6235f8
 
 service:
   type: ClusterIP


### PR DESCRIPTION
and thereby jupyterhub chart

latest update got the most recent minus one release, which missed the kubespawner bump