### PR TITLE
Bump r2d to include nteract jupyter extension v1.7

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -113,7 +113,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:f73db11
+    repo2dockerImage: jupyter/repo2docker:7a50772
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
https://github.com/jupyter/repo2docker/pull/306 - new version of the nteract extension

This is a  repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/f73db11...7a50772
