### PR TITLE
Bring in the new UI that allows other repo providers to be selected

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-8ebaf89
+   version: 0.1.0-ece47e4
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION

This is a BinderHub version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/8ebaf89...ece47e4
