### PR TITLE
Bump repo2docker version

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -4,7 +4,7 @@ binderhub:
       - mybinder.org
 
   registry:
-    prefix: gcr.io/binder-prod/prod-v4-1-
+    prefix: gcr.io/binder-prod/r2d-3cd4519
 
   hub:
     url: https://hub.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/image-v0-4-
+    prefix: gcr.io/binder-staging/r2d-3cd4519
 
   hub:
     url: https://hub.staging.mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -52,7 +52,7 @@ binderhub:
             add:
             - NET_ADMIN
 
-  repo2dockerImage: jupyter/repo2docker:093184b
+  repo2dockerImage: jupyter/repo2docker:3cd4519
 
 nginx-ingress:
   rbac:


### PR DESCRIPTION
- Change image prefix so all current images are invalidated. This
  gets in the crucial fix https://github.com/jupyter/repo2docker/pull/150
- Change image prefix to have repo2docker commit hash on it.