### PR TITLE
bump per-repo quota to 500

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -105,7 +105,7 @@ binderhub:
             - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:f069a7b
-  perRepoQuota: 300
+  perRepoQuota: 500
 
 playground:
   image:


### PR DESCRIPTION
for jupyterlab blog post, which is rapidly approaching the 300 limit in its first hour