### PR TITLE
minor fixes in test_build

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -27,24 +27,22 @@ def push_dummy_gh_branch(repo, branch, keyfile):
         with open(branchfile, 'w') as f:
             f.write(branch)
         subprocess.check_call(['git', 'add', branchfile], cwd=gitdir)
-        subprocess.check_call(['git', 'commit', '-m', 'Dummy update for {}'.format(branch)], cwd=gitdir)
+        subprocess.check_call(['git', 'commit', '-m', f'Dummy update for {branch}'], cwd=gitdir)
         subprocess.check_call(
-            ['git', 'push', 'origin', 'HEAD:{}'.format(branch)],
-            env={
-                'GIT_SSH_COMMAND': 'ssh -i {}'.format(keyfile)
-            },
-            cwd=gitdir
+            ['git', 'push', 'origin', f'HEAD:{branch}'],
+            env=git_env,
+            cwd=gitdir,
         )
 
-        yield
-        # Delete the branch so we don't clutter!
-        subprocess.check_call(
-            ['git', 'push', 'origin', ':{}'.format(branch)],
-            env={
-                'GIT_SSH_COMMAND': 'ssh -i {}'.format(keyfile)
-            },
-            cwd=gitdir
-        )
+        try:
+            yield
+        finally:
+            # Delete the branch so we don't clutter!
+            subprocess.check_call(
+                ['git', 'push', 'origin', f':{branch}'],
+                env=git_env,
+                cwd=gitdir,
+            )
 
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,11 +1,13 @@
+from contextlib import contextmanager
 import json
-import pytest
-import requests
 import subprocess
 import tempfile
 import time
 import os
-from contextlib import contextmanager
+import sys
+
+import pytest
+import requests
 
 
 @contextmanager
@@ -54,14 +56,18 @@ def test_build_binder(binder_url):
     branch = str(time.time())
     repo = 'binderhub-ci-repos/requirements'
 
-    with push_dummy_gh_branch('git@github.com:/{}.git'.format(repo), branch, os.path.abspath('secrets/binderhub-ci-key')):
-        build_url = binder_url + '/build/gh/{repo}/{ref}'.format(repo=repo, ref=branch)
+    with push_dummy_gh_branch(f'git@github.com:/{repo}.git', branch, os.path.abspath('secrets/binderhub-ci-key')):
+        build_url = binder_url + f'/build/gh/{repo}/{branch}'
+        print(f"building {build_url}")
         r = requests.get(build_url, stream=True)
         r.raise_for_status()
         for line in r.iter_lines():
             line = line.decode('utf8')
             if line.startswith('data:'):
                 data = json.loads(line.split(':', 1)[1])
+                # include message output for debugging
+                if data.get('message'):
+                    sys.stdout.write(data['message'])
                 if data['phase'] == 'ready':
                     notebook_url = data['url']
                     token = data['token']
@@ -71,7 +77,7 @@ def test_build_binder(binder_url):
             assert False
 
         r = requests.get(notebook_url + '/api', headers={
-            'Authorization': 'token {}'.format(token)
+            'Authorization': f'token {token}'
         })
         assert r.status_code == 200
         assert 'version' in r.json()


### PR DESCRIPTION
- ensure branch cleanup happens (if `yield` raises due to test failure, cleanup was being skipped)
- echo build messages to stdout, so they will be in 'captured stdout' report on test failure
- use f-strings because we're on Python 3.6! 🎉 

I made two small commits directly to staging to get the build working, since it was preventing successful deploy:

- 056181f403f959b12b3d023bf0b28518da6ec289 ensures the deploy key is used in the initial clone, because *a* key is required to clone with ssh. Local testing doesn't run into this because most of us will have a default ssh key that works.
- 657214fa390219d44577e1e3b438029776c91230 fixes permissions on the deploy private key, which git-crypt was unpacking as world-readable and ssh refused to use private keys with open permissions