### PR TITLE
bump binderhub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-4075ab8
+   version: 0.1.0-517ab7c
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This includes the latest updates, including revertig a kubespawner update, which is suspected to have caused memory and cpu leaks.

Will revert promptly if hub memory/cpu continue to grow after this, which will mean the cause is still unknown.

Watching [here](https://grafana.mybinder.org/dashboard/db/components-resource-metrics?refresh=1m&orgId=1) after deploy.