### PR TITLE
[wip] add pod-culler replicaset

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: mybinder
+    imagePrefix: minrk/binder-
+    images:
+      pod-culler:
+        valuesPath: podCuller.image

--- a/images/pod-culler/Dockerfile
+++ b/images/pod-culler/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6-alpine
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache -r /tmp/requirements.txt && pip freeze
+ADD culler /usr/local/bin/culler
+CMD culler

--- a/images/pod-culler/culler
+++ b/images/pod-culler/culler
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Delete all user pods older than a given duration.
+
+We use the Kubernetes cluster autoscaler, which
+removes nodes from the kubernetes cluster when they have
+been 'empty' for more than 10 minutes However, we
+have issues where some pods get 'stuck' and never actually
+die, sometimes forever. This causes nodes to not be
+killed automatically.
+
+This script makes it easier to find and delete pods that match a certain
+name or age. By default, it only *finds* and lists these pods. If the `--delete` flag
+is given, it will also *delete* those pods.
+
+You need the `kubernetes` python library installed for this to work.
+"""
+import argparse
+from kubernetes import config, client
+from datetime import datetime, timedelta, timezone
+
+# Load kubernetes incluster config
+config.load_incluster_config()
+namespace = os.environ['POD_NAMESPACE']
+kube = client.CoreV1Api()
+
+# load time options (units are minutes)
+max_age = float(os.getenv('MAX_AGE') or '360')
+interval = float(os.getenv('INTERVAL') or '60') * 60
+
+def cull_pods(max_age_hours):
+    """Cull pods older than max_age hours"""
+    pods = kube.list_namespaced_pod(namespace, label_selector="component=singleuser-server")
+    total_pods = []
+    age_cutoff = timedelta(minutes=max_age)
+    for pod in pods.items:
+        # API results always use UTC timezone
+        age = datetime.now(timezone.utc) - pod.status.start_time.replace(tzinfo=timezone.utc)
+        if age > cutoff:
+            if False:
+                kube.delete_namespaced_pod(pod.metadata.name, namespace, client.V1DeleteOptions())
+                print("Deleted {:.1f}h old pod {}".format(age.total_seconds() / 60 / 60, pod.metadata.name))
+                summary_text = 'Deleted {} pods'
+            else:
+                print("Found {:.1f}h old pod {}".format(age.total_seconds() / 60 / 60, pod.metadata.name))
+                summary_text = 'Found {} pods'
+
+            total_pods.append(pod.metadata.name)
+
+    print('---', '\n', summary_text.format(len(total_pods)))
+
+
+def main():
+    while True:
+        try:
+            cull_pods(max_age)
+        except Exception:
+            traceback.print_traceback()
+        time.sleep(interval_minutes * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/images/pod-culler/requirements.txt
+++ b/images/pod-culler/requirements.txt
@@ -1,0 +1,19 @@
+kubernetes==4.0.0
+# remainder from pip freeze:
+cachetools==2.0.1
+certifi==2018.1.18
+chardet==3.0.4
+google-auth==1.4.1
+idna==2.6
+ipaddress==1.0.19
+# kubernetes==4.0.0
+oauthlib==2.0.6
+pyasn1==0.4.2
+pyasn1-modules==0.2.1
+PyYAML==3.12
+requests==2.18.4
+requests-oauthlib==0.8.0
+rsa==3.4.2
+six==1.11.0
+urllib3==1.22
+websocket-client==0.40.0

--- a/mybinder/templates/pod-culler.yaml
+++ b/mybinder/templates/pod-culler.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: pod-culler
+  labels:
+    app: pod-culler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod-culler
+  template:
+    metadata:
+      labels:
+        app: pod-culler
+    spec:
+      containers:
+      - name: culler
+        image: {{ .Values.podCuller.image.name }}:{{ .Values.podCuller.image.tag }}
+        resources:
+          requests:
+            memory: 100Mi
+        env:
+        - name: MAX_AGE
+          value: {{ .Values.culler.maxAge | quote }}
+        - name: INTERVAL
+          value: {{ .Values.culler.interval | quote }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -97,6 +97,14 @@ binderhub:
   repo2dockerImage: jupyter/repo2docker:8d39900
   perRepoQuota: 200
 
+podCuller:
+  image:
+    name: minrk/binder-pod-culler
+    tag: 12ebbc7
+  # these times are minutes:
+  maxAge: 360
+  interval: 30
+
 playground:
   image:
     name: yuvipanda/play.nteract.io


### PR DESCRIPTION
essentially runs our delete script every hour to enforce a max age of six hours on user pods

cull image built with chartpress, publication not automated yet

- [ ] test it out
- [ ] enable chartpress on travis to build / publish images
- [ ] maybe use [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)