### PR TITLE
Revert "BinderHub bump to deploy timestamped logging"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-d95cd14
+   version: 0.1.0-470642d
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#604

See if we get the normal output back.