### PR TITLE
temporarily bumping singleuser memory to 8GB

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -21,8 +21,8 @@ binderhub:
   jupyterhub:
     singleuser:
       memory:
-        guarantee: 2G
-        limit: 2G
+        guarantee: 8G
+        limit: 8G
       cpu:
         guarantee: 0.1
         limit: 2


### PR DESCRIPTION
For @a-paxton giving a presentation. This should be reversed in about 6 hours.