### PR TITLE
serve an HTML error page for stopped pods

### DIFF
--- a/mybinder/templates/proxy-patches/configmap.yaml
+++ b/mybinder/templates/proxy-patches/configmap.yaml
@@ -9,12 +9,50 @@ data:
       listen 80;
 
       # Return 404 for anything that comes here
-      # This preserves the same behavior as before, just without overloading the hub
+      # serve an informative error about stopped pods
+      error_page 404 /404.html;
+      location /404.html {
+        root /srv/proxy-patches;
+        internal;
+      }
       location / {
         return 404;
       }
     }
 
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: proxy-html-files
+data:
+  404.html: >
+    <html>
+    <head>
+    <title>Your Binder has stopped</title>
+    {{ $rootUrl := printf "https://%s" (index .Values.binderhub.ingress.hosts 0) }}
+    <link href="{{ $rootUrl }}/static/dist/styles.css" rel="stylesheet">
+    </head>
+    <body>
+    <div class="container">
+    <h3 class="text-center">Your Binder has stopped!</h3>
+    <p>
+    If this was your Binder, it may have been stopped due to an
+    error or culled by the monitoring service due to age or idleness.
+    </p>
+    <p>
+    If this was a link you were given, it wasn't the right link!
+    You might ask the person who gave you the link to share the binder URL
+    and not the URL they see in their browser when the Binder is running.
+    It should look like <tt>{{ $rootUrl }}/v2/gh/...</tt>
+    and not <tt>{{ .Values.binderhub.hub.url }}/user/...</tt>
+    </p>
+    <p>
+    <a href="{{ $rootUrl }}">The main Binder page</a>
+    will show you this link for a given repo, and even give you a snippet to make a badge
+    that links to your Binder.
+    </p>
+    </body>
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         - name: nginx-config
           configMap:
             name: proxy-patches-nginx-config
+        - name: nginx-files
+          configMap:
+            name: proxy-html-files
         - name: proxy-help-config
           configMap:
             name: proxy-help-config
@@ -36,6 +39,8 @@ spec:
         volumeMounts:
           - mountPath: /etc/nginx/conf.d/
             name: nginx-config
+          - mountPath: /srv/proxy-patches/
+            name: nginx-files
       - name: proxy-help
         image: minrk/proxy-help:0.1
         volumeMounts:


### PR DESCRIPTION
instead of redirecting to home or serving generic nginx 404

This should be a more permanent solution to #448

Related to https://github.com/jupyterhub/binderhub/issues/457 and https://github.com/jupyterhub/binderhub/issues/458

This fixes #443 *except* for the fact that we should think about promoting this behavior to the binderhub chart itself.