### PR TITLE
Revert "Add a dummy cron job"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ install:
 script:
  - true
 
-jobs:
-  include:
-    - if: type = cron
-      stage: cron
-      script: echo "this is cron"
-
 # We are using before_deploy instead of script or deploy
 # since before_deploy gives us nice, folded log views,
 # which neither script nor deploy seems to!


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#534

@betatim I think adding jobs means all jobs are opt-in so having just this dummy cron job *replaced* the default deployment jobs with the dummy cron. As a result, it prevented deploying #543. To add a cron job, we seem to need to build our whole deploy flow with the jobs structure. That should also make it clearer that the cron job only runs the cron stage, not a full deploy.