### PR TITLE
enable dind on prod

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,4 @@ dependencies:
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
    version: 0.1.0-fc29c17
-
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Let's keep an eye on this. The first deploy to staging failed, but after manual inspection and cleanup of `/var/run/dind`, staging is fine now. I've manually inspected the `/var/run/dind` directories on all prod nodes, and they all look okay, so whatever weird thing happened on staging does not appear to be happening on prod, but we should keep an eye out for failed builds and roll this back if we see problems.