### PR TITLE
bump the image prefix

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -12,7 +12,7 @@ binderhub:
       memory: 2Gi
 
   registry:
-    prefix: gcr.io/binder-prod/r2d-fd74043
+    prefix: gcr.io/binder-prod/r2d-acae7f9-
 
   hub:
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/r2d-fd74043
+    prefix: gcr.io/binder-staging/r2d-acae7f9-
 
   hub:
     url: https://hub.staging.mybinder.org


### PR DESCRIPTION
https://github.com/jupyterhub/binderhub/pull/454 changed the image name-generation to be more reliable, but the result is a changed image name-generation scheme. This was deployed to mybinder.org this evening in #507

We can use this opportunity to bump our image prefix since the image cache is invalidated anyway by the new image-naming scheme.