### PR TITLE
pin hub image tag

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,6 +63,8 @@ binderhub:
       # maxAge is 6 hours: 6 * 3600 = 21600
       maxAge: 21600
     hub:
+      image:
+        tag: 322336a
       extraConfigMap:
         cors: *cors
       extraConfig:


### PR DESCRIPTION
to version in the jupyterhub chart of the last known good deploy

this should help isolate the source of the memory leak without reverting everything