### PR TITLE
Bump repo2docker version

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -117,7 +117,7 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
-  repo2dockerImage: jupyter/repo2docker:6e9088d
+  repo2dockerImage: jupyter/repo2docker:e046c11
 
 playground:
   image:


### PR DESCRIPTION
Brings in:

- https://github.com/jupyter/repo2docker/pull/210
- https://github.com/jupyter/repo2docker/pull/209
- https://github.com/jupyter/repo2docker/pull/208
- https://github.com/jupyter/repo2docker/pull/207
- https://github.com/jupyter/repo2docker/pull/206
- https://github.com/jupyter/repo2docker/pull/205
- https://github.com/jupyter/repo2docker/pull/204
- https://github.com/jupyter/repo2docker/pull/200