### PR TITLE
bumping binderhub + packing users and reducing memory ceiling

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-fbd816c
+   version: 0.1.0-3f81760
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -75,8 +75,8 @@ binderhub:
         kubernetes.io/tls-acme: "true"
     singleuser:
       memory:
-        guarantee: 1G
-        limit: 4G
+        guarantee: 2G
+        limit: 2G
       initContainers:
       - name: tc-init
         image: minrk/tc-init:0.0.4
@@ -116,7 +116,7 @@ binderhub:
           capabilities:
             add:
             - NET_ADMIN
-
+    schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:6e9088d
 
 playground:


### PR DESCRIPTION
This gets a new version of BinderHub which lets us change how users are distributed across nodes. It then asks kubernetes to pack them onto fewer nodes and lowers the memory limit. Still needs the BinderHub version bump which I'll add once tests pass. cc @yuvipanda 