### PR TITLE
Update to latest version of jupyter-lab and -notebook

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-e75cc14
+   version: 0.1.0-748c2f4
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -95,7 +95,7 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
-  repo2dockerImage: jupyter/repo2docker:v0.5
+  repo2dockerImage: jupyter/repo2docker:687788f
 
 playground:
   image:


### PR DESCRIPTION
Brings in https://github.com/jupyter/repo2docker/pull/225 and also updates binderhub update https://github.com/jupyterhub/binderhub/pull/445