### PR TITLE
Merging delete-pod sections and adding a getting started page

### DIFF
--- a/docs/source/command_snippets.md
+++ b/docs/source/command_snippets.md
@@ -5,19 +5,33 @@ that are useful for operating and investigating what is happening on the
 cluster. Think of it as a mybinder.org specific extension of the [kubernetes
 cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/).
 
+## List all pods that match a given name or age
 
-## List all pods older than X
+Sometimes you want to delete all the pods for a given repository. The easiest
+way to do this is to name-match the part of the pod name that corresponds to
+the repo (since there will be a bunch of random characters as well).
 
-To get a list of all pods older than four hours:
+Here's a python script that will match pods with a given name or a given
+age. You can use it with the following pattern:
+
 ```
-kubectl get pod --namespace=prod | grep '^jupyter-' | grep '\(\([12][0-9]\|[4-9]\)h\|d\)$'
+python scripts/delete-pods.py --pod-name <your-query> --older-than <your-query>
 ```
 
-or all those that have existed for more than 24hours:
-```
-kubectl get pod --namespace=prod | grep '^jupyter-' | grep 'd$' | awk '{print $1}')
-```
+* `--pod-name` is a string and will be matched to any pod that contains this string.
+* `--older-than` is a float (in hours) and will match any pod that is older than this amount.
 
+Note, they are both optional, but you need to supply *at least* one. Running
+the above command by itself will list all pods that match the query.
+
+## Delete all pods that match a given name or age
+
+If you wish to **delete** the pods that match the query above, you supply the `--delete`
+kwarg like so:
+
+```
+python scripts/delete-pods.py --pod-name <your-query> --older-than <your-query> --delete
+```
 
 ## Remove a node from the cluster
 
@@ -44,35 +58,3 @@ pods. The `--no-headers` asks kubectl to not print column titles as a header.
 The `awk` command selects the 7th column in the output (which is the node name).
 The sort / uniq / sort combination helps print the number of pods per each node in
 sorted order.
-
-## Delete all pods that match a given name
-
-Sometimes you want to delete all the pods for a given repository. The easiest
-way to do this is to name-match the part of the pod name that corresponds to
-the repo (since there will be a bunch of random characters as well).
-
-Here's a python script that will match pods with a given name and delete them
-(you need to uncomment the line to actually do the deleting). The script can
-be run by changing your directory to the root of this repository, then running
-
-```
-python scripts/delete_pods_matching_name.py <your-query> --delete
-```
-
-## Delete all user pods older than a given number of hours
-
-We use the Kubernetes cluster autoscaler, which
-removes nodes from the kubernetes cluster when they have
-been 'empty' for more than 10 minutes However, we
-have issues where some pods get 'stuck' and never actually
-die, sometimes forever. This causes nodes to not be
-killed automatically.
-
-You can use the 'old-user-pods.py' script to lis/kill these pods. You can run it with:
-
-```bash
-./scripts/old-user-pods.py <number-of-hours> --delete
-```
-
-If you do not pass --delete, it will simply print all the matching pods.
-You will need the `kubernetes` python library installed to use this script!

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,0 +1,61 @@
+# Getting started with the `mybinder.org` dev team
+
+This page contains a starting point for people who would like to help
+maintain the BinderHub deployment at `mybinder.org`.
+
+## Make sure you have access on the Google Cloud project
+
+Go to `console.cloud.google.com` and see if you have `binder-prod` listed
+in your projects. If not, message one of the Binder devs on the [Gitter Channel](https://gitter.im/jupyterhub/binder)
+to get access.
+
+## Install `kubectl` and the `gcloud` SDK
+
+The most important tool for keeping an eye on the Kubernetes deployment is
+`kubectl` and the `gcloud` SDK. These will let you run queries on the
+`mybinder.org` deployment from your command line. To set this up, check
+out the [Zero to JupyterHub Google SDK section](https://zero-to-jupyterhub.readthedocs.io/en/latest/create-k8s-cluster.html#setting-up-kubernetes-on-google-cloud).
+(everything before the part where you create a google cloud cluster).
+
+When you run `gcloud init` for the first time, it'll ask you to authenticate
+and to choose a project / default region. You should authenticate with
+the email that's been given privileges to work on `mybinder.org`, choose
+the project `binder-prod`, and use the region `us-central1-a`.
+
+We recommend enabling [`kubectl` autocompletion](https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion)
+as well.
+
+## Set up `kubectl` to connect to `mybinder.org`
+
+Once you have `kubectl` installed, you can connect it with `mybinder.org`.
+To do so, run the following command:
+
+```
+gcloud container clusters get-credentials prod-a --zone us-central1-a --project binder-prod
+```
+
+This will open a log-in page in your browser. If you've got access, you'll
+be able to log in and your `kubectl` will now be able to run commands
+with `mybinder.org`.
+
+You can test this out by running:
+
+```
+kubectl --namespace=prod get pod
+```
+
+and a list of all running Binder pods should be printed.
+
+## Look at the project Grafana
+
+Another useful resource is the [mybinder.org Grafana dashboard](https://grafana.mybinder.org/?orgId=1).
+This has information about the current state of the binder deployment. Take a
+look at all of these plots and familiarize yourself with them. They're quite
+useful in spotting and debugging problems in the future.
+
+## Start helping out!
+
+There are many ways that you can help debug/maintain/improve the `mybinder.org`
+deployment. The best way to get started is to keep an eye on the [Gitter Channel](https://gitter.im/jupyterhub/binder)
+as well as the Grafana dashboard. If you see something interesting, don't hesitate
+to ask questions or make suggestions!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ Introduction
    :maxdepth: 2
    :caption: Introduction
 
+   getting_started.md
    production_environment.md
 
 Components


### PR DESCRIPTION
This cleans up the `list pods of a given age / name" sections, and also adds a section for getting started. We can probably improve the latter page but it's a start!