### PR TITLE
Revert "bump per-repo quota to 500"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -105,7 +105,7 @@ binderhub:
             - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:f069a7b
-  perRepoQuota: 500
+  perRepoQuota: 300
 
 playground:
   image:


### PR DESCRIPTION
Reverting because k8s is going bonkers! (see incident report for more info) https://hackmd.io/BwYwrAhgpgDBDsBaAzCALAM0WswsRBmUQCMQBOIiAE0hOpiA

Reverts jupyterhub/mybinder.org-deploy#428