### PR TITLE
Add part of the home directory to the PATH

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -113,7 +113,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:7a50772
+    repo2dockerImage: jupyter/repo2docker:a6c001a
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
Adds a directory in the user's home directory to the PATH. This means people can install executables in `postBuild`.

This is a repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/7a50772...a6c001a
