### PR TITLE
Revert "binderhub: pycurl"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-ce79685
+   version: 0.1.0-748c2f4
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#431

This has caused failures that look like:

```
Error creating user rationalmatter---demo-notebooks-dhdroiuf: HTTP 503: Service Unavailable
    b'Service Unavailable'
```