### PR TITLE
band-aid: sleep to give the deployment time to wake up

### DIFF
--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -40,6 +40,11 @@ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 
 python3 ./deploy.py deploy ${TARGET}
 
+# FIXME: add readiness probe so that deploy doesn't finish before
+# hub is available.
+# For now, sleep to give deploy a chance to warm up.
+sleep 10
+
 # Run some tests to make sure we really did pass!
 py.test --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
 


### PR DESCRIPTION
we *should* be using a readiness probe so that `deploy.py` doesn't return before the deployment is fully ready.

This sleep should let us reduce the number of times we need to re-run travis in the meantime.

Remove this when we get a proper readiness probe!