### PR TITLE
Don't explicitly block metadata access

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -94,29 +94,6 @@ binderhub:
           capabilities:
             add:
             - NET_ADMIN
-      - name: block-metadata
-        image: minrk/tc-init:0.0.4
-        # Block access to GCE Metadata Service from user pods!
-        command:
-          - iptables
-          - -A
-          - OUTPUT
-          - -p
-          - tcp
-          - --dport
-          - "80"
-          - -d
-          - 169.254.169.254
-          - -j
-          - DROP
-        securityContext:
-          # capabilities.add seems to be disabled
-          # by the `runAsUser: 1000` in the pod-level securityContext
-          # unless we explicitly run as root
-          runAsUser: 0
-          capabilities:
-            add:
-            - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:e046c11
 


### PR DESCRIPTION
This has been rolled into z2jh and is on by default, so we
were doing this twice