### PR TITLE
Set googleAnalyticsDomain explicitly

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -19,6 +19,7 @@ binderhub:
             - hub.mybinder.org
 
   googleAnalyticsCode: "UA-101904940-1"
+  googleAnalyticsDomain: "mybinder.org"
 
 grafana:
   server:


### PR DESCRIPTION
This makes sure we don't set tracking cookies for *.mybinder.org