### PR TITLE
Lower the guaranteed memory and upper limit on CPU

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -21,11 +21,11 @@ binderhub:
   jupyterhub:
     singleuser:
       memory:
-        guarantee: 2G
+        guarantee: 1G
         limit: 2G
       cpu:
         guarantee: 0.1
-        limit: 2
+        limit: 1
     hub:
       resources:
         requests:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -16,7 +16,7 @@ binderhub:
         limit: 256M
       cpu:
         guarantee: 0.1
-        limit: 1
+        limit: 0.5
     ingress:
       hosts:
         - hub.staging.mybinder.org


### PR DESCRIPTION
From looking at typical usage pattern most pods use O(100MB) of memory
and hardly any CPU. This is an attempt to allow us to pack our nodes
more tightly.

To look at usage of pods run `kubectl top pods | grep jupyter-`