### PR TITLE
Bump binderhub version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-ce79685
+   version: 0.1.0-9abd8bf
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/binderhub/pull/463,
which should help a lot with CPU saturation issues