### PR TITLE
Move unlocking secrets to pre_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_deploy:
   mv git-crypt ${HOME}/bin/git-crypt
 # Restore where we were!
 - cd ${TRAVIS_BUILD_DIR}
-
 env:
   global:
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,15 @@ before_deploy:
   echo "46c288cc849c23a28239de3386c6050e5c7d7acd50b1d0248d86e6efff09c61b  git-crypt" | shasum -a 256 -c -
   chmod +x git-crypt
   mv git-crypt ${HOME}/bin/git-crypt
-# Restore where we were!
-- cd ${TRAVIS_BUILD_DIR}
+- |
+  # Unlock our secret files!
+  # Travis allows encrypting only one file per repo (boo) so we use it to
+  # encrypt our git-crypt key
+  cd ${TRAVIS_BUILD_DIR}
+  openssl aes-256-cbc -K $encrypted_510e3970077d_key -iv $encrypted_510e3970077d_iv -in travis/crypt-key.enc -out travis/crypt-key -d
+  git-crypt unlock travis/crypt-key
+  chmod 0600 secrets/*key
+
 env:
   global:
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/deploy.py
+++ b/deploy.py
@@ -22,12 +22,7 @@ def deploy(release):
         '-f', os.path.join('secrets', 'config', release + '.yaml')
     ]
 
-    try:
-        subprocess.check_output(helm)
-    except subprocess.CalledProcessError as e:
-        print("FAILED: Helm upgrade failed!")
-        print(e.output)
-        raise
+    subprocess.check_call(helm)
     print(BOLD + GREEN + f"SUCCESS: Helm upgrade for {release} completed" + NC)
 
     # Explicitly wait for all deployments and daemonsets to be fully rolled out

--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -12,16 +12,6 @@ NC=$(tput sgr0) # Reset to default
 
 echo -e "${BOLDGREEN}Starting deployment process${NC}"
 
-# Unlock our secret files!
-# Travis allows encrypting only one file per repo (boo) so we use it to
-# encrypt our git-crypt key
-openssl aes-256-cbc -K $encrypted_510e3970077d_key -iv $encrypted_510e3970077d_iv -in travis/crypt-key.enc -out travis/crypt-key -d
-git-crypt unlock travis/crypt-key
-# ensure private keys have private permissions,
-# otherwise ssh will ignore them
-chmod 0600 secrets/*key
-echo -e "${BOLDREVERSEGREEN}SUCCESS: Decrypted secrets required for deployment${NC}"
-
 function deploy {
     KIND="${1}"
     CLUSTER="${2}"

--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -6,13 +6,11 @@ set -euo pipefail
 
 # Colors we gonna use for colored output
 GREEN=$(tput setaf 2)
-REVERSE=$(tput rev)
 BOLD=$(tput bold)
-BOLDREVERSEGREEN="${BOLD}${REVERSE}${GREEN}"
+BOLDGREEN="${BOLD}${GREEN}"
 NC=$(tput sgr0) # Reset to default
 
-
-echo -e "${BOLDREVERSEGREEN}Starting deployment process${NC}"
+echo -e "${BOLDGREEN}Starting deployment process${NC}"
 
 # Unlock our secret files!
 # Travis allows encrypting only one file per repo (boo) so we use it to
@@ -30,21 +28,21 @@ function deploy {
     BINDER_URL="${3}"
     HUB_URL="${4}"
 
-    echo -e "${BOLDREVERSEGREEN}Starting deployment to: ${KIND}${NC}"
+    echo -e "${BOLDGREEN}Starting deployment to: ${KIND}${NC}"
 
     # Authenticate to gcloud & get it to authenticate to kubectl!
     gcloud auth activate-service-account --key-file=secrets/gke-auth-key-${KIND}.json
     gcloud container clusters get-credentials ${CLUSTER} --zone=us-central1-a --project=binder-${KIND}
 
-    echo -e "${BOLDREVERSEGREEN}SUCCESS: Credentials for deploying to ${KIND} activated${NC}"
+    echo -e "${BOLDGREEN}SUCCESS: Credentials for deploying to ${KIND} activated${NC}"
 
     python3 ./deploy.py ${KIND}
 
-    echo -e "${BOLDREVERSEGREEN}SUCCESS: Deployment push to ${KIND} completed${NC}"
-    echo -e "${BOLDREVERSEGREEN}Running tests to validate deployment...${NC}"
+    echo -e "${BOLDGREEN}SUCCESS: Deployment push to ${KIND} completed${NC}"
+    echo -e "${BOLDGREEN}Running tests to validate deployment...${NC}"
     # Run some tests to make sure we really did pass!
     py.test --binder-url=${BINDER_URL} --hub-url=${HUB_URL}
-    echo -e "${BOLDREVERSEGREEN}SUCCESS: Deployment to ${KIND} completed and verified!${NC}"
+    echo -e "${BOLDGREEN}SUCCESS: Deployment to ${KIND} completed and verified!${NC}"
 }
 
 deploy "staging" "staging" https://staging.mybinder.org https://hub.staging.mybinder.org


### PR DESCRIPTION
- Restore helm upgrade output, to help debugging (hah!)
- Remove ineffective REVERSE color from travis output, since it does not support
  reverse color effects
- Move unlocking secrets to pre_deploy step. This lets us move
  everything into deploy.py and remove travis-script