### PR TITLE
Bump repo2docker version

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -95,7 +95,7 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
-  repo2dockerImage: jupyter/repo2docker:e046c11
+  repo2dockerImage: jupyter/repo2docker:v0.5
 
 playground:
   image:


### PR DESCRIPTION
Get https://github.com/jupyter/repo2docker/pull/219 in