### PR TITLE
Add snippet to remove a node

### DIFF
--- a/docs/source/command_snippets.md
+++ b/docs/source/command_snippets.md
@@ -17,3 +17,15 @@ or all those that have existed for more than 24hours:
 ```
 kubectl get pod --namespace=prod | grep '^jupyter-' | grep 'd$' | awk '{print $1}')
 ```
+
+
+## Remove a node from the cluster
+
+First cordon off the node with `kubectl cordon <nodename>`.
+Wait for there to be no `jupyter-*` pods on the node. You can check this with
+`kubectl get pods --namespace=prod -o wide | grep "<nodename>$" | grep "^jupyter-"`.
+Then drain the node `kubectl drain <nodename>`. The kubectl drain command will
+most likely give you an error about certain pods running on the node that
+prevent it from draining the node. It is Ok (and expected) to use the suggested
+flags to force the draining: `kubectl drain <nodename> --ignore-daemonsets --force --delete-local-data`. The autoscaler should now remove the  node for you.
+This can take 10-15minutes.


### PR DESCRIPTION
Closes #292 and starts adding commands that are useful to the SRE guide in the snippets section.

Should the section be renamed? I am Ok with its current name.