### PR TITLE
Remove bandwidth throttling from build pods

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -23,7 +23,32 @@ binderhub:
 
   dind:
     enabled: true
-    initContainers: *initContainers
+    initContainers:
+      # Only block access to metadata service, do not throttle network
+      # egress yet, since that slows down image pushing
+      - name: block-metadata
+        image: minrk/tc-init:0.0.4
+        # Block access to GCE Metadata Service from user pods!
+        command:
+          - iptables
+          - -A
+          - OUTPUT
+          - -p
+          - tcp
+          - --dport
+          - "80"
+          - -d
+          - 169.254.169.254
+          - -j
+          - DROP
+        securityContext:
+          # capabilities.add seems to be disabled
+          # by the `runAsUser: 1000` in the pod-level securityContext
+          # unless we explicitly run as root
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
 
   jupyterhub:
     cull:
@@ -52,7 +77,7 @@ binderhub:
       memory:
         guarantee: 1G
         limit: 4G
-      initContainers: &initContainers
+      initContainers:
       - name: tc-init
         image: minrk/tc-init:0.0.4
         env:


### PR DESCRIPTION
This throttles push bandwidth to the image registry,
making pushes unusably slow. We can't whitelist it easily
since there's no clear fixed API range for that endpoint.

Reopens #230 