### PR TITLE
staging: enable docker-in-docker

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -16,6 +16,9 @@ binderhub:
   registry:
     enabled: true
 
+  dind:
+    enabled: true
+
   jupyterhub:
     cull:
       timeout: 600


### PR DESCRIPTION
support was added in the latest binderhub bump, now time to enable it