### PR TITLE
avoid redirecting API requests to binderhub

### DIFF
--- a/mybinder/templates/proxy-patches/configmap.yaml
+++ b/mybinder/templates/proxy-patches/configmap.yaml
@@ -6,8 +6,23 @@ metadata:
 data:
   redirects.conf: |
     server {
-          listen 80;
-          rewrite (.*) https://{{ index .Values.binderhub.ingress.hosts 0 }} redirect;
+      listen 80;
+
+      # we want to redirect *humans* to the landing page,
+      # but not stale API requests from clients
+      if ($request_method != GET) {
+        # 404 on anything but a GET request
+        return 404;
+      }
+      location ~ ^/user/.*/api/ {
+        # 404 on API requests
+        # these can happen when a pod has been culled
+        # but clients are still connected and trying to poll
+        return 404;
+      }
+      location / {
+        rewrite (.*) https://{{ index .Values.binderhub.ingress.hosts 0 }} redirect;
+      }
     }
 
 ---

--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: proxy-patches
   labels:
     app: proxy-patches
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: proxy-patches
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
check for /user/.../api requests and non-gets, and return a 404

we only want to send humans all the way back to the landing page