### PR TITLE
moving grafana deploy msg to end of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,16 +49,6 @@ before_deploy:
   helm repo update
   (cd mybinder && helm dep up)
 - |
-  # Stage 2, Step 3: Post message to Grafana that deployment is starting
-  source secrets/grafana-api-key
-  export PULL_REQUEST_ID=$(git log -1 --pretty=%B | head -n1 | sed 's/^.*#\([0-9]*\).*/\1/')
-  export AUTHOR_NAME="$(git log  -1 --pretty=%aN)"
-  export PULL_REQUEST_TITLE="$(git log --pretty=%B -1 | tail -n+3)"
-  python3 travis/post-grafana-annotation.py  \
-    --grafana-url https://grafana.mybinder.org \
-    --tag deployment-start \
-    "$(echo -en \"${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${TRAVIS_REPO_SLUG}/pull/${PULL_REQUEST_ID}\")"
-- |
   # Stage 3, Step 1: Deploy to staging
   python ./deploy.py staging staging
 - |
@@ -68,8 +58,19 @@ before_deploy:
   # Stage 4, Step 1: Deploy to production
   python ./deploy.py prod prod-a
 - |
-  # Stage 4, Step 2: Verify production works
+  # Stage 4, Step 2: Post message to Grafana that deployment has completed
+  source secrets/grafana-api-key
+  export PULL_REQUEST_ID=$(git log -1 --pretty=%B | head -n1 | sed 's/^.*#\([0-9]*\).*/\1/')
+  export AUTHOR_NAME="$(git log  -1 --pretty=%aN)"
+  export PULL_REQUEST_TITLE="$(git log --pretty=%B -1 | tail -n+3)"
+  python3 travis/post-grafana-annotation.py  \
+    --grafana-url https://grafana.mybinder.org \
+    --tag deployment-start \
+    "$(echo -en \"${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${TRAVIS_REPO_SLUG}/pull/${PULL_REQUEST_ID}\")"
+- |
+  # Stage 4, Step 3: Verify production works
   travis_retry py.test -n 2 --binder-url=https://mybinder.org --hub-url=https://hub.mybinder.org
+
 
 env:
   global:


### PR DESCRIPTION
Right now, a message is posted to grafana just *before* we try deploying an upgrade. This means that we get a lot of double-grafana messages because travis needs to be restarted. This PR moves the grafana message to the _end_ of a deploy so that it serves as a "confirmation" message, and should only happen once