### PR TITLE
Setup a static host for serving badges from

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -45,6 +45,11 @@ nginx-ingress:
     service:
       loadBalancerIP: 35.202.202.188
 
+static:
+  ingress:
+    hosts:
+      - static.mybinder.org
+
 redirector:
   redirects:
     - type: host

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -43,6 +43,11 @@ nginx-ingress:
     service:
       loadBalancerIP: 104.197.11.66
 
+static:
+  ingress:
+    hosts:
+      - static.staging.mybinder.org
+
 redirector:
   redirects:
     - type: host

--- a/mybinder/templates/static/ingress.yaml
+++ b/mybinder/templates/static/ingress.yaml
@@ -1,0 +1,37 @@
+# Ingress that serves whitelisted static images only
+# This allows end users to include our badges without us
+# accidentally tracking all the people who see the badges.
+# https://github.com/jupyterhub/binderhub/issues/379 has more info.
+#
+# This is a separate path-whitelisted ingress rather than just
+# a domain alias to prevent possible reflection attacks.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: static
+  labels:
+    app: static
+    component: frontend
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    {{ $root := . }}
+    {{ range $host := .Values.static.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          {{ range $path := $root.Values.static.paths }}
+          - path: {{ $path }}
+            backend:
+              serviceName: binder
+              servicePort: 80
+          {{ end }}
+    {{ end }}
+  tls:
+    - secretName: kubelego-tls-static
+      hosts:
+      {{ range $host := .Values.static.ingress.hosts }}
+      - {{ $host }}
+      {{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -119,6 +119,10 @@ nginx-ingress:
       # Preserve client IPs
       externalTrafficPolicy: Local
 
+static:
+  paths:
+    - /badge.svg
+
 kube-lego:
   config:
     LEGO_EMAIL: yuvipanda@gmail.com


### PR DESCRIPTION
This stops sending any tracking cookie with the binder badge.

Partial fix for https://github.com/jupyterhub/binderhub/issues/379