### PR TITLE
Ban jupyterlab/jupyterlab-demo to reduce load

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -7,6 +7,7 @@ binderhub:
         # e.g. '^org/repo.*',
         '^ines/spacy-binder.*',
         '^SamLau95/nbinteract-image.*',
+        '^jupyterlab/jupyterlab-demo.*',
       ]
   service:
     type: ClusterIP


### PR DESCRIPTION
It appears there is a problem with building this repository so banning
it and debugging build from a fork.

Last change to the repo: https://github.com/jupyterlab/jupyterlab-demo/pull/73/files