### PR TITLE
Bump repo2docker version

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -91,7 +91,7 @@ binderhub:
             add:
             - NET_ADMIN
 
-  repo2dockerImage: jupyter/repo2docker:f7096ca
+  repo2dockerImage: jupyter/repo2docker:c929ef9
 
 playground:
   image:


### PR DESCRIPTION
https://github.com/jupyter/repo2docker/pull/182,
https://github.com/jupyter/repo2docker/pull/181 and
https://github.com/jupyter/repo2docker/pull/183 are the major
changes. The image is bigger now, since it's no longer based
on alpine.