### PR TITLE
Increase Ingress replicas count

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -45,6 +45,7 @@ nginx-ingress:
   controller:
     service:
       loadBalancerIP: 35.202.202.188
+    replicaCount: 10
 
 static:
   ingress:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -42,6 +42,7 @@ nginx-ingress:
   controller:
     service:
       loadBalancerIP: 104.197.11.66
+    replicaCount: 4
 
 static:
   ingress:


### PR DESCRIPTION
Increasing the replica count on prod and reducing on staging. Staging is mostly to check that setting individual values for prod and staging works.

I remember a while back we had to increase the number of ingress replicas because "of reasons". There doesn't seem to be anything obviously wrong with the cluster but people can't connect to their spawned pods. This seems like a cheap thing to do.