### PR TITLE
Simplify 404 page text

### DIFF
--- a/mybinder/templates/proxy-patches/configmap.yaml
+++ b/mybinder/templates/proxy-patches/configmap.yaml
@@ -29,29 +29,37 @@ data:
   404.html: >
     <html>
     <head>
-    <title>Your Binder has stopped</title>
+    <title>Binder not found</title>
     {{ $rootUrl := printf "https://%s" (index .Values.binderhub.ingress.hosts 0) }}
     <link href="{{ $rootUrl }}/static/dist/styles.css" rel="stylesheet">
     </head>
     <body>
     <div class="container">
-    <h3 class="text-center">Your Binder has stopped!</h3>
+    <h2 class="text-center">Oops!</h2>
+    <h3 class="text-center">We can't seem to find the Binder page you are looking for.</h3>
+    <h4>404 error</h4>
     <p>
-    If this was your Binder, it may have been stopped due to an
-    error or culled by the monitoring service due to age or idleness.
+    Here are some helpful tips.
     </p>
     <p>
-    If this was a link you were given, it wasn't the right link!
-    You might ask the person who gave you the link to share the binder URL
-    and not the URL they see in their browser when the Binder is running.
-    It should look like <tt>{{ $rootUrl }}/v2/gh/...</tt>
-    and not <tt>{{ .Values.binderhub.hub.url }}/user/...</tt>
+    <h4>Is this a Binder that you created?</h4>
+    <p>
+    Your Binder stopped due to an error or it was removed
+    due to age or inactivity.
     </p>
     <p>
-    <a href="{{ $rootUrl }}">The main Binder page</a>
-    will show you this link for a given repo, and even give you a snippet to make a badge
-    that links to your Binder.
+    Return to the
+    <a href="{{ $rootUrl }}">Binder home page</a>
+    to retry creating your Binder.
     </p>
+    <h4>Did someone give you this Binder link?</h4>
+    <p>
+    If so, the link is outdated or incorrect. Recheck the link for typos
+    or ask the person who gave you the link for an updated link.
+    A shareable Binder link should look like
+    <tt>{{ $rootUrl }}/v2/gh/...</tt>.
+    </p>
+    <h4><a href="{{ $rootUrl }}">Binder home page</a></h4>
     </body>
 ---
 kind: ConfigMap


### PR DESCRIPTION
Provides clarity to the user on troubleshooting when they receive a 404 page as suggested by @minrk.

This is a first pass. Additional PRs could improve the styling.

Closes #462