### PR TITLE
Bump BinderHub chart

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0-512fbac
+version: 0.1.0-691c2bc
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Deploys both https://github.com/jupyterhub/binderhub/pull/169 and
https://github.com/jupyterhub/binderhub/pull/170