### PR TITLE
Automatically deploy to prod if tests succeed on staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,11 @@ deploy:
   script: ./travis/travis-script.bash
   on:
     branch:
-      - staging
-      - prod
+      - master
 
 branches:
   only:
-    - staging
-    - prod
+    - master
 
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # mybinder.org-deploy
 
-Staging: [![Staging Build Status](https://travis-ci.org/jupyterhub/mybinder.org-deploy.svg?branch=staging)](https://travis-ci.org/jupyterhub/mybinder.org-deploy) |
-Production: [![Production Build Status](https://travis-ci.org/jupyterhub/mybinder.org-deploy.svg?branch=prod)](https://travis-ci.org/jupyterhub/mybinder.org-deploy/branches)
+Deployment: [![Staging Build Status](https://travis-ci.org/jupyterhub/mybinder.org-deploy.svg?branch=master)](https://travis-ci.org/jupyterhub/mybinder.org-deploy)
 
 Deployment, configuration, and Site Reliability documentation files for the
 public [mybinder.org][] service.
@@ -44,32 +43,15 @@ deploy to the `prod` (production) branch of the repository.
 ### Deploy to Staging
 
 1. Make the [changes](#upgrading-dependencies-for-the-mybinderorg-deployment) on your fork.
-2. Make a PR to the `staging` branch with the changes you want.
+2. Make a PR to the `master` branch with the changes you want.
 3. Review, accept, and merge this PR. This will make Travis deploy the changes
-   to [staging.mybinder.org][].
-4. Go to [staging.mybinder.org][] to look at the changes.
-5. Verify that [staging.mybinder.org][] works as intended. Please take your
-   time to check that the change is working as expected.
-
-**If the changes look correct:**
-
-Proceed to [Deploy to Production](#deploy-to-production) section.
-
-**If the changes don't look correct, or there is an error:**
-
-6. **Immediately revert the PR that was made to the [staging][] branch.**
-7. Verify that [staging.mybinder.org][] is working as it was before the PR
-   and revert.
+   to [staging.mybinder.org][], run tests in the `tests/` directory against it.
+4. If the tests succeed, the change will be deployed to [mybinder.org][].
+5. If the tests fail, the chane will *not* be deployed to [mybinder.org][].
+   The deployer would then need to investigate why it failed, and if they can
+   not figure out a cause in about 10 minutes, revert the change.
+   Ideally, the build should not remain broken for more than ten minutes.
 8. Troubleshoot and make changes to your fork. Repeat the process from Step 1.
-
-### Deploy to Production
-
-1. Always deploy changes to staging prior to deploying to production.
-2. Make a new PR, merging [staging][] into the [prod][] branch.
-3. Merge this PR, and wait for Travis to make a deployment to [prod][].
-4. Verify that [mybinder.org][] works as intended. Please take your
-   time to check that the change is working as expected.
-5. CELEBRATE! :tada:
 
 ## Upgrading dependencies for the mybinder.org deployment
 
@@ -121,7 +103,7 @@ which we step through below.
 
 6. Merge this change to `mybinder/requirements.yaml` into the [mybinder.org-deploy][]
    repository following the steps in the [Deploying a change][] section above
-   to deploy the change to [staging][], and then [prod][].
+   to deploy the change.
 
 ### repo2docker
 
@@ -151,7 +133,7 @@ The following lines describe how to point mybinder.org to the new repo2docker im
 
 5. Merge this change to `mybinder/values.yaml` into the [mybinder.org-deploy][]
    repository following the steps in the [Deploying a change][] section above
-   to deploy the change to [staging][], and then [prod][].
+   to deploy the change.
 
 [mybinder.org-deploy]: https://github.com/jupyterhub/mybinder.org-deploy
 [prod]: https://mybinder.org

--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -2,50 +2,49 @@
 set -euo pipefail
 # Used by travis to trigger deployments
 # Keeping this here rather than make travis.yml too complex
+# We deploy to staging, run some automated tests, and if they pass we deploy to production!
 
 TARGET="${TRAVIS_BRANCH}"
 
-if [ "${TARGET}" = "prod" ]; then
-    BINDER_URL="https://mybinder.org"
-    HUB_URL="https://hub.mybinder.org"
-    # Specify currently active cluster
-    # FIXME: Deploy to multiple clusters?
-    CLUSTER="prod-a"
-else
-    BINDER_URL="https://${TARGET}.mybinder.org"
-    HUB_URL="https://hub.${TARGET}.mybinder.org"
-    CLUSTER="${TARGET}"
-fi
+function deploy {
+    KIND="${1}"
+    CLUSTER="${2}"
+    BINDER_URL="${3}"
+    HUB_URL="${4}"
 
-echo "Starting deploy..."
+    echo "Starting deploy to ${KIND}..."
 
-# Unlock our secret files!
-# Travis allows encrypting only one file per repo (boo) so we use it to
-# encrypt our git-crypt key
-openssl aes-256-cbc -K $encrypted_510e3970077d_key -iv $encrypted_510e3970077d_iv -in travis/crypt-key.enc -out travis/crypt-key -d
-git-crypt unlock travis/crypt-key
-# ensure private keys have private permissions,
-# otherwise ssh will ignore them
-chmod 0600 secrets/*key
+    # Unlock our secret files!
+    # Travis allows encrypting only one file per repo (boo) so we use it to
+    # encrypt our git-crypt key
+    openssl aes-256-cbc -K $encrypted_510e3970077d_key -iv $encrypted_510e3970077d_iv -in travis/crypt-key.enc -out travis/crypt-key -d
+    git-crypt unlock travis/crypt-key
+    # ensure private keys have private permissions,
+    # otherwise ssh will ignore them
+    chmod 0600 secrets/*key
 
 
-# Authenticate to gcloud & get it to authenticate to kubectl!
-gcloud auth activate-service-account --key-file=secrets/gke-auth-key-${TARGET}.json
-gcloud container clusters get-credentials ${CLUSTER} --zone=us-central1-a --project=binder-${TARGET}
+    # Authenticate to gcloud & get it to authenticate to kubectl!
+    gcloud auth activate-service-account --key-file=secrets/gke-auth-key-${TARGET}.json
+    gcloud container clusters get-credentials ${CLUSTER} --zone=us-central1-a --project=binder-${TARGET}
 
 
-# Make sure we have our helm repo!
-helm init --client-only
-helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+    # Make sure we have our helm repo!
+    helm init --client-only
+    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 
-python3 ./deploy.py deploy ${TARGET}
+    python3 ./deploy.py deploy ${TARGET}
 
-# FIXME: add readiness probe so that deploy doesn't finish before
-# hub is available.
-# For now, sleep to give deploy a chance to warm up.
-sleep 10
+    # FIXME: add readiness probe so that deploy doesn't finish before
+    # hub is available.
+    # For now, sleep to give deploy a chance to warm up.
+    sleep 10
 
-# Run some tests to make sure we really did pass!
-py.test -s --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
+    # Run some tests to make sure we really did pass!
+    py.test -s --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
 
-echo "Done!"
+    echo "Done deploying to ${KIND}!"
+}
+
+deploy "staging" "staging" https://staging.mybinder.org https://hub.staging.mybinder.org
+deploy "prod" "prod-a" https://mybinder.org https://hub.mybinder.org


### PR DESCRIPTION
The original reasoning for having staging and prod deployments
be both manual was we didn't have automated tests we could rely on.
So a human had to manually test staging before deploying to prod.
It was a stop-gap until we had better automation.

Now we have automated tests, and so the stop gap should go away.

This removes an entire step from our deployment workflow,
which should make it easier for a larger group of users to do.
It'll also take less time than it does now.

Someone will still need to watch for deployment failures, but since
the deployment will stop if staging deploy fails, that should be ok.

Ultimately, we need to make deployments easy enough and painless
enough that number of people doing deploys is higher and more
diverse than now, and I think this is a good step in that direction.