### PR TITLE
unbanning ds100

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -22,11 +22,6 @@ binderhub:
           hosts:
             - hub.staging.mybinder.org
 
-  extraConfig:
-    bans: |
-        c.GitHubRepoProvider.banned_specs = [
-        ]
-
 grafana:
   server:
     ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,9 +1,9 @@
 binderhub:
   extraConfig:
+    # Add banned repositories to the list below
+    # They should be strings that will match "^<org-name>/<repo-name>.*"
     bans: |
         c.GitHubRepoProvider.banned_specs = [
-          '^ds-100/textbook.*',
-          '^samlau95/nbinteract-image.*'
         ]
   service:
     type: ClusterIP


### PR DESCRIPTION
This reverts the staging-specific change, and then unbans both ds100 repositories on the master `values.yaml`.