### PR TITLE
Update JupyterHab helm chart to bring in new culler

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-9abd8bf
+   version: 0.1.0-b7e6711
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This updates the jupyterhub chart version to bring in a new culler that is better at dealing with users that are slow to stop. See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/531 for the culler changes.