### PR TITLE
Bump binderhub version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-da6b462
+   version: 0.1.0-6910d38
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Gets https://github.com/jupyterhub/binderhub/pull/329 and
https://github.com/jupyterhub/binderhub/pull/329