### PR TITLE
Revert "https://github.com/jupyter/repo2docker/pull/88"

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -32,4 +32,4 @@ jupyterhub:
       guarantee: 1G
       limit: 4G
 
-repo2dockerImage: jupyter/repo2docker:70677ed
+repo2dockerImage: jupyter/repo2docker:v0.4.1


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#50

This broke beta, which was reverted in #53 