### PR TITLE
Increase memory limit for CHP nginx container

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -44,10 +44,10 @@ binderhub:
       nginx:
         resources:
           requests:
-            memory: 2Gi
+            memory: 3Gi
             cpu: 1
           limits:
-            memory: 2Gi
+            memory: 3Gi
             cpu: 1
     ingress:
       hosts:


### PR DESCRIPTION
This container seems to regularly bump into the memory limit and gets
killed. Increasing the limit is more of a bandaid to help with the
symptom, than a long term fix.

From grafana it seems we get occasional spikes which are above the limit, not sustained long term increase/leaks.