### PR TITLE
Temporarily block berkeley's nbinteract repos

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -2,7 +2,8 @@ binderhub:
   extraConfig:
     bans: |
         c.GitHubRepoProvider.banned_specs = [
-          '^navoshta/juno-demo-notebooks.*'
+          '^ds-100/textbook.*',
+          '^samlau95/nbinteract-image.*'
         ]
   service:
     type: ClusterIP


### PR DESCRIPTION
They seem to be launching on page load, overwhelming our
servers