### PR TITLE
[WIP] appendix: trust proxy headers and load config from env

### DIFF
--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -26,3 +26,6 @@ if os.getenv('CULL_INTERVAL'):
 # this is what allows us to shutdown servers when people leave a notebook open and wander off
 if os.getenv('CULL_CONNECTED') not in {'', '0'}:
     c.MappingKernelManager.cull_connected = True
+
+# trust proxy headers
+c.NotebookApp.trust_xheaders = True

--- a/appendix/extra_notebook_config.py
+++ b/appendix/extra_notebook_config.py
@@ -29,3 +29,14 @@ if os.getenv('CULL_CONNECTED') not in {'', '0'}:
 
 # trust proxy headers
 c.NotebookApp.trust_xheaders = True
+
+import sys
+import traceback
+
+for key in sorted(os.environ):
+    if key.startswith("EXTRA_NBCONFIG_"):
+        try:
+            exec(os.envion[key])
+        except Exception as e:
+            print("Error loading config from env %s: %s" % (key, os.envion[key]))
+            traceback.print_exception(*sys.exc_info())

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -12,7 +12,7 @@ binderhub:
       memory: 2Gi
 
   registry:
-    prefix: gcr.io/binder-prod/r2d-05168b0-
+    prefix: gcr.io/binder-prod/r2d-d4c9c88-
 
   hub:
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/r2d-05168b0-
+    prefix: gcr.io/binder-staging/r2d-d4c9c88-
 
   hub:
     url: https://hub.staging.mybinder.org


### PR DESCRIPTION
since the appendix goes in the image, any change to notebook config must be paired with a bump to our image prefix to force rebuilds. This adds support for notebook config in `EXTRA_NBCONFIG_` environment variables, so that we can change config for new launches of existing images by setting environment variables.