### PR TITLE
revert hub image tag pinning

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,8 +63,6 @@ binderhub:
       # maxAge is 6 hours: 6 * 3600 = 21600
       maxAge: 21600
     hub:
-      image:
-        tag: 322336a
       extraConfigMap:
         cors: *cors
       extraConfig:


### PR DESCRIPTION
pinning the hub image definitely fixed the problem, but all signs point to the new hub image not having the issue, so try unpinning it and seeing if it comes back.

If it's fine after this, all was right with the repo state, but something went wonky with the deploy.