### PR TITLE
use patched grafana image

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -155,6 +155,7 @@ kube-lego:
 
 grafana:
   server:
+    image: "minrk/grafana:4.6.3-pr142"
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
grafana's docker image is incompatible with security fixes in kubernetes 1.8.9/1.9.4

There is an [open PR](https://github.com/grafana/grafana-docker/pull/142) with a fix, but it has not been applied to the public image yet. I applied the patch and built and pushed the image myself. We can switch back to a public image once the patch has landed.