### PR TITLE
fix prometheus nodeSelector

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -106,8 +106,8 @@ kube-lego:
   nodeSelector: *coreNodeSelector
 
 prometheus:
-  nodeSelector: *coreNodeSelector
   server:
+    nodeSelector: *coreNodeSelector
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
it goes in prometheus.server, not prometheus


<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a <BinderHub / repo2docker> version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/<REPO-NAME>/compare/<OLD-HASH>...<NEW-HASH>