### PR TITLE
add nodeSelectors for prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,11 +1,19 @@
+userNodeSelector: &userNodeSelector
+  cloud.google.com/gke-nodepool: hm16
+coreNodeSelector: &coreNodeSelector
+  cloud.google.com/gke-nodepool: core-pool
+
 binderhub:
+  build:
+    nodeSelector: *userNodeSelector
+  nodeSelector: *coreNodeSelector
   ingress:
     hosts:
       - mybinder.org
 
   resources:
     requests:
-      cpu: "2"
+      cpu: "0.25"
       memory: 2Gi
     limits:
       cpu: "2"
@@ -20,6 +28,7 @@ binderhub:
 
   jupyterhub:
     singleuser:
+      nodeSelector: *userNodeSelector
       memory:
         guarantee: 1G
         limit: 2G
@@ -27,20 +36,22 @@ binderhub:
         guarantee: 0.1
         limit: 1
     hub:
+      nodeSelector: *coreNodeSelector
       resources:
         requests:
-          cpu: "2"
+          cpu: "0.25"
           memory: 2Gi
         limits:
           cpu: "2"
           memory: 2Gi
 
     proxy:
+      nodeSelector: *coreNodeSelector
       chp:
         resources:
           requests:
             memory: 512Mi
-            cpu: "0.5"
+            cpu: "0.25"
           limits:
             memory: 512Mi
             cpu: "0.5"
@@ -48,7 +59,7 @@ binderhub:
         resources:
           requests:
             memory: 3Gi
-            cpu: 1
+            cpu: "0.25"
           limits:
             memory: 3Gi
             cpu: 1
@@ -64,6 +75,7 @@ binderhub:
   googleAnalyticsDomain: "mybinder.org"
 
 grafana:
+  nodeSelector: *coreNodeSelector
   resources:
     requests:
       cpu: "0.2"
@@ -90,12 +102,15 @@ grafana:
           isDefault: true
           editable: false
 
+kube-lego:
+  nodeSelector: *coreNodeSelector
 
 prometheus:
+  nodeSelector: *coreNodeSelector
   server:
     resources:
       requests:
-        cpu: "4"
+        cpu: "2"
         memory: 16Gi
       limits:
         cpu: "4"
@@ -114,6 +129,7 @@ prometheus:
           secretName: kubelego-tls-prometheus
 
 nginx-ingress:
+  nodeSelector: *coreNodeSelector
   controller:
     service:
       loadBalancerIP: 35.202.202.188
@@ -124,7 +140,11 @@ static:
     hosts:
       - static.mybinder.org
 
+proxy-patches:
+  nodeSelector: *coreNodeSelector
+
 redirector:
+  nodeSelector: *coreNodeSelector
   redirects:
     - type: host
       host:

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-fd778a3
+   version: 0.1.0-331ab96
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      nodeSelector: {{ toJson .Values.proxyPatches.nodeSelector }}
       volumes:
         - name: nginx-config
           configMap:

--- a/mybinder/templates/redirector/deployment.yaml
+++ b/mybinder/templates/redirector/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: redirector
         component: nginx
     spec:
+      nodeSelector: {{ toJson .Values.redirector.nodeSelector }}
       volumes:
         - name: config
           configMap:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -163,6 +163,10 @@ nginx-ingress:
       # Preserve client IPs
       externalTrafficPolicy: Local
 
+redirector:
+  nodeSelector: {}
+  redirects: []
+
 static:
   paths:
     - /badge.svg
@@ -213,6 +217,7 @@ prometheus:
         kubernetes.io/tls-acme: "true"
 
 proxyPatches:
+  nodeSelector: {}
   enabled: true
   interval: 60
   routes:


### PR DESCRIPTION
separates user pods from 'core' pods

core pods run on a new single-node n4-highmem (for now) pool
user pods run on the existing pool

Updates https://github.com/jupyterhub/binderhub/compare/fd778a3...331ab96

to avoid a dind pod running on the core node(s)