### PR TITLE
use tc-init to limit egress bandwidth in user containers

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -37,6 +37,20 @@ binderhub:
       memory:
         guarantee: 1G
         limit: 4G
+      initContainers:
+      - name: tc-init
+        image: minrk/tc-init:0.0.3
+        env:
+          - name: EGRESS_BANDWIDTH
+            value: 1mbit
+        securityContext:
+          # capabilities.add seems to be disabled
+          # by the `runAsUser: 1000` in the pod-level securityContext
+          # unless we explicitly run as root
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
 
   repo2dockerImage: jupyter/repo2docker:093184b
 


### PR DESCRIPTION
The current limit is 1mbit (128kB/s). Should it be something different? Lower? Higher?

As it is now, there aren't very many valid use cases for sending data out from a binder, but once there is the option to load GitHub credentials and push, then 128k might start feeling pretty slow. I'd rather wait and then turn it up than find out we have a problem and turn it down, though.

This is the upload bandwidth for connections initiated from the container.

Specifically **not** affected:

1. downloads from the container initiated from outside (e.g. browser downloads/UI)
2. downloads to the container initiated from the container (e.g. download of data files into the container)

Only running binders are affected, not builds which are still a place where arbitrary user code executes. But builds don't yet expose initContainer config at the moment, and our concurrent build limit and the possibility of a build timeout (do we have one?) also makes this a less valuable target.

This is the main part of #146