### PR TITLE
BinderHub bump to deploy timestamped logging

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-470642d
+   version: 0.1.0-d95cd14
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Mostly adds timestamps to the image cleaner output.

https://github.com/jupyterhub/binderhub/compare/470642d...d95cd14