### PR TITLE
Make nginx-ingress only watch for ingresses in its own namespace

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
  - name: nginx-ingress
-   version: 0.8.9
+   version: 0.8.13
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
    version: 4.5.0

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -85,6 +85,8 @@ nginx-ingress:
       annotations:
         prometheus.io/scrape: "true"
   controller:
+    scope:
+      enabled: true
     config:
       # Allow POSTs of upto 64MB, for large notebook support.
       proxy-body-size: 64m


### PR DESCRIPTION
This prevents cross-talk between different namespaces. Especially
useful when running on staging, since nginx controller can be
reloaded unnecessarily.

Also bump nginx ingress version while we are at it