### PR TITLE
bump repo2docker to 85f69a74

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -113,7 +113,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:2dbe4c5
+    repo2dockerImage: jupyter/repo2docker:85f69a74
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
- bionic base image (18.04)
- setup.py support
- fix legacy image

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/2dbe4c5...85f69a74