### PR TITLE
Enable repo2docker support in the binderhub chart

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-2a7b0aa
+   version: 0.1.0-22fcbc5
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/binderhub/pull/480