### PR TITLE
ensure pip packages are up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache: pip
 install:
   - |
     # Stage 1: Install pytest + test dependencies
-    pip install pyyaml pytest pytest-timeout pytest-xdist requests
+    pip install --upgrade setuptools pip
+    pip install --upgrade pyyaml pytest pytest-timeout pytest-xdist requests
 
 script:
  - true


### PR DESCRIPTION
latest deploy failed due to an apparent version conflict due to upgrading one package (pytest-timeout) but not another (pytest)