### PR TITLE
Bump helm timeout to 600s

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -17,6 +17,7 @@ def deploy(release):
         release,
         'mybinder',
         '--wait',
+        '--timeout', '600',
         '-f', os.path.join('config', release + '.yaml'),
         '-f', os.path.join('secrets', 'config', release + '.yaml')
     ]


### PR DESCRIPTION
Currently it is at 300s, which can fail sometimes when large
images need to be pulled.