### PR TITLE
Fixup Grafana + Prometheus

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -20,6 +20,26 @@ binderhub:
 
   googleAnalyticsCode: "UA-101904940-1"
 
+grafana:
+  server:
+    ingress:
+      hosts:
+        - grafana.mybinder.org
+      tls:
+        - hosts:
+            - grafana.mybinder.org
+          secretName: kubelego-tls-grafana
+
+prometheus:
+  server:
+    ingress:
+        hosts:
+          - prometheus.mybinder.org
+        tls:
+          - hosts:
+              - prometheus.mybinder.org
+            secretName: kubelego-tls-prometheus
+
 nginx-ingress:
   controller:
     service:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -18,6 +18,26 @@ binderhub:
           hosts:
             - hub.staging.mybinder.org
 
+grafana:
+  server:
+    ingress:
+      hosts:
+        - grafana.staging.mybinder.org
+      tls:
+        - hosts:
+            - grafana.staging.mybinder.org
+          secretName: kubelego-tls-grafana
+
+prometheus:
+  server:
+    ingress:
+        hosts:
+          - prometheus.staging.mybinder.org
+        tls:
+          - hosts:
+              - prometheus.staging.mybinder.org
+            secretName: kubelego-tls-prometheus
+
 nginx-ingress:
   controller:
     service:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -112,6 +112,49 @@ kube-lego:
   rbac:
     create: true
 
+grafana:
+  server:
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        kubernetes.io/tls-acme: "true"
+  serverConfigFile:
+    grafana.ini: |
+      ; instance_name = ${HOSTNAME}
+      [paths]
+      data = /var/lib/grafana/data
+      logs = /var/log/grafana
+      plugins = /var/lib/grafana/plugins
+
+      [snapshots]
+      external_enabled = true
+      external_snapshot_url = https://snapshots-origin.raintank.io
+      external_snapshot_name = Publish to snapshot.raintank.io
+
+      [users]
+      ;allow_sign_up = true
+      ;allow_org_create = true
+      ;auto_assign_org = true
+      ;auto_assign_org_role = Viewer
+      ;login_hint = email or username
+      ;default_theme = dark
+
+      [auth.anonymous]
+      enabled = true
+      org_name = Main Org.
+      org_role = Viewer
+
+      [log]
+      mode = console
+      level = info
+
+      [dashboards.json]
+      enabled = true
+      path = /var/lib/grafana/dashboards
+
+      [grafana_net]
+      url = https://grafana.net
 
 prometheus:
   alertmanager:
@@ -362,7 +405,6 @@ prometheus:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
-      hosts:
-        - prometheus.mybinder.org
+        kubernetes.io/tls-acme: "true"
     persistentVolume:
       size: 500Gi


### PR DESCRIPTION
- HTTPS for Grafana and Prometheus
- Enable anon viewers in Grafana
- Don't set up auth yet, just use the admin pw that is generated.
  We can set up GitHub Auth after https://github.com/kubernetes/charts/pull/2903
  is merged.