### PR TITLE
allow nginx-ingress default backend to be disrupted

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -140,6 +140,8 @@ playground:
 nginx-ingress:
   rbac:
     create: true
+  defaultBackend:
+    minAvailable: 0
   statsExporter:
     service:
       annotations:


### PR DESCRIPTION
since it’s only there to serve error pages, allow it to be disrupted and sent to other nodes

prevents nginx-ingress-backend pod from preventing node reclamation