### PR TITLE
Update repo2docker a6c001a...42ad233

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -116,7 +116,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:a6c001a
+    repo2dockerImage: jupyter/repo2docker:42ad233
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION


<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/a6c001a...42ad233