### PR TITLE
Increase per repo quota to 303

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -105,7 +105,7 @@ binderhub:
             - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:f069a7b
-  perRepoQuota: 300
+  perRepoQuota: 303
 
 playground:
   image:


### PR DESCRIPTION
This is a "no op" deployment to see how we do deploying while there are a lot of users.