### PR TITLE
Remove mtanda-histogram-panel plugin from grafana

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -141,7 +141,6 @@ grafana:
       annotations:
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
-    installPlugins: mtanda-histogram-panel
   serverConfigFile:
     grafana.ini: |
       ; instance_name = ${HOSTNAME}


### PR DESCRIPTION
Prepared this PR because I wasn't sure if this was causing periodic restarts of grafana or not.

Short chat with @minrk suggests that we don't actually use this plugin. Waiting for @choldgraf to confirm/deny.

@minrk further diagnosed that actually [grafana segfaults](https://console.cloud.google.com/logs/viewer?project=binder-prod&minLogLevel=0&expandAll=false&timestamp=2018-02-22T11:25:45.000000000Z&dateRangeStart=2018-02-22T10:42:17.023Z&dateRangeEnd=2018-02-22T11:42:17.023Z&interval=PT1H&resource=container%2Fcluster_name%2Fprod-a&logName=projects%2Fbinder-prod%2Flogs%2Fgrafana&advancedFilter=resource.type%3D%22container%22%0Aresource.labels.pod_id%3D%22prod-grafana-5f9999dc4f-n77vj%22%0Aresource.labels.zone%3D%22us-central1-a%22%0Aresource.labels.project_id%3D%22binder-prod%22%0Aresource.labels.cluster_name%3D%22prod-a%22%0Aresource.labels.container_name%3D%22grafana%22%0Aresource.labels.namespace_id%3D%22prod%22%0Aresource.labels.instance_id%3D%22210694033853395397%22%0Atimestamp%3D%222018-02-22T11:25:45.000000000Z%22%0AinsertId%3D%221od3ybg1fftndi%22) and the messages about installing the plugin are just a side effect of grafana starting back up.

If we don't use it let's remove it as part of housekeeping.