### PR TITLE
Increase per repo limit to 200

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -95,7 +95,7 @@ binderhub:
             - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:f069a7b
-  perRepoQuota: 100
+  perRepoQuota: 200
 
 playground:
   image:


### PR DESCRIPTION
After fixing the threading problem () CPU usage of jupyterhub has dropped to "zero" (check the new grafana dashboard https://grafana.mybinder.org/dashboard/db/components-resource-metrics?refresh=1m&orgId=1&from=now-12h&to=now).

We will use this as an opportunity to increase the per repo limit in at most steps of 100. Between steps we will wait to reach the limit and another 30-60minutes after that to see how stable things are.

Will merge this in a bit once we have an established baseline of current CPU usage (at perrepolimit of 100).