### PR TITLE
bump binderhub again

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -28,6 +28,13 @@ def setup_auth(release, cluster):
 
 def deploy(release):
     print(BOLD + GREEN + f"Starting helm upgrade for {release}" + NC, flush=True)
+    # Temporary fix: delete proxy deployment before upgrading
+    # needed due to changing labels causing upgrade failure
+    subprocess.check_call([
+        'kubectl',
+        '--namespace', release,
+        'delete', 'deployment', 'proxy',
+    ])
     helm = [
         'helm', 'upgrade', '--install',
         '--namespace', release,

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-4075ab8
+   version: 0.1.0-65e767a
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This has a temporary fix for #559 by deleting the proxy deployment prior to `helm upgrade`. This will result in a bit of downtime, but appears to be the only workaround for https://github.com/kubernetes/helm/issues/2494

In general, https://github.com/kubernetes/helm/issues/2494 seems to suggest that we need to delete objects (or whole helm deployments) any time we change labels.