### PR TITLE
deploy repo2docker fixes

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -4,7 +4,7 @@ binderhub:
       - mybinder.org
 
   registry:
-    prefix: gcr.io/binder-prod/r2d-3cd4519
+    prefix: gcr.io/binder-prod/r2d-fd74043
 
   hub:
     url: https://hub.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/r2d-3cd4519
+    prefix: gcr.io/binder-staging/r2d-fd74043
 
   hub:
     url: https://hub.staging.mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -75,7 +75,7 @@ binderhub:
             add:
             - NET_ADMIN
 
-  repo2dockerImage: jupyter/repo2docker:3cd4519
+  repo2dockerImage: jupyter/repo2docker:fd74043
 
 nginx-ingress:
   rbac:


### PR DESCRIPTION
versions bumped:

- jupyterlab 0.29.2
- ipywidgets 6.0.1

venv uses frozen env spec for reproduciblity

image cache is invalidated due to jupyterlab version pinning problem in previous version