### PR TITLE
implement CPU limits

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -23,6 +23,8 @@ binderhub:
       memory:
         guarantee: 2G
         limit: 2G
+      cpu:
+        limit: "2"
     hub:
       resources:
         requests:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -14,6 +14,8 @@ binderhub:
       memory:
         guarantee: 256M
         limit: 256M
+      cpu:
+        limit: "1"
     ingress:
       hosts:
         - hub.staging.mybinder.org


### PR DESCRIPTION
limit to 2 CPUs on prod, 1 on staging

still no CPU guarantees. Oversubscribing CPUs should usually be fine.

There are several Binders currently using lots of CPU. I'm going to shut them down once this lands.