### PR TITLE
Bump JupyterHub once more

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-4670b66
+   version: 0.1.0-b5000ad
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/4670b66...b5000ad
