### PR TITLE
Switch to using a label to select node pool

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,5 +1,5 @@
 userNodeSelector: &userNodeSelector
-  cloud.google.com/gke-nodepool: temp-hm16
+  mybinder.org/pool-type: users
 coreNodeSelector: &coreNodeSelector
   cloud.google.com/gke-nodepool: core-pool
 


### PR DESCRIPTION
This uses a label that is applied to a node pool to select where to run
the user pods. This means we can add several node pools that all have
the same label. Useful for transitioning from one pool to another or
when we want to have more than one pool for some reason.

This should be a no-op as we are already selecting this pool.