### PR TITLE
Bring in auto docker version and GitHub API caching

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-87025d4
+   version: 0.1.0-72c2c36
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Docker client now uses 'auto' as version to reduce friction when client
and server disagree on the version but are compatible.

Adds functionality to cache GitHub API requests.

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a BinderHub  version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/87025d4...72c2c36