### PR TITLE
bump charts, update ingresses

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,6 +1,7 @@
 binderhub:
   ingress:
-    host: mybinder.org
+    hosts:
+      - mybinder.org
 
   registry:
     prefix: gcr.io/binder-prod/prod-v4-1-
@@ -10,7 +11,12 @@ binderhub:
 
   jupyterhub:
     ingress:
-      host: hub.mybinder.org
+      hosts:
+        - hub.mybinder.org
+      tls:
+        - secretName: kubelego-tls-jupyterhub-prod
+          hosts:
+            - hub.mybinder.org
 
   googleAnalyticsCode: "UA-101904940-1"
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,6 +1,7 @@
 binderhub:
   ingress:
-    host: staging.mybinder.org
+    hosts:
+      - staging.mybinder.org
 
   registry:
     prefix: gcr.io/binder-staging/image-v0-4-
@@ -10,7 +11,12 @@ binderhub:
 
   jupyterhub:
     ingress:
-      host: hub.staging.mybinder.org
+      hosts:
+        - hub.staging.mybinder.org
+      tls:
+        - secretName: kubelego-tls-jupyterhub-staging
+          hosts:
+            - hub.staging.mybinder.org
 
 nginx-ingress:
   controller:

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-e2cffe5
+   version: 0.1.0-0b6c4f4
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -25,14 +25,15 @@ binderhub:
     proxy:
       service:
         type: ClusterIP
+      https:
+        enabled: true
+        letsencrypt:
+          contactEmail: yuvipanda@gmail.com
     ingress:
       enabled: true
       annotations:
         ingress.kubernetes.io/proxy-body-size: 64m
         kubernetes.io/ingress.class: nginx
-      https:
-        enabled: true
-        type: "kube-lego"
     singleuser:
       memory:
         guarantee: 1G

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -25,15 +25,12 @@ binderhub:
     proxy:
       service:
         type: ClusterIP
-      https:
-        enabled: true
-        letsencrypt:
-          contactEmail: yuvipanda@gmail.com
     ingress:
       enabled: true
       annotations:
         ingress.kubernetes.io/proxy-body-size: 64m
         kubernetes.io/ingress.class: nginx
+        kubernetes.io/tls-acme: "true"
     singleuser:
       memory:
         guarantee: 1G


### PR DESCRIPTION
latest jupyterhub chart changes how letsencrypt ingresses are handled. JupyterHub's ingresses have changed:

1. jupyterhub lego support has moved to an internal egress with its own controller
2. the 'regular' ingress has removed automatic kube-lego support, so lego config needs to be applied manually here

- [x] needs to wait for binderhub chart to get https://github.com/jupyterhub/binderhub/pull/305 for the ingress updates

Landing this PR gets two important changes from the jupyterhub chart:

1. updates to KubeSpawner, which should fix pods orphaned by spawn timeouts (this is most of the really long-running pods, I think)
2. support for initContainers, so the tc-init bits enabling bandwidth throttling will start taking effect