### PR TITLE
pod stats notebook in `scripts`

### DIFF
--- a/scripts/pod-stats.ipynb
+++ b/scripts/pod-stats.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kubernetes import config, client\n",
+    "from datetime import timezone, datetime\n",
+    "import pandas as pd\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authenticate and set up kubectl API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this cell to make sure kubectl is authenticated. If you get an error, debug w/ kubectl\n",
+    "!kubectl --namespace=prod get pod > /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONTEXT = \"gke_binder-prod_us-central1-a_prod-a\"\n",
+    "NAMESPACE = \"prod\"\n",
+    "config.load_kube_config(context=CONTEXT)\n",
+    "\n",
+    "# Get list of pods with given label selector in the 'prod' namespace\n",
+    "core_api = client.CoreV1Api()\n",
+    "\n",
+    "pods = core_api.list_namespaced_pod(NAMESPACE, label_selector=\"component=singleuser-server\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parse data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []\n",
+    "for pod in pods.items:\n",
+    "    age = datetime.now(timezone.utc) - pod.status.start_time.replace(tzinfo=timezone.utc)\n",
+    "    data.append({'age': age.total_seconds() / 60, 'name': pod.metadata.name})\n",
+    "\n",
+    "data = pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QUERY = 'jupyterlab'\n",
+    "\n",
+    "print('Num matches: {}'.format(data[data['name'].map(lambda a: QUERY in a)].shape))\n",
+    "\n",
+    "ax = data[data['name'].map(lambda a: 'jupyterlab' in a)]['age'].plot.hist(bins=20)\n",
+    "ax.set(xlim=[0, None], title=QUERY, xlabel='Pod Age');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
another helper notebook - this one just lists the current pods and dumps it into a DataFrame. Also has a simple viz to look at the distribution of pod age for a given repo. There are probably a lot of other cool things you could do with the notebook, so this is just a start :-)

at some point it could potentially be merged with the `pod-health` notebook too (if this is too redundant, feel free that we make this merge now)