### PR TITLE
Add pod health check notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*~
+__pycache__
+*.py[co]
+.cache
+
+mybinder/charts
+mybinder/requirements.lock
+
+.ipynb_checkpoints

--- a/scripts/pod-health-check.ipynb
+++ b/scripts/pod-health-check.ipynb
@@ -1,0 +1,477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Binder pod health check\n",
+    "\n",
+    "This notebook uses the Kubernetes and JupyterHub APIs\n",
+    "to check the health of a Binder deployment.\n",
+    "\n",
+    "This notebook:\n",
+    "\n",
+    "- retrieves the user list from jupyterhub\n",
+    "- retrieves user pods from kubernetes\n",
+    "- looks for pods that don't map to users (orphaned pods)\n",
+    "- creates a summary report for current pods (status and orphan)\n",
+    "- deletes orphaned pods, if desired"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Connect to Kubernetes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import kubernetes.config\n",
+    "import kubernetes.client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Enter the name of the Kubernetes context and the namespace you want to check:\n",
+    "\n",
+    "context could be something like `gke_binder-prod_us-central1-a_prod-a`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context = 'prod-a'\n",
+    "namespace = 'prod'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kubernetes.config.load_kube_config(context=context)\n",
+    "kube = kubernetes.client.CoreV1Api()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[ ns.metadata.name for ns in kube.list_namespace().items ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: get current state\n",
+    "\n",
+    "- fetch userlist from JupyterHub\n",
+    "- fetch user pods from kubernetes\n",
+    "  (we only care about user pods, not the rest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import requests\n",
+    "\n",
+    "def get_hub_users():\n",
+    "    \"\"\"Return the list of currently active usernames\"\"\"\n",
+    "    binder_secret = [\n",
+    "        s for s in kube.list_namespaced_secret(namespace).items\n",
+    "        if s.metadata.name == 'binder-secret'\n",
+    "    ][0]\n",
+    "    binder_config = [\n",
+    "        c for c in kube.list_namespaced_config_map(namespace).items\n",
+    "        if c.metadata.name == 'binder-config'\n",
+    "    ][0]\n",
+    "\n",
+    "    b64_hub_token = binder_secret.data['binder.hub-token']\n",
+    "    hub_api_token = base64.b64decode(b64_hub_token).decode('ascii')\n",
+    "    hub_url = binder_config.data['binder.hub-url'].rstrip('/')\n",
+    "    \n",
+    "    r = requests.get(\n",
+    "        hub_url + '/hub/api/users',\n",
+    "        headers={'Authorization': f'token {hub_api_token}'},\n",
+    "    )\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_jupyter_pods():\n",
+    "    \"\"\"Get all of the pods that should map to users\"\"\"\n",
+    "    return [\n",
+    "        pod for pod in kube.list_namespaced_pod(namespace=namespace).items\n",
+    "        if pod.metadata.labels.get('component') == 'singleuser-server'\n",
+    "        and pod.metadata.labels.get('heritage') == 'jupyterhub'\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "fetch users and pods at the same time to minimize\n",
+    "chance of races.\n",
+    "\n",
+    "Get users after pods to ensure that a race doesn't look like an orphan."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pods = get_jupyter_pods()\n",
+    "users = get_hub_users()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3. identify orphaned pods\n",
+    "\n",
+    "Construct a set of usernames of active users (ignoring those with stopped servers,\n",
+    "either because they haven't started yet, or have shutdown for some reason)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# filter to active users\n",
+    "active_users = [ u for u in users if u['pending'] or u['server'] ]\n",
+    "# create set of names for active users\n",
+    "usernames = {user['name'] for user in active_users}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Identify the pods that have been orphaned (i.e. do not map to a user)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import escapism\n",
+    "orphaned_pods = [\n",
+    "    pod for pod in pods\n",
+    "    if escapism.unescape(\n",
+    "        pod.metadata.labels['hub.jupyter.org/username'],\n",
+    "        escape_char='_') not in usernames\n",
+    "]\n",
+    "# sanity check: make sure not all pods are orphans\n",
+    "assert len(orphaned_pods) != len(pods), \"All pods appear to be orphans!\"\n",
+    "print(f\"{len(orphaned_pods)} apparently orphaned pods:\")\n",
+    "[ pod.metadata.name for pod in orphaned_pods ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4. report!\n",
+    "\n",
+    "This builds a simple report of the current pods and their statuses.\n",
+    "Orphaned pods have a big ❌ next to them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import Counter\n",
+    "import datetime\n",
+    "\n",
+    "import jinja2\n",
+    "from IPython.display import Markdown\n",
+    "\n",
+    "def get_pod_status(pod):\n",
+    "    \"\"\"Get the pod status\"\"\"\n",
+    "    container_state = pod.status.container_statuses[0].state\n",
+    "    if container_state.waiting:\n",
+    "        return container_state.waiting.reason\n",
+    "    else:\n",
+    "        return 'Running'\n",
+    "\n",
+    "# sort pods by creation date\n",
+    "pods = sorted(pods, key=lambda pod: pod.metadata.creation_timestamp)\n",
+    "active_pods = [pod for pod in pods if pod not in orphaned_pods]\n",
+    "status_counter = Counter([get_pod_status(pod) for pod in pods])\n",
+    "orphan_status_counter = Counter([get_pod_status(pod) for pod in orphaned_pods])\n",
+    "\n",
+    "def relative_date(dt):\n",
+    "    \"\"\"Render a datetime as a concise relative date\"\"\"\n",
+    "    td = datetime.datetime.now(tz=datetime.timezone.utc) - dt\n",
+    "    \n",
+    "    if td.days:\n",
+    "        return f\"{td.days}d\"\n",
+    "    if td.seconds >= 3600:\n",
+    "        return f\"{td.seconds // 3600}h\"\n",
+    "    return f\"{td.seconds // 60}m\"\n",
+    "\n",
+    "jinja_env = jinja2.Environment()\n",
+    "\n",
+    "jinja_env.filters['get_pod_status'] = get_pod_status\n",
+    "jinja_env.filters['relative_date'] = relative_date\n",
+    "\n",
+    "tpl = jinja_env.from_string(\"\"\"\n",
+    "We have {{pods | length}} pods, of which {{orphaned_pods | length}} are orphaned.\n",
+    "\n",
+    "{% if active_pods | length != active_users | length %}\n",
+    "**From the users list, we would expect {{active_users | length}} active pods,\n",
+    "but found {{active_pods | length}}.\n",
+    "Our orphan classification may be incorrect!**\n",
+    "{% endif %}\n",
+    "\n",
+    "Pods are in the following states:\n",
+    "\n",
+    "{% for status, count in status_counter.items() %}\n",
+    "- {{status}}: {{count}} pods\n",
+    "  {%- if orphan_status_counter[status] %}\n",
+    "  ({{orphan_status_counter[status]}}/{{count}} orphaned)\n",
+    "  {%- endif %}\n",
+    "{% endfor %}\n",
+    "\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <th>orphaned</th>\n",
+    "    <th>pod</th>\n",
+    "    <th>status</th>\n",
+    "    <th>age</th>\n",
+    "  </tr>\n",
+    "\n",
+    "  {% for pod in pods %}\n",
+    "  <tr>\n",
+    "    <td>\n",
+    "    {% if pod in orphaned_pods %}\n",
+    "    ❌\n",
+    "    {% endif %}\n",
+    "    </td>\n",
+    "    <td>\n",
+    "    {{ pod.metadata.name }}\n",
+    "    </td>\n",
+    "    <td>\n",
+    "    {{ pod | get_pod_status }}\n",
+    "    </td>\n",
+    "    <td>\n",
+    "    {{ pod.metadata.creation_timestamp | relative_date }}\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "  {% endfor %}\n",
+    "</table>\n",
+    "\"\"\")\n",
+    "\n",
+    "Markdown(tpl.render(**globals()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: cleanup orphaned pods\n",
+    "\n",
+    "Now that we've looked at that report,\n",
+    "we can start to cleanup any pods that shouldn't be there.\n",
+    "\n",
+    "We start with a sanity check to ensure we don't proceed beyond this point\n",
+    "if our orphan check isn't trustworthy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'pods' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-1-4e07d037981d>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mexpected\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpods\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mactual\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0morphaned_pods\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m+\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mactive_users\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf\"orphaned pods + active users = {actual} =? {expected}\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf\"{len(orphaned_pods):13} + {len(active_users):12} = {actual} =? {expected}\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0morphaned_pods\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m+\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mactive_users\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpods\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'pods' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "expected = len(pods)\n",
+    "actual = len(orphaned_pods) + len(active_users)\n",
+    "print(f\"orphaned pods + active users = {actual} =? {expected}\")\n",
+    "print(f\"{len(orphaned_pods):13} + {len(active_users):12} = {actual} =? {expected}\")\n",
+    "if len(orphaned_pods) + len(active_users) != len(pods):\n",
+    "    raise ValueError(\"Some of the orphaned could be mislabled!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can delete the orphaned pods,\n",
+    "if it really looks like they won't be cleaned up by normal Hub means."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kubernetes.client.rest import ApiException\n",
+    "\n",
+    "def delete_pod(name):\n",
+    "    \"\"\"Delete a single pod\n",
+    "    \n",
+    "    ignore 404 for already deleted pods\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        kube.delete_namespaced_pod(\n",
+    "            name, namespace,\n",
+    "            kubernetes.client.V1DeleteOptions(grace_period_seconds=0),\n",
+    "        )\n",
+    "    except ApiException as e:\n",
+    "        if e.status == 404:\n",
+    "            print(f\"Already deleted pod {name}\")\n",
+    "        else:\n",
+    "            raise\n",
+    "    \n",
+    "def delete_orphaned_pods(noconfirm=False):\n",
+    "    \"\"\"Delete all orphaned pods\n",
+    "    \n",
+    "    with confirmation to avoid triggering on Run All\n",
+    "    \"\"\"\n",
+    "    if not noconfirm:\n",
+    "        r = input(f\"Are you sure you want to delete {len(orphaned_pods)} pod(s)? [y/N] \")\n",
+    "        if not r.lower().startswith('y'):\n",
+    "            print(\"Cancelled\")\n",
+    "            return\n",
+    "        \n",
+    "    for pod in orphaned_pods:\n",
+    "        name = pod.metadata.name\n",
+    "        print(f\"Deleting orphaned pod {name}\")\n",
+    "        delete_pod(name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete_orphaned_pods()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We shouldn't generally have to do this one,\n",
+    "but sometimes a user pod might be left running for a really long time.\n",
+    "\n",
+    "This could be intentional, or it could be a window left open,\n",
+    "or it could be an activity-tracking bug.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def delete_pods_older_than(hours, *,noconfirm=False):\n",
+    "    \"\"\"Delete pods older than the given number of hours\n",
+    "    \n",
+    "    a timedelta can be passed for other time intervals.\n",
+    "    \"\"\"\n",
+    "    if isinstance(hours, datetime.timedelta):\n",
+    "        td = hours\n",
+    "    else:\n",
+    "        td = datetime.timedelta(hours=hours)\n",
+    "    cutoff = datetime.datetime.now(tz=datetime.timezone.utc) - td\n",
+    "    old_pods = [ pod for pod in pods if pod.metadata.creation_timestamp < cutoff ]\n",
+    "    if not old_pods:\n",
+    "        print(\"No pods to delete\")\n",
+    "        return\n",
+    "\n",
+    "    if not noconfirm:\n",
+    "        r = input(f\"Are you sure you want to delete {len(old_pods)} pod(s) older than {relative_date(cutoff)}? [y/N] \")\n",
+    "        if not r.lower().startswith('y'):\n",
+    "            print(\"Cancelled\")\n",
+    "            return\n",
+    "    \n",
+    "    for pod in pods:\n",
+    "        name = pod.metadata.name\n",
+    "        created = pod.metadata.creation_timestamp\n",
+    "        if created < cutoff:\n",
+    "            print(f\"Deleting {relative_date(created):3} old pod {name}\")\n",
+    "            delete_pod(name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete_pods_older_than(12)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Notebook that inspects the state of jupyterhub and running pods and creates a simple report, including identification of probable orphaned pods (i.e. user pods with no corresponding user registered with JupyterHub).

Example report from running earlier today:

<img width="620" alt="screen shot 2017-11-29 at 14 59 24" src="https://user-images.githubusercontent.com/151929/33380101-460589de-d51a-11e7-84d5-afe1c80b6c94.png">

Includes functions for deleting the orphaned pods if so desired.