### PR TITLE
Revert "Merge PR #50 into beta"

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -32,4 +32,4 @@ jupyterhub:
       guarantee: 1G
       limit: 4G
 
-repo2dockerImage: jupyter/repo2docker:70677ed
+repo2dockerImage: jupyter/repo2docker:v0.4.1


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#52

Causing 'Internal Server Errors', unsure if it is related to this deploy tho.