### PR TITLE
enable maxAge culler

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-e54c217
+   version: 0.1.0-316895a
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -54,6 +54,8 @@ binderhub:
   jupyterhub:
     cull:
       timeout: 600
+      # maxAge is 6 hours: 6 * 3600 = 21600
+      maxAge: 21600
     hub:
       extraConfigMap:
         cors: *cors


### PR DESCRIPTION
user pods older than 6 hours will automatically be culled, regardless of activity

There are currently 25 pods that should be culled as soon as this is deployed. Let's see!