### PR TITLE
Explicitly wait for all deployments & daemonsets

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -23,26 +23,28 @@ def deploy(release):
 
     subprocess.check_call(helm)
 
-    # Explicitly wait for the hub, proxy and binder deployments to be up and running
-    # --wait in helm isn't good enough for these
-    subprocess.check_call([
-        'kubectl', 'rollout', 'status',
-        '--namespace', release,
-        '--watch', 'deployment/hub',
-    ])
+    # Explicitly wait for all deployments and daemonsets to be fully rolled out
 
-    subprocess.check_call([
-        'kubectl', 'rollout', 'status',
+    deployments = subprocess.check_output([
+        'kubectl',
         '--namespace', release,
-        '--watch', 'deployment/binder',
-    ])
+        'get', 'deployments',
+        '-o', 'name'
+    ]).decode().strip().split('\n')
 
-    subprocess.check_call([
-        'kubectl', 'rollout', 'status',
+    daemonsets = subprocess.check_output([
+        'kubectl',
         '--namespace', release,
-        '--watch', 'deployment/proxy',
-    ])
+        'get', 'daemonsets',
+        '-o', 'name'
+    ]).decode().strip().split('\n')
 
+    for d in deployments + daemonsets:
+        subprocess.check_call([
+            'kubectl', 'rollout', 'status',
+            '--namespace', release,
+            '--watch', d
+        ])
 
 
 def main():

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
    version: 0.8.13
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
-   version: 4.5.0
+   version: 4.6.16
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
    version: 0.5.0

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -201,6 +201,9 @@ grafana:
       url = https://grafana.net
 
 prometheus:
+  nodeExporter:
+    updateStrategy:
+      type: RollingUpdate
   alertmanager:
     enabled: false
   pushgateway:


### PR DESCRIPTION
Not just for specific ones. This makes sure that our deployment
is truly complete before we start our tests in travis.

Had to bump prometheus version to get ability to specify
updateStrategy for nodeExporter, without which kubectl rollout
does not work.