### PR TITLE
Pull in repo2docker with R shiny app support

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -116,7 +116,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:42ad233
+    repo2dockerImage: jupyter/repo2docker:d4c9c88
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
This is a  repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/42ad233...d4c9c88
