### PR TITLE
bump binderhub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-c0a1dae
+   version: 0.1.0-7a22080
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
updates image-cleaner, fixes docker socket mounting in races between builds and dind

c0a1dae...7a22080

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a BinderHub version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/c0a1dae...7a22080