### PR TITLE
Revert "Revert "bumping binderhub version to increase timeout limit per https://github.com/jupyterhub/binderhub/issues/188""

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0-3b1009b
+version: 0.1.0-94116a1
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#88

I've deleted all the running pods, so we now have space