### PR TITLE
Revert "bump r2d: #174"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -38,7 +38,7 @@ binderhub:
         guarantee: 1G
         limit: 4G
 
-  repo2dockerImage: jupyter/repo2docker:7a007d7
+  repo2dockerImage: jupyter/repo2docker:9dffb2c
 
 nginx-ingress:
   rbac:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#111

Reason:

Building `binder-examples/requirements` and `binder-examples/conda` results in this image:

```
File "/usr/local/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.6/subprocess.py", line 1275, in _execute_child
    restore_signals, start_new_session, preexec_fn)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

thoughts @betatim @yuvipanda ?