### PR TITLE
Revert "use tc-init to limit egress bandwidth in user containers"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -37,20 +37,6 @@ binderhub:
       memory:
         guarantee: 1G
         limit: 4G
-      initContainers:
-      - name: tc-init
-        image: minrk/tc-init:0.0.3
-        env:
-          - name: EGRESS_BANDWIDTH
-            value: 1mbit
-        securityContext:
-          # capabilities.add seems to be disabled
-          # by the `runAsUser: 1000` in the pod-level securityContext
-          # unless we explicitly run as root
-          runAsUser: 0
-          capabilities:
-            add:
-            - NET_ADMIN
 
   repo2dockerImage: jupyter/repo2docker:093184b
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#161

IIRC, this will make it seem to users that mybinder.org is being accessed over a 
128k connection, which is too slow. I'd recommend a 100Mbit limit.