### PR TITLE
set cpu guarantee to 0.1

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -24,6 +24,7 @@ binderhub:
         guarantee: 2G
         limit: 2G
       cpu:
+        gurantee: 0.1
         limit: 2
     hub:
       resources:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -15,6 +15,7 @@ binderhub:
         guarantee: 256M
         limit: 256M
       cpu:
+        gurantee: 0.1
         limit: 1
     ingress:
       hosts:


### PR DESCRIPTION
default seems to be same as limit, so introducing limit accidentally introduced a *request* for 2 cpus