### PR TITLE
Revert "Revert "binderhub: pycurl""

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-748c2f4
+   version: 0.1.0-ce79685
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Restores pycurl, since it was unrelated to the Service Unavailable errors