### PR TITLE
binderhub #476

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-cd4f6de
+   version: 0.1.0-e65121b
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
https://github.com/jupyterhub/binderhub/pull/476

fixes build URL handling for non-GitHub providers.