### PR TITLE
kubespawner: delete stopped pods

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-bb4029a
+   version: 0.1.0-e54c217
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
gets https://github.com/jupyterhub/kubespawner/pull/147

also pins tornado to 4.5.3 via https://github.com/jupyterhub/binderhub/pull/485 which may fix the recent lost-connection problems, or at least eliminate one possible candidate.