### PR TITLE
Intentionally fail deployment to see if travis behaves properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_deploy:
 - |
   # Install gcloud SDK!
   curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-173.0.0-linux-x86_64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  # Test if this fails
+  vaasgasdg
 - |
   # Install Kubectl
   curl -L https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl > ${HOME}/bin/kubectl


### PR DESCRIPTION
Travis has no docs on what happens if a command fails in
before_deploy. This lets us check that and modify our behavior
accordingly. We definitely do not want deployment to continue
if *any* of the steps fail