### PR TITLE
Update repo2docker to have a default command

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -94,7 +94,7 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
-  repo2dockerImage: jupyter/repo2docker:8d39900
+  repo2dockerImage: jupyter/repo2docker:f543665
   perRepoQuota: 200
 
 playground:


### PR DESCRIPTION
Brings in https://github.com/jupyter/repo2docker/pull/176