### PR TITLE
Provide only two replicas of nginx-ingress pods

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -45,7 +45,7 @@ nginx-ingress:
   controller:
     service:
       loadBalancerIP: 35.202.202.188
-    replicaCount: 10
+    replicaCount: 2
 
 static:
   ingress:


### PR DESCRIPTION
10 is far too much, I think it was increased as a possible fix
for an unrelated issue, and makes debugging harder (since it
is unclear which of the pods a request has gone through)