### PR TITLE
repo2dockerImage config moved under build

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -94,7 +94,8 @@ binderhub:
             add:
             - NET_ADMIN
       schedulerStrategy: pack
-  repo2dockerImage: jupyter/repo2docker:acae7f9
+  build:
+    repo2dockerImage: jupyter/repo2docker:acae7f9
   perRepoQuota: 200
 
 playground:


### PR DESCRIPTION
adding build options is now under build after https://github.com/jupyterhub/binderhub/pull/459