### PR TITLE
binderhub bump to PR #453

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-94f5f3e
+   version: 0.1.0-2a7b0aa
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
update to sha [2a7b0aa](https://github.com/jupyterhub/binderhub/commit/2a7b0aa90139e5149bdb53785be006b1b07a3a50)