### PR TITLE
Notify grafana when deploy to production *starts*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,7 @@ before_deploy:
   # Stage 3, Step 2: Verify staging works
   travis_retry py.test -n 2 --binder-url=https://staging.mybinder.org --hub-url=https://hub.staging.mybinder.org
 - |
-  # Stage 4, Step 1: Deploy to production
-  python ./deploy.py prod prod-a
-- |
-  # Stage 4, Step 2: Post message to Grafana that deployment has completed
+  # Stage 4, Step 1: Post message to Grafana that deployment to production has started
   source secrets/grafana-api-key
   export PULL_REQUEST_ID=$(git log -1 --pretty=%B | head -n1 | sed 's/^.*#\([0-9]*\).*/\1/')
   export AUTHOR_NAME="$(git log  -1 --pretty=%aN)"
@@ -66,7 +63,10 @@ before_deploy:
   python3 travis/post-grafana-annotation.py  \
     --grafana-url https://grafana.mybinder.org \
     --tag deployment-start \
-    "$(echo -en \"${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${TRAVIS_REPO_SLUG}/pull/${PULL_REQUEST_ID}\")"
+    "$(echo -en ${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${TRAVIS_REPO_SLUG}/pull/${PULL_REQUEST_ID})"
+- |
+  # Stage 4, Step 2: Deploy to production
+  python ./deploy.py prod prod-a
 - |
   # Stage 4, Step 3: Verify production works
   travis_retry py.test -n 2 --binder-url=https://mybinder.org --hub-url=https://hub.mybinder.org


### PR DESCRIPTION
- notifying prior to deploy-to-staging was too early, especially because deploying to staging doesn't mean deploy to prod will occur (e.g. tests fail on staging), and production deploy may take a while to start (#565)
- notifying after deploy-to-prod seems too late since events related to deploy won't show up until after the deploy finishes, which may be after a while for slow deploys, as happened this morning:

<img width="300" alt="screen shot 2018-04-19 at 14 58 21" src="https://user-images.githubusercontent.com/151929/38992938-83b83d62-43e2-11e8-9b8e-810710ac00f4.png">

also removes spurious quotation marks around annotation

We could also notify on both start and finish of deploys (and even failure), so that we have bookends for the deployment process. This is usually very brief, but the big deployment today that upgraded dind took half an hour because of how many changes there were.

cc @choldgraf 