### PR TITLE
Bump binderhub version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-410bd57
+   version: 0.1.0-38ba9cb
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/binderhub/pull/439