### PR TITLE
Docs for: ingress, kube-lego, GKE, GCR & cloud product philosophy

### DIFF
--- a/docs/source/command_snippets.md
+++ b/docs/source/command_snippets.md
@@ -105,10 +105,10 @@ the new minimum is higher than the current size and there is no need to increase
 the size of the cluster the autoscaler will not scale up the cluster even though
 it is below the minimum size.
 
-## Manually decrease cluster size
+## Manually scaling down the cluster size
 
-The autoscaler has issues scaling nodes *down*, and so scaling down needs to be
-manually done. The problems are caused by problem is caused by:
+The autoscaler has issues scaling nodes *down*, so scaling down needs to be
+manually done. The problems are caused by:
 
 1. The cluster autoscaler will never remove nodes that have user pods running.
 2. We can not tell the Kubernetes Scheduler to 'pack' user pods efficiently -
@@ -117,9 +117,11 @@ manually done. The problems are caused by problem is caused by:
    a node before it can be scaled down, this leads to inefficient
    load distribution.
 
-Because of this, you might have to manually scale down the cluster now and then.
+Because the autoscaler will only remove a node when it has no pods, this means
+it is unlikely that nodes will be properly removed. Thus the necessity for
+manually scaling down now and then.
 
-You can find the node utilization with the following command:
+You can print the node utilization with the following command:
 
 ```bash
 kubectl --namespace=prod get pod  -o wide | grep jupyter | awk '{ print $7; }' | sort | uniq -c | sort -n
@@ -133,19 +135,26 @@ This outputs something like:
      79 gke-prod-a-ssd-pool-32-134a959a-k7f8
 ```
 
-The first node has only one pod in it, so you can `cordon` it:
+This prints the number of pods on the node on the left, and the node name
+on the right.
+
+In this case, the first node has only one pod in it, so you can `cordon` it:
 
 ```bash
-kubectl cordon  gke-prod-a-ssd-pool-32-134a959a-d34f
+kubectl cordon gke-prod-a-ssd-pool-32-134a959a-d34f
 ```
 
-And after a few hours, you can remove all pods from it:
+"cordoning" explicitly tells kubernetes **not** to start new pods on this node.
+For more information on cordoning, see :ref:`term-cordoning`.
+
+And after a few hours, you can remove all pods from it with:
 
 ```bash
 kubectl drain --force --delete-local-data --ignore-daemonsets --grace-period=0  gke-prod-a-ssd-pool-32-134a959a-d34f
 ```
 
-After this, the node should be automatically killed by the autoscaler in about 10 minutes.
+After running this, the node should now (forcibly) have 0 pods running on it,
+and will be automatically killed by the autoscaler in about 10 minutes.
 
 ## Acronyms that Chris likes to use in Gitter
 

--- a/docs/source/components/cloud.md
+++ b/docs/source/components/cloud.md
@@ -1,0 +1,186 @@
+# Cloud products
+
+mybinder.org runs on [Google Cloud](https://cloud.google.com/) currently.
+This document lists the various cloud products we use, and how we use them.
+
+## Philosophy
+
+We use **only** commodity cloud products - things that can be easily
+replicated in other clouds *and* bare-metal hardware. This gives us
+several technical and social advantages:
+
+1. We avoid vendor lock-in, and can migrate providers if need be
+   for any reason easily.
+2. Makes sure our infrastructure is easily reproducible by others,
+   who might have different resources available to them. This is 
+   much harder if we have a hard dependency on any single cloud-provider's
+   products.
+3. Most such commodity products are open source, or have binary
+   compatible open source implementations available. This allows us
+   to file and fix bugs in other Open Source Software for the benefit
+   of everyone, rather than just a particular cloud provider's implementation.
+4. Local testing when a core component depends on a cloud provider's
+   product is usually very difficult. Constraining ourselves to commodity
+   products only makes this easier.
+
+As an example, using PostgreSQL via [Google Cloud SQL](https://cloud.google.com/sql/docs/)
+would be fine since anyone can run PostgreSQL. But using something like 
+[Google Cloud Spanner](https://cloud.google.com/spanner/) or 
+[Google Cloud PubSub](https://cloud.google.com/pubsub/docs/) is something to be
+avoidded, since these can not be run without also being on Google Cloud.
+Similarly, using [Google Cloud LoadBalancing](https://cloud.google.com/load-balancing/)
+is also perfectly fine, since a lot of open source solutions (HAProxy, Envoy, nginx, etc)
+can be used to provide the same service.
+
+## Projects
+
+We have two major [projects](https://cloud.google.com/storage/docs/projects)
+that run on Google Cloud.
+
+1. `binder-prod`, runs production - `mybinder.org` and all resources
+   needed for it.
+2. `binder-staging` runs staging - `staging.mybinder.org` and all resources
+   needed for it.
+
+We try to make staging and prod be as similar as possible. Staging should just
+be smaller and use fewer resources. So everything we describe below
+are present in staging too.
+
+## Google Kubernetes Engine
+
+The open source [Kubernetes](https://kubernetes.io/) project is used to run
+all our code. [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
+is the google hosted version of Kubernetes. It is very close to what is shipped
+as Open Source, and does not have much in the way of proprietary enhancements.
+
+### Cluster
+
+In production, the cluster is called `prod-a`. In staging, it is called `staging`.
+
+### Node Pools
+
+GKE has the concept of a [NodePool](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pools)
+that specifies the kind of machine (RAM, CPU, Storage) we want to use for our Kubernetes
+cluster. If we want to change the kind of machines, we can create a new NodePool,
+cordon the current one, wait for all pods in current nodes to die, and then delete the
+current NodePool.
+
+### Machine sizes
+
+The `prod-a` cluster currently uses `n1-highmem-32` machines. These have
+32 CPU cores and 208 GB of Memory. We use the `highmem` machines (with more Memory per CPU)
+than `standard` machines for the following reasons:
+
+1. Memory is an *incompressible* resource - once you give a process memory, you can
+   not take it away without killing the process. CPU is *compressible* - you can
+   take away how much CPU a process is using without killing it.
+2. Our users generally seem to be running not-very-cpu-intensive code, as can be
+   witnessed from our generally low CPU usage.
+3. Docker layer caching gives us massive performance boosts - less time spent
+   pulling images leads to faster startup times for users. Using larger nodes
+   increases the cache hit rate, so we use nodes with more rather than less RAM.
+
+Using `highmem` machines saves us a lot of money, since we are not paying for CPU
+we are not using!
+
+The `staging` cluster uses much smaller machines than the production one, to keep costs
+down.
+
+### Boot disk sizes
+
+In `prod-a`, we use 1000 GB SSD disks as boot disks. On Google Cloud, the size of
+the disk [controls](https://cloud.google.com/compute/docs/disks/performance) the
+performance - larger the disk, faster it is. Our disks need to be fast since we
+are doing a lot of IO operations during docker build / push / pull / run, so we
+use SSDs.
+
+Note that SSD boot disks are *not* a feature available on GKE to all customers -
+we have been given [early access](https://github.com/kubernetes/kubernetes/issues/36499)
+to this feature, since it makes a dramatic difference to our performance (and
+we knew where to ask!).
+
+Staging does not use SSD boot disks.
+
+### Autoscaling
+
+We use the GKE [Cluster Autoscaler](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler)
+feature to add more nodes when we run out of resources. When the cluster is 100%
+full, the cluster autoscaler adds a new node to handle more pods. However,
+there is no way to make the autoscaler kick in at 80% of 90% utilization
+([bug](https://github.com/kubernetes/autoscaler/issues/148)), so this leads
+to [launch failures](https://github.com/jupyterhub/mybinder.org-deploy/issues/474)
+for a while when a new node comes up.
+
+The autoscaler can be set to have a `minimum` number of nodes and a `maximum` number
+of nodes. 
+
+## Google Container Registry
+
+A core part of MyBinder.org is building, storing and then running docker images
+(built by [repo2docker](https://github.com/jupyter/repo2docker)). Docker images
+are generally stored in a [docker registry](https://github.com/docker/distribution),
+using a well defined standard API. 
+
+We use Google Cloud's hosted docker registry - [Google Container Registry (GCR)](https://cloud.google.com/container-registry/).
+This lets us use a standard mechanism for storing and retrieving docker images
+without having to run any of that infrastructure ourselves.
+
+
+### Authentication
+
+GCR is private by default, and can be only used from inside the Google Cloud project
+the registry is located in. When using GKE, the authentication for pulling images
+to run is already set up for us, so we do not need to do anything special. For pushing
+images, we authenticate via a [service account](https://cloud.google.com/container-registry/docs/advanced-authentication#using_a_json_key_file).
+You can find this service account credential under `registry` in `secrets/config/prod.yaml`
+and `secrets/config/staging.yaml`.
+
+### Access
+
+The images are scoped per-project, the images made by `mybinder.org` are 
+stored in the `binder-prod` project, and the images made by `staging.mybinder.org` 
+are stored in the `binder-staging` project.
+
+We do not allow users to pull our images, for a few reasons:
+
+1. We pay network egress costs when images are used outside the project they are in,
+   and this can become very costly!
+2. This can be abused to treat us as a content redistributor - build
+   an image with content you want, and then just pull the image from elsewhere. This
+   makes us a convenient possible hop in cybercrime / piracy / other operations, 
+   complicates possible [DMCA](https://en.wikipedia.org/wiki/Digital_Millennium_Copyright_Act) 
+   / [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) compliance and 
+   probably a bunch of other bad things we do not have the imagination to foresee. 
+3. We might decide to clean up old images when we no longer need them, and this might 
+   break other users who might depend on this.
+
+For users who want access to a docker image similar to how it is built with Binder,
+we recommend using [repo2docker](https://github.com/jupyter/repo2docker) to build
+your own, and push it to a registry of your choice.
+
+### Naming
+
+Since building an image takes a long time, we would like to re-use images as much
+as possible. If we have built an image once for a particular repository at a particular
+commit, we want to not rebuild that image - just re-use it as much as possible. 
+We generate an image name for each image we build that is uniquely derived from 
+the name of the repository + the commit hash. This lets us check easily if 
+the image has already been built, and if so, we can skip the building step.
+
+The code for generating this image name from repository information is
+in [binderhub's builder.py](https://github.com/jupyterhub/binderhub/blob/master/binderhub/builder.py),
+under `_generate_build_name`.
+
+Sometimes, we *do* want to invalidate all previously built images - for example,
+when we do a major notebook version bump. This will cause all repositories to be
+rebuilt the next time they are launched. There is a performance cost to this, so
+this invalidation has to be done judiciously. This is done by giving all the images
+a `prefix` (`binderhub.registry.prefix` in `config/prod.yaml` and `config/staging.yaml`).
+Changing this prefix will invalidate all existing images.
+
+## Logging 
+
+We use [Google Stackdriver](https://cloud.google.com/stackdriver/) for logging.
+Stackdriver supports other features (such as metrics and dashboarding), but we 
+use [prometheus](metrics.html) and [grafana](dashboards.html) instead for those
+features. 

--- a/docs/source/components/cloud.md
+++ b/docs/source/components/cloud.md
@@ -11,11 +11,12 @@ several technical and social advantages:
 
 1. We avoid vendor lock-in, and can migrate providers if need be
    for any reason easily.
-2. Makes sure our infrastructure is easily reproducible by others,
-   who might have different resources available to them. This is 
+2. It makes our infrastructure easily reproducible by others,
+   who might have different resources available to them. This is
    much harder if we have a hard dependency on any single cloud-provider's
    products.
-3. Most such commodity products are open source, or have binary
+3. We can more easily contribute back to the open-source community.
+   Most such commodity products are open source, or have binary-
    compatible open source implementations available. This allows us
    to file and fix bugs in other Open Source Software for the benefit
    of everyone, rather than just a particular cloud provider's implementation.
@@ -24,10 +25,10 @@ several technical and social advantages:
    products only makes this easier.
 
 As an example, using PostgreSQL via [Google Cloud SQL](https://cloud.google.com/sql/docs/)
-would be fine since anyone can run PostgreSQL. But using something like 
-[Google Cloud Spanner](https://cloud.google.com/spanner/) or 
+would be fine since anyone can run PostgreSQL. But using something like
+[Google Cloud Spanner](https://cloud.google.com/spanner/) or
 [Google Cloud PubSub](https://cloud.google.com/pubsub/docs/) is something to be
-avoidded, since these can not be run without also being on Google Cloud.
+avoided, since these can not be run without also being on Google Cloud.
 Similarly, using [Google Cloud LoadBalancing](https://cloud.google.com/load-balancing/)
 is also perfectly fine, since a lot of open source solutions (HAProxy, Envoy, nginx, etc)
 can be used to provide the same service.
@@ -42,9 +43,9 @@ that run on Google Cloud.
 2. `binder-staging` runs staging - `staging.mybinder.org` and all resources
    needed for it.
 
-We try to make staging and prod be as similar as possible. Staging should just
-be smaller and use fewer resources. So everything we describe below
-are present in staging too.
+We try to make staging and prod be as similar as possible. Staging should
+be smaller and use fewer resources. Everything we describe below
+is present in staging too.
 
 ## Google Kubernetes Engine
 
@@ -61,7 +62,7 @@ In production, the cluster is called `prod-a`. In staging, it is called `staging
 
 GKE has the concept of a [NodePool](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pools)
 that specifies the kind of machine (RAM, CPU, Storage) we want to use for our Kubernetes
-cluster. If we want to change the kind of machines, we can create a new NodePool,
+cluster. If we want to change the kind of machines we use, we can create a new NodePool,
 cordon the current one, wait for all pods in current nodes to die, and then delete the
 current NodePool.
 
@@ -69,7 +70,7 @@ current NodePool.
 
 The `prod-a` cluster currently uses `n1-highmem-32` machines. These have
 32 CPU cores and 208 GB of Memory. We use the `highmem` machines (with more Memory per CPU)
-than `standard` machines for the following reasons:
+as opposed to `standard` machines for the following reasons:
 
 1. Memory is an *incompressible* resource - once you give a process memory, you can
    not take it away without killing the process. CPU is *compressible* - you can
@@ -80,8 +81,8 @@ than `standard` machines for the following reasons:
    pulling images leads to faster startup times for users. Using larger nodes
    increases the cache hit rate, so we use nodes with more rather than less RAM.
 
-Using `highmem` machines saves us a lot of money, since we are not paying for CPU
-we are not using!
+*tl;dr: Using `highmem` machines saves us a lot of money, since we are not paying for CPU
+we are not using!*
 
 The `staging` cluster uses much smaller machines than the production one, to keep costs
 down.
@@ -89,9 +90,8 @@ down.
 ### Boot disk sizes
 
 In `prod-a`, we use 1000 GB SSD disks as boot disks. On Google Cloud, the size of
-the disk [controls](https://cloud.google.com/compute/docs/disks/performance) the
-performance - larger the disk, faster it is. Our disks need to be fast since we
-are doing a lot of IO operations during docker build / push / pull / run, so we
+the disk [controls the performance](https://cloud.google.com/compute/docs/disks/performance) - larger the disk, the faster it is. Our disks need to be fast since we
+are doing a lot of I/O operations during docker build / push / pull / run, so we
 use SSDs.
 
 Note that SSD boot disks are *not* a feature available on GKE to all customers -
@@ -109,17 +109,17 @@ full, the cluster autoscaler adds a new node to handle more pods. However,
 there is no way to make the autoscaler kick in at 80% of 90% utilization
 ([bug](https://github.com/kubernetes/autoscaler/issues/148)), so this leads
 to [launch failures](https://github.com/jupyterhub/mybinder.org-deploy/issues/474)
-for a while when a new node comes up.
+for a short time when a new node comes up.
 
 The autoscaler can be set to have a `minimum` number of nodes and a `maximum` number
-of nodes. 
+of nodes.
 
 ## Google Container Registry
 
-A core part of MyBinder.org is building, storing and then running docker images
+A core part of mybinder.org is building, storing and then running docker images
 (built by [repo2docker](https://github.com/jupyter/repo2docker)). Docker images
 are generally stored in a [docker registry](https://github.com/docker/distribution),
-using a well defined standard API. 
+using a well-defined standard API.
 
 We use Google Cloud's hosted docker registry - [Google Container Registry (GCR)](https://cloud.google.com/container-registry/).
 This lets us use a standard mechanism for storing and retrieving docker images
@@ -132,13 +132,14 @@ GCR is private by default, and can be only used from inside the Google Cloud pro
 the registry is located in. When using GKE, the authentication for pulling images
 to run is already set up for us, so we do not need to do anything special. For pushing
 images, we authenticate via a [service account](https://cloud.google.com/container-registry/docs/advanced-authentication#using_a_json_key_file).
+
 You can find this service account credential under `registry` in `secrets/config/prod.yaml`
 and `secrets/config/staging.yaml`.
 
 ### Access
 
-The images are scoped per-project, the images made by `mybinder.org` are 
-stored in the `binder-prod` project, and the images made by `staging.mybinder.org` 
+The images are scoped per-project, the images made by `mybinder.org` are
+stored in the `binder-prod` project, and the images made by `staging.mybinder.org`
 are stored in the `binder-staging` project.
 
 We do not allow users to pull our images, for a few reasons:
@@ -147,11 +148,11 @@ We do not allow users to pull our images, for a few reasons:
    and this can become very costly!
 2. This can be abused to treat us as a content redistributor - build
    an image with content you want, and then just pull the image from elsewhere. This
-   makes us a convenient possible hop in cybercrime / piracy / other operations, 
-   complicates possible [DMCA](https://en.wikipedia.org/wiki/Digital_Millennium_Copyright_Act) 
-   / [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) compliance and 
-   probably a bunch of other bad things we do not have the imagination to foresee. 
-3. We might decide to clean up old images when we no longer need them, and this might 
+   makes us a convenient possible hop in cybercrime / piracy / other operations,
+   complicates possible [DMCA](https://en.wikipedia.org/wiki/Digital_Millennium_Copyright_Act)
+   / [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) compliance and
+   probably a bunch of other bad things we do not have the imagination to foresee.
+3. We might decide to clean up old images when we no longer need them, and this might
    break other users who might depend on this.
 
 For users who want access to a docker image similar to how it is built with Binder,
@@ -162,12 +163,12 @@ your own, and push it to a registry of your choice.
 
 Since building an image takes a long time, we would like to re-use images as much
 as possible. If we have built an image once for a particular repository at a particular
-commit, we want to not rebuild that image - just re-use it as much as possible. 
-We generate an image name for each image we build that is uniquely derived from 
-the name of the repository + the commit hash. This lets us check easily if 
+commit, we want to not rebuild that image - just re-use it as much as possible.
+We generate an image name for each image we build that is uniquely derived from
+the name of the repository + the commit hash. This lets us check if
 the image has already been built, and if so, we can skip the building step.
 
-The code for generating this image name from repository information is
+The code for generating the image name from repository information is
 in [binderhub's builder.py](https://github.com/jupyterhub/binderhub/blob/master/binderhub/builder.py),
 under `_generate_build_name`.
 
@@ -178,9 +179,16 @@ this invalidation has to be done judiciously. This is done by giving all the ima
 a `prefix` (`binderhub.registry.prefix` in `config/prod.yaml` and `config/staging.yaml`).
 Changing this prefix will invalidate all existing images.
 
-## Logging 
+## Logging, Metrics, and Dashboarding
 
-We use [Google Stackdriver](https://cloud.google.com/stackdriver/) for logging.
-Stackdriver supports other features (such as metrics and dashboarding), but we 
-use [prometheus](metrics.html) and [grafana](dashboards.html) instead for those
-features. 
+We use [Google Stackdriver](https://cloud.google.com/stackdriver/) for logging
+activity on the Kubernetes deployment. This is useful for listing the raw
+logs coming out of BinderHub, though we don't use it for dashboarding (see below).
+
+We use [prometheus](metrics.html) for collecting more fine-grained metrics about
+what's happening on the deployment, and [grafana](dashboards.html) for generating
+dashboards using the data from prometheus.
+
+We use [Google Analytics](https://analytics.google.com/analytics/web) to keep
+track of activity on the `mybinder.org` site, though note that we lose track
+of users as soon as they are directed to their Binder session.

--- a/docs/source/components/ingress.md
+++ b/docs/source/components/ingress.md
@@ -1,7 +1,7 @@
 # HTTPS ingress with nginx + kube-lego
 
 Kubernetes [Ingress Objects](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-are used to manage HTTP(S) access from the wide internet to inside the kubernetes cluster.
+are used to manage HTTP(S) access from the internet to inside the Kubernetes cluster.
 Among other things, it lets us do the following:
 
 1. Provide a HTTPS end point so users can connect to us securely
@@ -13,11 +13,11 @@ our Ingress needs.
 
 ## Nginx Ingress
 
-We run on Google Cloud's Kubernetes Engine, which comes pre-installed with
-the [Google Cloud Load Balancer Ingress provider](https://github.com/kubernetes/ingress-gce).
-We decided to not use it and use nginx instead for the following reasons:
+We run on Google Cloud's Kubernetes Engine. Note that GKE comes pre-installed with
+the [Google Cloud Load Balancer Ingress provider](https://github.com/kubernetes/ingress-gce),
+but we decided to use nginx instead for the following reasons:
 
-1. GCLB has a 30s default timeout on all HTTP connections. This is counted 
+1. GCLB has a 30s default timeout on all HTTP connections. This is counted
    not just when connection is idle, but from connection start time. This
    is particularly bad for websockets, since those connections usually last for
    a lot longer than 30s! There is no easy way to configure this timeout from
@@ -25,22 +25,21 @@ We decided to not use it and use nginx instead for the following reasons:
 2. GCLB does not guarantee you can use the same IP for multiple domains. We
    want the various subdomains of `mybinder.org` to point to the same IP
    so we can easily add / remove new services without waiting for DNS propagation
-   delay. 
+   delay.
 
-These are the primary reasons for using nginx ingress instead of the default one.
-
-### Installation 
+### Installation
 
 nginx-ingress is installed using the [nginx-ingress helm chart](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress).
 This installs the following components:
 
-1. `nginx-ingress-controller`, which keeps the HTTPS rules in sync with `Ingress` objects and serves the HTTPS requests. This also exports
+1. `nginx-ingress-controller` - keeps the HTTPS rules in sync with `Ingress`
+   objects and serves the HTTPS requests. This also exports
    [metrics](metrics.html) that are captured in prometheus.
-2. `nginx-ingress-default-backend`, which simply returns 404 & is used
+2. `nginx-ingress-default-backend` - simply returns a 404 error & is used
    by `nginx-ingress-controller` to serve any requests that don't match
    any rules.
 
-The specific ways these have been configured in can be seen in `mybinder/values.yaml`
+The specific ways these have been configured can be seen in the `mybinder/values.yaml`
 file in this repo, under `nginx-ingress`.
 
 ### Configuration with Ingress objects
@@ -54,16 +53,16 @@ present with `kubectl --namespace=prod get ingress`.
 The following ingress objects currently exist:
 
 * `jupyterhub` - Directs traffic to `hub.mybinder.org`.
-  The zero-to-jupyterhub guide has more [documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/advanced.html#ingress)
+  The zero-to-jupyterhub guide has more [documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/advanced.html#ingress).
 * `binderhub` - Directs traffic to `mybinder.org`. You can find more details
-   about this in the [binderhub helm chart](https://github.com/jupyterhub/binderhub/tree/master/helm-chart)
-* `redirector` - Directs traffic to the HTTP redirector we run for mybinder.org.
+   about this in the [binderhub helm chart](https://github.com/jupyterhub/binderhub/tree/master/helm-chart).
+* `redirector` - Directs traffic to the HTTP redirector we run for `mybinder.org`.
    This helps do redirects such as `docs.mybinder.org` or `beta.mybinder.org`.
    The list of redirects is configured in `mybinder/values.yaml`. The code
    for this is in `mybinder/templates/redirector` in this repo.
-* `static` - Directs traffic into `static.mybinder.org`. We serve the mybinder.org
+* `static` - Directs traffic into `static.mybinder.org`. We serve the `mybinder.org`
    badges from a different domain for [privacy reasons](https://github.com/jupyterhub/binderhub/issues/379).
-   This ingress lets us direct traffic only from `static.mybinder.org/badge.svg` to the 
+   This ingress lets us direct traffic only from `static.mybinder.org/badge.svg` to the
    binder pod.
 * `prometheus-server` - Directs traffic to `prometheus.mybinder.org`. Configured under
   `prometheus` in both `mybinder/values.yaml` and `config/prod.yaml`.
@@ -78,8 +77,12 @@ We use [Let's Encrypt](https://letsencrypt.org/) for all our HTTPS certificates.
 [Kube Lego](https://github.com/jetstack/kube-lego) is used to automatically
 provision and maintain HTTPS certificates for us.
 
-Note: Kube-lego is deprecated, and we should move to [cert-manager](https://github.com/jetstack/cert-manager/)
-soon.
+```eval_rst
+.. note::
+
+   Kube-lego is deprecated, and we should move to
+   `cert-manager <https://github.com/jetstack/cert-manager/>`_ soon.
+```
 
 ### Installation
 
@@ -87,7 +90,7 @@ kube-lego is installed using the [kube-lego](https://github.com/kubernetes/chart
 
 ### Configuration
 
-`kube-lego` requires Ingress objects to have specific `annotations` and 
+`kube-lego` requires Ingress objects to have specific `annotations` and
 `tls` values, as [documented here](https://github.com/jetstack/kube-lego#how-kube-lego-works).
 We specify this for all our ingress objects, mostly by customizing various helm charts
 in `mybinder/values.yaml`.
@@ -95,7 +98,7 @@ in `mybinder/values.yaml`.
 ### Let's Encrypt account
 
 Let's Encrypt uses [accounts](https://community.letsencrypt.org/t/what-are-accounts-do-i-need-to-backup-them/21318)
-to keep track of HTTPS certificates & expiry dates. 
+to keep track of HTTPS certificates & expiry dates.
 Currently, the account is registered to `yuvipanda@gmail.com`, mostly as a historical
 accident. Changing it requires some amount of care to make sure we do not suffer
 intermittent HTTPS failure, and should be done whenever we switch to cert-manager.

--- a/docs/source/components/ingress.md
+++ b/docs/source/components/ingress.md
@@ -13,9 +13,9 @@ our Ingress needs.
 
 ## Nginx Ingress
 
-We run on Google Cloud's Kubernetes Engine. Note that GKE comes pre-installed with
+We run on Google Cloud's Kubernetes Engine. Even thought GKE comes pre-installed with
 the [Google Cloud Load Balancer Ingress provider](https://github.com/kubernetes/ingress-gce),
-but we decided to use nginx instead for the following reasons:
+we decided to use nginx instead for the following reasons:
 
 1. GCLB has a 30s default timeout on all HTTP connections. This is counted
    not just when connection is idle, but from connection start time. This

--- a/docs/source/components/ingress.md
+++ b/docs/source/components/ingress.md
@@ -1,0 +1,101 @@
+# HTTPS ingress with nginx + kube-lego
+
+Kubernetes [Ingress Objects](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+are used to manage HTTP(S) access from the wide internet to inside the kubernetes cluster.
+Among other things, it lets us do the following:
+
+1. Provide a HTTPS end point so users can connect to us securely
+2. Direct traffic to various Services based on hostnames or URL paths
+3. Allow using one public IP address for multiple domain names
+
+We use the [nginx-ingress](https://github.com/kubernetes/ingress-nginx) provider to handle
+our Ingress needs.
+
+## Nginx Ingress
+
+We run on Google Cloud's Kubernetes Engine, which comes pre-installed with
+the [Google Cloud Load Balancer Ingress provider](https://github.com/kubernetes/ingress-gce).
+We decided to not use it and use nginx instead for the following reasons:
+
+1. GCLB has a 30s default timeout on all HTTP connections. This is counted 
+   not just when connection is idle, but from connection start time. This
+   is particularly bad for websockets, since those connections usually last for
+   a lot longer than 30s! There is no easy way to configure this timeout from
+   inside Kubernetes.
+2. GCLB does not guarantee you can use the same IP for multiple domains. We
+   want the various subdomains of `mybinder.org` to point to the same IP
+   so we can easily add / remove new services without waiting for DNS propagation
+   delay. 
+
+These are the primary reasons for using nginx ingress instead of the default one.
+
+### Installation 
+
+nginx-ingress is installed using the [nginx-ingress helm chart](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress).
+This installs the following components:
+
+1. `nginx-ingress-controller`, which keeps the HTTPS rules in sync with `Ingress` objects and serves the HTTPS requests. This also exports
+   [metrics](metrics.html) that are captured in prometheus.
+2. `nginx-ingress-default-backend`, which simply returns 404 & is used
+   by `nginx-ingress-controller` to serve any requests that don't match
+   any rules.
+
+The specific ways these have been configured in can be seen in `mybinder/values.yaml`
+file in this repo, under `nginx-ingress`.
+
+### Configuration with Ingress objects
+
+`Ingress` objects are used to tell the ingress controllers which requests
+should be routed to which `Service` objects. Usually, the rules either
+check for a hostname (like `mybinder.org` or `prometheus.mybinder.org`) and/or
+a URL prefix (like `/metrics` or `/docs`). You can see all the ingress objects
+present with `kubectl --namespace=prod get ingress`.
+
+The following ingress objects currently exist:
+
+* `jupyterhub` - Directs traffic to `hub.mybinder.org`.
+  The zero-to-jupyterhub guide has more [documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/advanced.html#ingress)
+* `binderhub` - Directs traffic to `mybinder.org`. You can find more details
+   about this in the [binderhub helm chart](https://github.com/jupyterhub/binderhub/tree/master/helm-chart)
+* `redirector` - Directs traffic to the HTTP redirector we run for mybinder.org.
+   This helps do redirects such as `docs.mybinder.org` or `beta.mybinder.org`.
+   The list of redirects is configured in `mybinder/values.yaml`. The code
+   for this is in `mybinder/templates/redirector` in this repo.
+* `static` - Directs traffic into `static.mybinder.org`. We serve the mybinder.org
+   badges from a different domain for [privacy reasons](https://github.com/jupyterhub/binderhub/issues/379).
+   This ingress lets us direct traffic only from `static.mybinder.org/badge.svg` to the 
+   binder pod.
+* `prometheus-server` - Directs traffic to `prometheus.mybinder.org`. Configured under
+  `prometheus` in both `mybinder/values.yaml` and `config/prod.yaml`.
+* `grafana` - Directs traffic to `grafana.mybinder.org`. Configured under `grafana` in
+   both `mybinder/values.yaml` and `config/prod.yaml`.
+* `kube-lego-nginx` - Used by [kube-lego](#https-with-kube-lego) for doing automatic
+   HTTPS certificate renewals.
+
+## HTTPS certificates with kube-lego
+
+We use [Let's Encrypt](https://letsencrypt.org/) for all our HTTPS certificates.
+[Kube Lego](https://github.com/jetstack/kube-lego) is used to automatically
+provision and maintain HTTPS certificates for us.
+
+Note: Kube-lego is deprecated, and we should move to [cert-manager](https://github.com/jetstack/cert-manager/)
+soon.
+
+### Installation
+
+kube-lego is installed using the [kube-lego](https://github.com/kubernetes/charts/tree/master/stable/kube-lego).
+
+### Configuration
+
+`kube-lego` requires Ingress objects to have specific `annotations` and 
+`tls` values, as [documented here](https://github.com/jetstack/kube-lego#how-kube-lego-works).
+We specify this for all our ingress objects, mostly by customizing various helm charts
+in `mybinder/values.yaml`.
+
+### Let's Encrypt account
+
+Let's Encrypt uses [accounts](https://community.letsencrypt.org/t/what-are-accounts-do-i-need-to-backup-them/21318)
+to keep track of HTTPS certificates & expiry dates. 
+Currently, the account is registered to `yuvipanda@gmail.com`, mostly as a historical
+accident. Changing it requires some amount of care to make sure we do not suffer
+intermittent HTTPS failure, and should be done whenever we switch to cert-manager.

--- a/docs/source/components/ingress.md
+++ b/docs/source/components/ingress.md
@@ -13,7 +13,7 @@ our Ingress needs.
 
 ## Nginx Ingress
 
-We run on Google Cloud's Kubernetes Engine. Even thought GKE comes pre-installed with
+We run on Google Cloud's Kubernetes Engine. Even though GKE comes pre-installed with
 the [Google Cloud Load Balancer Ingress provider](https://github.com/kubernetes/ingress-gce),
 we decided to use nginx instead for the following reasons:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Introduction
 
    getting_started.md
    production_environment.md
+   terminology.md
 
 Components
 ----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Components
    components/metrics.md
    components/dashboards.md
    components/ingress.md
+   components/cloud.md
 
 Deployment and Operation
 ------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Components
 
    components/metrics.md
    components/dashboards.md
+   components/ingress.md
 
 Deployment and Operation
 ------------------------

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -1,0 +1,20 @@
+Terminology for the deployment
+==============================
+
+This page contains common words or phrases in the dev-ops community that will
+be useful in understanding and maintaining the ``mybinder.org`` deployment.
+
+.. _term-cordoning:
+
+"cordoning" a node
+------------------
+
+`Kubernetes page on cordoning <https://kubernetes-v1-4.github.io/docs/user-guide/kubectl/kubectl_cordon/>`_.
+
+Sometimes you want to ensure that **no new pods** will be started on a given
+node. Usually this is because you suspect the node has a problem with it, or
+you wish to remove the node but need it to be free of pods first.
+
+Cordoning the node tells Kubernetes to make it **unschedulable**, which means new
+pods won't start on the node. It is common to wait several hours, then manually
+remove any remaining pods on the node before removing it manually.


### PR DESCRIPTION
Lots of documentation on various components we use:

1. nginx-ingress for getting HTTP traffic into our cluster
2. kube-lego for Let's Encrypt ceritficates
3. Google Kubernetes Engine (GKE) for hosted Kubernetes
4. Google Container Registry (GCR) for hosted Container Registry

Also included is some guidance on when to use hosted vendor's cloud
products.

closes #416 closes #417 