### PR TITLE
Ban SamLau95/nbinteract-image

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -6,6 +6,7 @@ binderhub:
       c.GitHubRepoProvider.banned_specs = [
         # e.g. '^org/repo.*',
         '^ines/spacy-binder.*',
+        '^SamLau95/nbinteract-image.*',
       ]
   service:
     type: ClusterIP


### PR DESCRIPTION
This bans SamLau95/nbinteract-image as they are using up their 100 slots (and more) if we let them.

