### PR TITLE
bump repo2docker

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -86,7 +86,7 @@ binderhub:
             add:
             - NET_ADMIN
 
-  repo2dockerImage: jupyter/repo2docker:fd74043
+  repo2dockerImage: jupyter/repo2docker:1c7bd6e
 
 playground:
   image:


### PR DESCRIPTION
gets latest ipython, ipykernel, jupyterlab

Specifically *not* invalidating the current image cache by bumping the image prefix this time, so that we can see how that goes.

In general, repos shouldn't be expecting the latest jupyterlab/ipython/etc. in their containers unless they are specified explicitly in their requirements/environment.yml.