### PR TITLE
bump binderhub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-62bb376
+   version: 0.1.0-470642d
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
re-enable cordoning during image cleaning

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a binderhub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/62bb376...470642d
