### PR TITLE
Bump playground version

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -88,7 +88,7 @@ binderhub:
 playground:
   image:
     name: yuvipanda/play.nteract.io
-    tag: v0.1
+    tag: v0.2
   replicas: 1
 
 nginx-ingress:


### PR DESCRIPTION
This contains style fixes, and sets the default image to
http://github.com/binder-examples/jupyter-stacks