### PR TITLE
bump binderhub to get culler fixes

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-65e767a
+   version: 0.1.0-04022d2
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
should fix outage due to culler bugs

gets https://github.com/jupyterhub/jupyterhub/pull/1807 by way of https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/655 and https://github.com/jupyterhub/binderhub/pull/526