### PR TITLE
Revert "upgrade helm to 2.8.2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ before_deploy:
   chmod +x ${HOME}/bin/kubectl
 - |
   # Stage 1: Install helm
-  curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.8.2-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-  mv ${HOME}/linux-amd64/helm ${HOME}/bin/helm
+  curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.7.0-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file - && mv ${HOME}/linux-amd64/helm ${HOME}/bin/helm
 - |
   # Stage 1: Install git-crypt
   curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > git-crypt

--- a/deploy.py
+++ b/deploy.py
@@ -9,7 +9,6 @@ BOLD = subprocess.check_output(['tput', 'bold']).decode()
 GREEN = subprocess.check_output(['tput', 'setaf', '2']).decode()
 NC = subprocess.check_output(['tput', 'sgr0']).decode()
 
-
 def setup_auth(release, cluster):
     """
     Set up GCloud + Kubectl authentication for talking to a given cluster
@@ -27,21 +26,7 @@ def setup_auth(release, cluster):
     ])
 
 
-def setup_helm():
-    """ensure helm is up to date"""
-    subprocess.check_output([
-        'helm', 'init', '--upgrade',
-    ])
-    # wait for tiller to come up
-    subprocess.check_call([
-        'kubectl', 'rollout', 'status',
-        '--namespace', 'kube-system',
-        '--watch', 'deployment', 'tiller-deploy',
-    ])
-
-
 def deploy(release):
-    """Deploy jupyterhub"""
     print(BOLD + GREEN + f"Starting helm upgrade for {release}" + NC, flush=True)
     helm = [
         'helm', 'upgrade', '--install',
@@ -97,9 +82,6 @@ def main():
     args = argparser.parse_args()
 
     setup_auth(args.release, args.cluster)
-    setup_helm()
     deploy(args.release)
 
-
-if __name__ == '__main__':
-    main()
+main()


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#578

Kubernetes was unhappy with this and it failed on the upgrade. Here's the relevant travis line:

https://travis-ci.org/jupyterhub/mybinder.org-deploy/jobs/372149241#L582

```
Activated service account credentials for: [travis-deployer@binder-staging.iam.gserviceaccount.com]
Fetching cluster endpoint and auth data.
kubeconfig entry generated for staging.
Error: error installing: deployments.extensions is forbidden: User "travis-deployer@binder-staging.iam.gserviceaccount.com" cannot create deployments.extensions in the namespace "kube-system": Required "container.deployments.create" permission.
```

cc @minrk 