### PR TITLE
Redirect status.mybinder.org to the docs

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -138,3 +138,7 @@ redirector:
       host:
         from: playground.mybinder.org
         to: play.nteract.io
+    - type: host
+      host:
+        from: status.mybinder.org
+        to: mybinder.readthedocs.io/en/latest/status.html


### PR DESCRIPTION
This adds a redirect rule for status.mybinder.org to go to https://mybinder.readthedocs.io/en/latest/status.html
