### PR TITLE
Make tests more robust against log messages with missing phase

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -68,7 +68,7 @@ def test_build_binder(binder_url):
                 # include message output for debugging
                 if data.get('message'):
                     sys.stdout.write(data['message'])
-                if data['phase'] == 'ready':
+                if data.get('phase') == 'ready':
                     notebook_url = data['url']
                     token = data['token']
                     break

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -17,7 +17,7 @@ def test_launch_binder(binder_url):
         line = line.decode('utf8')
         if line.startswith('data:'):
             data = json.loads(line.split(':', 1)[1])
-            if data['phase'] == 'ready':
+            if data.get('phase') == 'ready':
                 notebook_url = data['url']
                 token = data['token']
                 break


### PR DESCRIPTION
Follow up to #588 that makes tests more robust to messages in the log stream that do not have optional fields.