### PR TITLE
Increase per repo limit to 300

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -95,7 +95,7 @@ binderhub:
             - NET_ADMIN
       schedulerStrategy: pack
   repo2dockerImage: jupyter/repo2docker:f069a7b
-  perRepoQuota: 200
+  perRepoQuota: 300
 
 playground:
   image:


### PR DESCRIPTION
This follows #460. While we promised to run at the limit of 200 for a while we are now going to 300 straight away. Thinking is that we have been running at >250 live binders for the last 6hours, >300 for over 5h. CPU usage of jhub is still low.