### PR TITLE
Use before_deploy than script for pre-deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
   - pip install pyyaml pytest pytest-timeout requests
 
 script:
+ - true
+
+before_deploy:
 - mkdir -p ${HOME}/bin
 - |
   # Install gcloud SDK!


### PR DESCRIPTION
Ugh, apparently script does *not* provide log folding