### PR TITLE
Enable Prometheus metrics in nginx-ingress controller

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -152,6 +152,8 @@ nginx-ingress:
       proxy-body-size: 64m
     stats:
       enabled: true
+    metrics:
+      enabled: true
     service:
       # Preserve client IPs
       externalTrafficPolicy: Local


### PR DESCRIPTION
Fix #634 