### PR TITLE
binderhub chart a072a12...856e3e6

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-a072a12
+   version: 0.1.0-856e3e6
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
apply trust_xheaders to single-user servers

This is a binderhub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/a072a12...856e3e6