### PR TITLE
Reducing per repo limit to 100

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -119,7 +119,7 @@ binderhub:
        && ./appendix/run-appendix \
        && rm -rf appendix.tar.gz appendix
       USER $NB_USER
-  perRepoQuota: 200
+  perRepoQuota: 100
 
 playground:
   image:


### PR DESCRIPTION
See if this reduces the load due to nbinteract launching a lot of binders.