### PR TITLE
steps to use the python commit script

### DIFF
--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -25,8 +25,8 @@ which we step through below.
 1. Merge changes to BinderHub.
 2. Open the [branches page for the BinderHub travis account](https://travis-ci.org/jupyterhub/binderhub/branches).
 3. Wait for the build for your PR merge to pass (it will say "#NNN passed").
-   If it does, then:
-
+   If it does, then continue to step 4. If it doesn't, take a look at the error message, and debug as needed
+   until they pass.
 4. Run the `list_new_commits.py` script in the `scripts/` of the
    `mybinder.org-deploy` repository. It will output something like the following:
 
@@ -34,6 +34,7 @@ which we step through below.
 
        BinderHub: https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>
        repo2docker: https://github.com/jupyter/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
+       JupyterHub: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/<OLD-HASH>...<NEW-HASH>
 
        ---------------------
 
@@ -75,7 +76,9 @@ The following lines describe how to point mybinder.org to the new repo2docker im
 1. Merge changes to repo2docker.
 2. Open the [branches page for repo2docker](https://travis-ci.org/jupyter/repo2docker/branches).
    And click on the number for the latest build on "Master".
-3. Wait for the build to pass (it will say "#NNN passed"). If it does, then:
+3. Wait for the build for your PR merge to pass (it will say "#NNN passed").
+   If it does, then continue to step 4. If it doesn't, take a look at the error message, and debug as needed
+   until they pass.
 4. Run the `list_new_commits.py` script in the `scripts/` of the
    `mybinder.org-deploy` repository. It will output something like the following:
 
@@ -83,7 +86,8 @@ The following lines describe how to point mybinder.org to the new repo2docker im
 
        BinderHub: https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>
        repo2docker: https://github.com/jupyter/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
-
+       JupyterHub: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/<OLD-HASH>...<NEW-HASH>
+       
        ---------------------
 
    Since you are updating repo2docker, copy the text in `<NEW-HASH>` for the

--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -24,35 +24,41 @@ which we step through below.
 
 1. Merge changes to BinderHub.
 2. Open the [branches page for the BinderHub travis account](https://travis-ci.org/jupyterhub/binderhub/branches).
-3. Click on the number for the latest build on "Master". It will say "#NNN passed".
-4. You'll see a list of builds that have been run on this branch. Click on the `TEST=helm` job.
-5. If the build succeeds (is green), a new helm chart for BinderHub will automatically
-   be published and listed on GitHub. Go to the [BinderHub Helm Chart](https://jupyterhub.github.io/helm-chart/#development-releases-binderhub)
-   page and grab the hash for the latest published version (at the top).
+3. Wait for the build for your PR merge to pass (it will say "#NNN passed").
+   If it does, then:
 
-       binderhub-<version-number>-<hash-name>
+4. Run the `list_new_commits.py` script in the `scripts/` of the
+   `mybinder.org-deploy` repository. It will output something like the following:
 
-   You want to copy `<hash-name>`. It will look something like
-   example, it is `f87ac35`.
+       ---------------------
 
-6. In your fork of the [mybinder.org-deploy](https://github.com/jupyterhub/mybinder.org-deploy)
+       BinderHub: https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>
+       repo2docker: https://github.com/jupyter/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
+
+       ---------------------
+
+   Since you are updating BinderHub, copy the text in `<NEW-HASH>` for the
+   line that refers to BinderHub. This is the name of the new BinderHub image.
+   We'll now update the config to refer to this image.
+
+5. In your fork of the [mybinder.org-deploy](https://github.com/jupyterhub/mybinder.org-deploy)
    repository, open `mybinder/requirements.yaml`.
-7. Toward the end of the file, you will see lines similar to:
+6. Toward the end of the file, you will see lines similar to:
 
       - name: binderhub
         version: 0.1.0-9692255
         repository: https://jupyterhub.github.io/helm-chart
 
-   COPY the *old* hash value (above, it is `9692255`) and keep it for later.
-   Replace the existing hash that comes just after the `-` under 'version' with new hash
-   from step 3. In this example, replace `9692255`  with the hash `f87ac35`that you've
-   copied in step 3. The edited lines will be:
+   Where `9692255` is the same value printed in `<OLD-HASH>` above.
+
+   Replace this hash with the text in `<NEW-HASH>` above. For example, in the
+   above case, we'll replace it with the new hash.
 
       - name: binderhub
         version: 0.1.0-fbf6e5a
         repository: https://jupyterhub.github.io/helm-chart
 
-8. Merge this change to `mybinder/requirements.yaml` into the mybinder.org-deploy
+7. Merge this change to `mybinder/requirements.yaml` into the mybinder.org-deploy
    repository following the steps in the [Deploying a change](#deploying-a-change) section
    to deploy the change.
 
@@ -68,27 +74,35 @@ The following lines describe how to point mybinder.org to the new repo2docker im
 
 1. Merge changes to repo2docker.
 2. Open the [branches page for repo2docker](https://travis-ci.org/jupyter/repo2docker/branches).
-3. Click on the number for the latest build on "Master". It will say "#NNN passed".
-4. You'll see a list of builds that have been run on this branch. Click on the
-   build underneath the **Deploy** section.
-5. You'll see the logs for this build. Scroll down and find the text:
+   And click on the number for the latest build on "Master".
+3. Wait for the build to pass (it will say "#NNN passed"). If it does, then:
+4. Run the `list_new_commits.py` script in the `scripts/` of the
+   `mybinder.org-deploy` repository. It will output something like the following:
 
-       Pushed new repo2docker image: <YOUR-IMAGE-NAME>
+       ---------------------
 
-   Copy the text in `<YOUR-IMAGE-NAME>`. **Note**: You may need to unfold the
-   code in the `Deploying application` line in order to see this text.
-6. In your fork of the mybinder.org-deploy repository, open
-   `mybinder/values.yaml`.
-7. Somewhere in the file you will see `repo2dockerImage`, it will look like
+       BinderHub: https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>
+       repo2docker: https://github.com/jupyter/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
+
+       ---------------------
+
+   Since you are updating repo2docker, copy the text in `<NEW-HASH>` for the
+   line that refers to repo2docker. This is the name of the new repo2docker image.
+   We'll now update the config to refer to this image.
+
+5. In your fork of the mybinder.org-deploy repository, open
+  `mybinder/values.yaml`.
+6. Somewhere in the file you will see `repo2dockerImage`, it will look like
    this:
-   
+
        repo2dockerImage: jupyter/repo2docker:65d5411
-   
-   COPY the *old* hash value (above, it is `65d5411`) and keep it for later.
-8. Replace the *old* hash that is there with what you copied in step 2.
+
+   Where `65d5411` is the same value in `<OLD-HASH>` above.
+
+7. Replace the *old* hash that is there with what you copied in step 4.
    For example, the edited file will look similar to:
 
-       repo2dockerImage: jupyter/repo2docker:<YOUR-NEW-HASH>
+       repo2dockerImage: jupyter/repo2docker:<NEW-HASH>
 
 8. Merge this change to `mybinder/values.yaml` into the mybinder.org-deploy
    repository following the steps in the [Deploying a change](#deploying-a-change) section
@@ -104,16 +118,17 @@ master.
 1. Make the changes as described above [on your fork of this repo](https://github.com/jupyterhub/mybinder.org-deploy).
 2. Keep track of the **hashes** that were updated. You should have both the *old* hash that
    was replaced, and the *new* hash that replaced it.
-3. Make a PR to the `master` branch with the changes you want.
-4. In the description of the PR, include a link to the *diff* between the old and new hashes
-   for the repository we're updating. It should have the following form:
-   
-       https://github.com/jupyterhub/<REPO-NAME>/compare/<OLD-HASH>...<NEW-HASH>
-       
-   For example, this is what the link for a recent update to BinderHub looks like:
-   
-       https://github.com/jupyterhub/binderhub/compare/3c21fde...af0d09e
-       
+3. If you haven't already, run the `list_new_commits.py` script in the `scripts/`
+   folder. This will print out a URL that describes the changes made to both
+   BinderHub and repo2docker.
+4. Make a PR to the `master` branch with the changes you want.
+
+    * Name the PR like so: `<TOOL-CHANGED>: <OLD-HASH>...<NEW-HASH>`
+    * In the description of the PR, paste the full URL that you printed out
+      `list_new_commits.py`. It should have the following form:
+
+          https://github.com/jupyterhub/<REPO-NAME>/compare/<OLD-HASH>...<NEW-HASH>
+
 5. Review, accept, and merge this PR. This will make Travis deploy the changes
    to [staging.mybinder.org](https://staging.mybinder.org), and run tests in the `tests/`
    directory against it. **In this case, you can merge your own PR**. Note that if the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,14 @@ Site Reliability Guide for mybinder.org
 Introduction
 ------------
 
+This site is a collection of wisdom, tools, and other helpful information to assist in
+the maintenance and team-processes around the BinderHub deployment at `mybinder.org <https://mybinder.org>`_.
+It's probably only relevant to you if you are an active maintainer of this deployment, though
+feel free to browse this information if you think it is useful!
+
+If you're looking for the Binder docs, `see this link <https://docs.mybinder.org>`_. If you're looking
+for information on deploying your own BinderHub, `see this link <https://binderhub.readthedocs.io>`_.
+
 .. toctree::
    :maxdepth: 2
    :caption: Introduction

--- a/scripts/list_new_commits.py
+++ b/scripts/list_new_commits.py
@@ -5,15 +5,19 @@ print('Fetching the SHA for live BinderHub and repo2docker...')
 
 # Load master requirements
 url_requirements = "https://raw.githubusercontent.com/jupyterhub/mybinder.org-deploy/master/mybinder/requirements.yaml"
-requirements = requests.get(url_requirements)
-requirements = load(requirements.text)
-
+requirements = load(requests.get(url_requirements).text)
 binderhub_dep = [ii for ii in requirements['dependencies'] if ii['name'] == 'binderhub'][0]
 bhub_live = binderhub_dep['version'].split('-')[-1]
+
+url_binderhub_requirements = "https://raw.githubusercontent.com/jupyterhub/binderhub/{}/helm-chart/binderhub/requirements.yaml".format(bhub_live)
+requirements = load(requests.get(url_binderhub_requirements).text)
+jupyterhub_dep = [ii for ii in requirements['dependencies'] if ii['name'] == 'jupyterhub'][0]
+jhub_live = jupyterhub_dep['version'].split('-')[-1]
 
 # Load master repo2docker
 url_helm_chart = "https://raw.githubusercontent.com/jupyterhub/mybinder.org-deploy/master/mybinder/values.yaml"
 helm_chart = requests.get(url_helm_chart)
+helm_chart = load(helm_chart.text)
 r2d_live = helm_chart['binderhub']['config']['BinderHub']['build_image'].split(':')[-1]
 
 print('Fetching latest commit SHA for BinderHub and repo2docker...')
@@ -23,18 +27,22 @@ url = "https://api.github.com/repos/jupyter/repo2docker/commits"
 resp = requests.get(url)
 r2d_master = resp.json()[0]['sha']
 
-# Load latest binderhub commit
-url = "https://api.github.com/repos/jupyterhub/binderhub/commits"
-resp = requests.get(url)
-# Grab the *second to latest* commit since this will be the image SHA
-# The latest commit is the "merge" commit and is excluded.
-bhub_master = resp.json()[1]['sha']
+# Load latest binderhub and jupyterhub commits
+repos = {'jupyterhub': 'zero-to-jupyterhub-k8s', 'binderhub': 'binderhub'}
+latest_hash = {}
+for i_repo, i_url in repos.items():
+    url = "https://api.github.com/repos/jupyterhub/{}/commits".format(i_url)
+    resp = requests.get(url)
+    # Grab the *second to latest* commit since this will be the image SHA
+    # The latest commit is the "merge" commit and is excluded.
+    latest_hash[i_repo] = resp.json()[1]['sha']
 
-url_bhub = 'https://github.com/jupyterhub/binderhub/compare/{}...{}'.format(bhub_live, bhub_master[:7])
+url_bhub = 'https://github.com/jupyterhub/binderhub/compare/{}...{}'.format(bhub_live, latest_hash['binderhub'][:7])
 url_r2d = 'https://github.com/jupyter/repo2docker/compare/{}...{}'.format(r2d_live, r2d_master[:7])
-
+url_jhub = 'https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/{}...{}'.format(jhub_live, latest_hash['jupyterhub'][:7])
 
 print('---------------------\n')
 print('BinderHub: {}'.format(url_bhub))
 print('repo2docker: {}'.format(url_r2d))
+print('JupyterHub: {}'.format(url_jhub))
 print('\n---------------------')


### PR DESCRIPTION
This updates the deploy steps to use the `list_new_commits.py` script. I hope this will reduce the number of steps needed to make a deploy, and also standardize the PR names that we've got. Lemme know what folks think!