### PR TITLE
Cache pip installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 python:
   - 3.6
 
+cache: pip
+
 install:
-  - pip install --no-cache-dir pyyaml pytest pytest-timeout requests
+  - pip install pyyaml pytest pytest-timeout requests
 
 script:
   - true


### PR DESCRIPTION
Should speed things up - pip install was taking about 25s on average!