### PR TITLE
band-aids for false-reporting tests

### DIFF
--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -43,9 +43,13 @@ python3 ./deploy.py deploy ${TARGET}
 # FIXME: add readiness probe so that deploy doesn't finish before
 # hub is available.
 # For now, sleep to give deploy a chance to warm up.
-sleep 10
+# The current reason for this sleep is that the nginx configuration reload drops connections,
+# which occurs *after* deployment is fully ready.
+# There does not appear to be a way to query whether nginx has finished updating.
+sleep 30
 
 # Run some tests to make sure we really did pass!
-py.test --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
+# Currently retrying to account for nginx dropping connections.
+travis_retry py.test --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
 
 echo "Done!"


### PR DESCRIPTION
Right now, we have an issue where deployments can fail (Travis is red) misleadingly because of nginx dropping connections.

This is tricky right now, because all deployments are 'finished' when this occurs, because nginx appears to reload configuration at runtime, not as part of any initialization that can be awaited (#187).

The band-aids are twofold:

1. Wait longer after finishing deployment before running tests.
   This is because we don't seem to have a way to directly wait for nginx configuration to load.
2. Re-run tests with travis_retry if they fail.
   This accounts for potentially flaky tests, currently failing.
   With the current failure mode, trying tests again immediately after failure will always work.
   This is what we have been doing manually by retriggering travis, but is now automatic and more efficient,
   since it only re-runs the tests and not the whole deploy.
   Doing the retry automatically removes the decision from humans (see #261).

These are not ideal, and should be removed if/when we can find a way to reliably wait for the nginx configuration to have reloaded prior to launching the tests.