### PR TITLE
Upgrade to JupyterHub v0.9b3

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-165bdc4
+   version: 0.1.0-4670b66
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Brings in JupyterHub 0.9b3

This is a BinderHub version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/165bdc4...4670b66
