### PR TITLE
run tests with travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,13 +63,13 @@ before_deploy:
   python ./deploy.py staging staging
 - |
   # Stage 3, Step 2: Verify staging works
-  py.test -n 2 --binder-url=https://staging.mybinder.org --hub-url=https://hub.staging.mybinder.org
+  travis_retry py.test -n 2 --binder-url=https://staging.mybinder.org --hub-url=https://hub.staging.mybinder.org
 - |
   # Stage 4, Step 1: Deploy to production
   python ./deploy.py prod prod-a
 - |
   # Stage 4, Step 2: Verify production works
-  py.test -n 2 --binder-url=https://mybinder.org --hub-url=https://hub.mybinder.org
+  travis_retry py.test -n 2 --binder-url=https://mybinder.org --hub-url=https://hub.mybinder.org
 
 env:
   global:


### PR DESCRIPTION
The first run of the tests may fail while things are warming up on a fresh deploy. travis_retry gives the tests a couple of attempts to succeed. This isn't the best, but we've had tests fail when everything is fine due to running too early too often, and I think this will save everyone time.

In particular, one source of recent failures has the proxy-helper which turns what would be Hub 403 responses into Binder-specific 404 pages. It takes a finite time to update the proxy with these redirects. This manifests as a test failure where the expected status is 404 but actual status is 403.