### PR TITLE
Bump prometheus chart version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
    version: 0.8.13
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
-   version: 5.1.0
+   version: 5.3.1
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
    version: 0.6.1


### PR DESCRIPTION
Primarily to get cadvisor rules back to working again
by bringing in https://github.com/kubernetes/charts/pull/3684.

Currently the labels for various container metadata is not
captured properly, so we have data for all container usage but
no idea what container is what!
