### PR TITLE
Bump cull idle timeout down to 10mins instead of 1h

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -18,6 +18,8 @@ registry:
   enabled: true
 
 jupyterhub:
+  cull:
+    timeout: 600
   hub:
     extraConfigMap:
       cors: *cors


### PR DESCRIPTION
Since we are already running into capacity problems