### PR TITLE
cull idle kernels via repo2docker appendix

### DIFF
--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -1,0 +1,3 @@
+import os
+c.NotebookApp.extra_template_paths.append('/etc/jupyter/binder_templates')
+c.NotebookApp.jinja_template_vars.update({'binder_url': os.environ.get('BINDER_URL', 'https://mybinder.org')})

--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -5,11 +5,19 @@ c.NotebookApp.jinja_template_vars.update({
 })
 
 # shutdown notebook after no activity for 10 minutes
-c.NotebookApp.shutdown_no_activity_timeout = 10 * 60
-# shutdown idle kernels after 10 minutes
-c.MappingKernelManager.cull_idle_timeout = 10 * 60
-# check kernel idleness every minute
-c.MappingKernelManager.cull_interval = 60
+if os.getenv('CULL_TIMEOUT'):
+    # shutdown the server after no activity
+    c.NotebookApp.shutdown_no_activity_timeout = int(os.getenv('CULL_TIMEOUT'))
+
+if os.getenv('CULL_KERNEL_TIMEOUT'):
+    # shutdown kernels after no activity
+    c.MappingKernelManager.cull_idle_timeout = int(os.getenv('CULL_KERNEL_TIMEOUT'))
+
+if os.getenv('CULL_INTERVAL'):
+    # check for idle kernels this often
+    c.MappingKernelManager.cull_interval = int(os.getenv('CULL_INTERVAL'))
+
 # a kernel with open connections but no activity still counts as idle
 # this is what allows us to shutdown servers when people leave a notebook open and wander off
-c.MappingKernelManager.cull_connected = True
+if os.getenv('CULL_CONNECTED') not in {'', '0'}:
+    c.MappingKernelManager.cull_connected = True

--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -4,7 +4,12 @@ c.NotebookApp.jinja_template_vars.update({
     'binder_url': os.environ.get('BINDER_URL', 'https://mybinder.org'),
 })
 
-# shutdown notebook after no activity for 10 minutes
+
+# if a user leaves a notebook with a running kernel,
+# the effective idle timeout will typically be CULL_TIMEOUT + CULL_KERNEL_TIMEOUT
+# as culling the kernel will register activity,
+# resetting the no_activity timer for the server as a whole
+
 if os.getenv('CULL_TIMEOUT'):
     # shutdown the server after no activity
     c.NotebookApp.shutdown_no_activity_timeout = int(os.getenv('CULL_TIMEOUT'))

--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -1,3 +1,15 @@
 import os
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/binder_templates')
-c.NotebookApp.jinja_template_vars.update({'binder_url': os.environ.get('BINDER_URL', 'https://mybinder.org')})
+c.NotebookApp.jinja_template_vars.update({
+    'binder_url': os.environ.get('BINDER_URL', 'https://mybinder.org'),
+})
+
+# shutdown notebook after no activity for 10 minutes
+c.NotebookApp.shutdown_no_activity_timeout = 10 * 60
+# shutdown idle kernels after 10 minutes
+c.MappingKernelManager.cull_idle_timeout = 10 * 60
+# check kernel idleness every minute
+c.MappingKernelManager.cull_interval = 60
+# a kernel with open connections but no activity still counts as idle
+# this is what allows us to shutdown servers when people leave a notebook open and wander off
+c.MappingKernelManager.cull_connected = True

--- a/appendix/run-appendix
+++ b/appendix/run-appendix
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+appendix_dir="$(dirname "$0")"
+mkdir -p /etc/jupyter
+# add and register custom templates and config
+cp -r "${appendix_dir}/templates" /etc/jupyter/binder_templates
+cat "${appendix_dir}/extra_notebook_config.py" >> /etc/jupyter/jupyter_notebook_config.py
+# ensure /etc/jupyter has read+listdir permissions for all
+chmod -R a+rX /etc/jupyter

--- a/appendix/templates/login.html
+++ b/appendix/templates/login.html
@@ -1,0 +1,10 @@
+{% extends "templates/login.html" %}
+{% block site %}
+
+<div id="ipython-main-app" class="container">
+    <h1>You don't have access to this Binder!</h1>
+    <h2>
+        You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>
+    </h2>
+</div>
+{% endblock site %}

--- a/appendix/templates/login.html
+++ b/appendix/templates/login.html
@@ -2,7 +2,7 @@
 {% block site %}
 
 <div id="ipython-main-app" class="container">
-  <h1>You can't access this Binder</h1>
+  <h1>Binder inaccessible</h1>
   <h2>
     You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
   </h2>
@@ -12,8 +12,8 @@
 
   <h4>Is this a Binder that you created?</h4>
   <p>
-    If so, your authentication cookie used has been deleted or expired.
-    You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
+    If so, your authentication cookie for this Binder has been deleted or expired.
+    You can launch a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
   </p>
 
   <h4>Did someone give you this Binder link?</h4>

--- a/appendix/templates/login.html
+++ b/appendix/templates/login.html
@@ -2,9 +2,24 @@
 {% block site %}
 
 <div id="ipython-main-app" class="container">
-    <h1>You don't have access to this Binder!</h1>
-    <h2>
-        You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>
-    </h2>
+  <h1>You can't access this Binder</h1>
+  <h2>
+    You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
+  </h2>
+  <p>
+    The shareable URL for this repo is: <tt>{{binder_url}}</tt>
+  </p>
+
+  <h4>Is this a Binder that you created?</h4>
+  <p>
+    If so, your authentication cookie used has been deleted or expired.
+    You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
+  </p>
+
+  <h4>Did someone give you this Binder link?</h4>
+  <p>
+    If so, the link is outdated or incorrect.
+    Recheck the link for typos or ask the person who gave you the link for an updated link.
+    A shareable Binder link should look like <tt>{{binder_url}}</tt>.
 </div>
 {% endblock site %}

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -7,7 +7,16 @@ binderhub:
     prefix: gcr.io/binder-staging/r2d-acae7f9-
 
   build:
-    appendixUrl: https://github.com/jupyterhub/mybinder.org-deploy/archive/7a07920b2.tar.gz
+    appendix: |
+      USER root
+      ENV BINDER_URL={binder_url}
+      ENV REPO_URL={repo_url}
+      RUN cd /tmp \
+       && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/329ab6a52c272cf425f9bd69221bf072893f87b1.tar.gz -O appendix.tar.gz \
+       && tar --wildcards -xzf appendix.tar.gz --strip 1 */appendix\
+       && ./appendix/run-appendix \
+       && rm -rf appendix.tar.gz appendix
+      USER $NB_USER
 
   hub:
     url: https://hub.staging.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -6,6 +6,9 @@ binderhub:
   registry:
     prefix: gcr.io/binder-staging/r2d-acae7f9-
 
+  build:
+    appendixUrl: https://github.com/jupyterhub/mybinder.org-deploy/archive/7a07920b2.tar.gz
+
   hub:
     url: https://hub.staging.mybinder.org
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/r2d-acae7f9-
+    prefix: gcr.io/binder-staging/r2d-05168b0-
 
   build:
     appendix: |

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -12,7 +12,7 @@ binderhub:
       ENV BINDER_URL={binder_url}
       ENV REPO_URL={repo_url}
       RUN cd /tmp \
-       && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/329ab6a52c272cf425f9bd69221bf072893f87b1.tar.gz -O appendix.tar.gz \
+       && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/ce31915cfc76b749a4e089b7c105856cea545319.tar.gz -O appendix.tar.gz \
        && tar --wildcards -xzf appendix.tar.gz --strip 1 */appendix\
        && ./appendix/run-appendix \
        && rm -rf appendix.tar.gz appendix

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-0bb083d
+   version: 0.1.0-628f741
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-628f741
+   version: 0.1.0-100220a
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-100220a
+   version: 0.1.0-bb4029a
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -94,6 +94,11 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
+      extraEnv:
+        CULL_CONNECTED: '1'
+        CULL_TIMEOUT: '600'
+        CULL_KERNEL_TIMEOUT: '600'
+        CULL_INTERVAL: '60'
   build:
     repo2dockerImage: jupyter/repo2docker:acae7f9
   perRepoQuota: 200

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -58,7 +58,8 @@ binderhub:
       extraConfigMap:
         cors: *cors
       extraConfig:
-        neverRestart: c.KubeSpawner.singleuser_extra_pod_config.update({'restartPolicy': 'Never'})
+        neverRestart: |
+          c.KubeSpawner.singleuser_extra_pod_config.update({'restartPolicy': 'Never'})
     proxy:
       service:
         type: ClusterIP

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -100,7 +100,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:acae7f9
+    repo2dockerImage: jupyter/repo2docker:05168b0
   perRepoQuota: 200
 
 playground:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -57,6 +57,8 @@ binderhub:
     hub:
       extraConfigMap:
         cors: *cors
+      extraConfig:
+        neverRestart: c.KubeSpawner.singleuser_extra_pod_config.update({'restartPolicy': 'Never'})
     proxy:
       service:
         type: ClusterIP


### PR DESCRIPTION
uses notebook server's culling mechanisms to shutdown kernels and servers that are idle. This should solve one very specific case where the notebook server has more information than the proxy's activity tracking: a left-open notebook tab with an active websocket connection.

The notebook culler has `.cull_connected` which allows the culler to ignore the active connections when considering a notebook idle. This means that leaving a notebook open but not running anything for ~ten minutes it will still get culled, which is not happening right now due to websocket keepalive traffic.

Since this is a harsher shutdown (opening a notebook and reading can result in culling), we could give it a longer timeout than the network-activity culler we are also using.

This is WIP because only the appendix files are added, not actually enabled, which must wait for https://github.com/jupyterhub/binderhub/pull/459