### PR TITLE
Revert "Revert "staging: enable docker-in-docker""

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -16,6 +16,9 @@ binderhub:
   registry:
     enabled: true
 
+  dind:
+    enabled: true
+
   jupyterhub:
     cull:
       timeout: 600


### PR DESCRIPTION
Retry docker-in-docker deploy

The dind directories on the nodes didn't look right. Deleting and recreating the pods fixed it, but it makes me nervous that this was necessary, especially since the two nodes behaved differently.

One node had no `/var/run/dind/docker.sock`, while the other had `/var/run/dind/docker.sock`, but it was a *directory*, which is weird and wrong (it should have been a socket).

After deploying this, assuming it succeeds, I am going to increase the cluster size to see if a new node gets a properly configured dind without intervention.