### PR TITLE
whitelist local network in tc-init

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -39,8 +39,10 @@ binderhub:
         limit: 4G
       initContainers:
       - name: tc-init
-        image: minrk/tc-init:0.0.3
+        image: minrk/tc-init:0.0.4
         env:
+          - name: WHITELIST_CIDR
+            value: 10.0.0.0/8
           - name: EGRESS_BANDWIDTH
             value: 1mbit
         securityContext:


### PR DESCRIPTION
follow-up to #161

@yuvipanda pointed out that egress bandwidth was throttling UI, which would be too harsh.

This PR whitelists 10.x.x.x traffic, effectively preventing the egress bandwidth from applying to traffic coming from or going to browsers through the proxy, or local communication with the Hub, etc.

This is still having no effect on binder until the latest updates to the jupyterhub chart propagate through the binderhub chart.