### PR TITLE
run cull every 11 minutes

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -53,6 +53,9 @@ binderhub:
 
   jupyterhub:
     cull:
+      # cull every 11 minutes so it is out of phase
+      # with the proxy check-routes interval of five minutes
+      every: 660
       timeout: 600
       # maxAge is 6 hours: 6 * 3600 = 21600
       maxAge: 21600


### PR DESCRIPTION
instead of every 10

reduces coincidence of cull + proxy.check_routes which is every 5 minutes by default, so cull and check_routes were usually happening at the same time, causing brief periods of poor performance every ten minutes.

related to https://github.com/jupyterhub/jupyterhub/pull/1753 and https://github.com/jupyterhub/jupyterhub/issues/1754