### PR TITLE
Add a dummy cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ install:
 script:
  - true
 
+jobs:
+  include:
+    - if: type = cron
+      stage: cron
+      script: echo "this is cron"
+
 # We are using before_deploy instead of script or deploy
 # since before_deploy gives us nice, folded log views,
 # which neither script nor deploy seems to!


### PR DESCRIPTION
Follows up https://github.com/jupyterhub/mybinder.org-deploy/pull/531#issuecomment-377963428

I've not got any experience with setting up cron jobs on travis. I think this change to the travis config will have us running just the `echo this is cron` script as part of the cron job. Not also the pre deployment. If we think it is Ok to run this small experiment on this repo we should merge this and then enable a daily cron job in the travis settings.

If it turns out that this also runs the deployment every 24h I would suggest we wrap that so it is not run as a cron. It should be a no-op but it feels weird to run a blank deployment every 24h just for laughs.