### PR TITLE
Revert "bump binderhub"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-517ab7c
+   version: 0.1.0-4075ab8
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#564

image-cleaner is failing with:

```
$ kubectl logs prod-dind-8wqqq image-cleaner
Pruning docker images when /var/lib/docker has less than 0.8% inodes free
Traceback (most recent call last):
  File "/usr/local/bin/image-cleaner.py", line 68, in <module>
    main()
  File "/usr/local/bin/image-cleaner.py", line 50, in main
    client = docker.from_env()
  File "/usr/local/lib/python3.6/site-packages/docker/client.py", line 27, in from_env
    return Client.from_env(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/docker/client.py", line 112, in from_env
    return cls(version=version, **kwargs_from_env(**kwargs))
  File "/usr/local/lib/python3.6/site-packages/docker/client.py", line 59, in __init__
    base_url, constants.IS_WINDOWS_PLATFORM, tls=bool(tls)
  File "/usr/local/lib/python3.6/site-packages/docker/utils/utils.py", line 438, in parse_host
    "Bind address needs a port: {0}".format(addr))
docker.errors.DockerException: Bind address needs a port: /var/run/dind/docker.sock
```

I'm guessing it needs to be `unix:///var/run/...`