### PR TITLE
Update binderhub staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ which we step through below.
 
 1. Merge changes to [BinderHub][].
 2. Open the [Travis build for BinderHub](https://travis-ci.org/jupyterhub/binderhub),
-   navigate to the page corresponding to the master branch.
+   navigate to the page corresponding to the master branch, `TEST=helm` job.
 3. If the build succeeds, grab the hash that is displayed at the end of the
    travis output. It looks something like:
 

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-441f5ea
+   version: 0.1.0-511cd5e
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
If I count correctly includes:
 - https://github.com/jupyterhub/binderhub/pull/395
   (remove unused formats for ClearSans webfont)
 - https://github.com/jupyterhub/binderhub/pull/396
   (Allow setting Google Analytics domain explicitly)
 - https://github.com/jupyterhub/binderhub/pull/397
   (Allow setting google analytics domain from helm chart)
 - https://github.com/jupyterhub/binderhub/pull/399
   (Updated initial message in form and clarity to UI element title)
 - https://github.com/jupyterhub/binderhub/pull/401
   (consolidate tips/notes)