### PR TITLE
kubetools module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ mybinder/requirements.lock
 
 docs/_build
 travis/crypt-key
+
+# Chris sandbox file name
+sandbox.ipynb

--- a/scripts/kubetools/__init__.py
+++ b/scripts/kubetools/__init__.py
@@ -1,0 +1,2 @@
+"""A collection of functions to facilitate working with k8s in Python."""
+from .kubetools import get_all, delete

--- a/scripts/kubetools/kubetools.py
+++ b/scripts/kubetools/kubetools.py
@@ -1,0 +1,53 @@
+from subprocess import check_output, check_call
+import pandas as pd
+
+AGE_IN_MINS = {'s': 1/60., 'm': 1, 'h': 60, 'd': 60*24}
+
+def _age_str_to_minutes(item):
+    kind = item[-1]
+    number = item[:-1]
+    return AGE_IN_MINS[kind] * float(number)
+
+def get_all(kind, ns='prod'):
+    """Run `kubectl get <kind>` and return results as a DataFrame.
+    
+    Parameters
+    ----------
+    kind : str
+        <kind> in `kubectl --namespace=<ns> get <kind>`
+    ns : str
+        <ns> in `kubectl --namespace=<ns> get <kind>`
+        
+    Returns
+    -------
+    df : DataFrame
+        The results in a Pandas DataFrame
+    """
+    cmd = 'kubectl get {} -o wide --namespace={}'.format(kind, ns)
+    out = check_output(cmd.split())
+    lines = out.decode().split('\n')
+    lines[0] = lines[0].lower()
+    lines = [ii.split() for ii in lines]
+    df = pd.DataFrame(lines[1:], columns=lines[0])
+    df = df.query('name != None')
+    df['age'] = df['age'].map(_age_str_to_minutes)
+    return df
+
+def delete(name, kind='pod', ns='prod', force=False, verbose=True):
+    """Run `kubectl delete <name>`
+    
+    Parameters
+    ----------
+    name : str
+        <name> in `kubectl --namespace=<ns> delete <kind> <name>`
+    kind : str
+        <kind> in `kubectl --namespace=<ns> delete <kind> <name>`
+    ns : str
+        <ns> in `kubectl --namespace=<ns> delete <kind> <name>`
+    """
+    cmd = 'kubectl --namespace={ns} delete {kind} {name}'.format(ns=ns, kind=kind, name=name)
+    if force is True:
+        cmd += ' --grace-period=0 --force'
+    check_call(cmd.split())
+    if verbose is True:
+        print('Deleted pod: {name}'.format(name=name))


### PR DESCRIPTION
I put together a tiny python module that I use to make it easier to work with kubernetes in python. It's definitely some degree of replication over the k8s Python API, but it basically just lets you do simple `kubectl` system calls from a python session. Right now it's only two functions:

1. `get_all` will run `kubectl get <kind> -o wide` and return the results in a DataFrame...this makes it easy if you wanna do things like "delete all pods that match condition XXX".
2. `delete` will run `kubectl delete <kind> <name>` w/ an optional `force=True` flag.

Not sure if this is too specific to be included in mybinder.org, but I've found these useful for quickly doing non-trivial things with `kubectl` so thought I'd make a PR in case it's useful for others...