### PR TITLE
Update singleuser_extra_pod_config to extra_pod_config

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -73,7 +73,7 @@ binderhub:
         cors: *cors
       extraConfig:
         neverRestart: |
-          c.KubeSpawner.singleuser_extra_pod_config.update({'restartPolicy': 'Never'})
+          c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
     proxy:
       service:
         type: ClusterIP


### PR DESCRIPTION
This updates our extra config snippet.

I am not sure why we need this at all and the proper fix is to [change this line](https://github.com/jupyterhub/kubespawner/blob/7ae99005409cb75684a0a1ec792dba4adcb4b4f2/kubespawner/objects.py#L160) in kubespawner directly. At least in my local tests setting `restartPolicy` does not influence the value of `restart_policy` in the string that `spec.to_str()` generates, but there is also no error when you set a incorrect property (seems like a bug in `kubernetes`).

A further mystery is that the values from `extra_pod_config` are put through [an attribute map](https://github.com/jupyterhub/kubespawner/blob/7ae99005409cb75684a0a1ec792dba4adcb4b4f2/kubespawner/objects.py#L245) so there it should work with the wrong name. But evidently doesn't, my hypothesis is that something with the deprecation of the old name of `singleuser_extra_pod_config` doesn't work properly.

Going to deploy this to see if it fixes up our current deployment, then consider a PR to kubespawner, and then discussion on why we have this extra config snippet in the first place.