### PR TITLE
Guarantee 1G of RAM each for both containers in hub proxy

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -25,6 +25,14 @@ binderhub:
     proxy:
       service:
         type: ClusterIP
+      chp:
+        resources:
+          requests:
+            memory: 1Gi
+      nginx:
+        resources:
+          requests:
+            memory: 1Gi
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
It's our SPOF, so let's treat it well. It dying probably contributed
to an outage just now.