### PR TITLE
incident (jlab build takes over, 30 July 2018) and docs update

### DIFF
--- a/docs/source/command_snippets.md
+++ b/docs/source/command_snippets.md
@@ -323,30 +323,6 @@ of the older node). Here's the process for recycling nodes.
 
 ## Networking
 
-### Manually confirm network between pods is working
-
-To confirm that binderhub can talk to jupyterhub, to the internet in general, or
-you want to confirm for yourself that there is no connectivity problem between
-pods follow this recipe.
-
-1. connect to the pod you want to use as "source", for example the jupyterhub
-pod: `kubectl --namespace=prod exec -it hub-989cc9bd-bbkbk /bin/bash`
-1. start `python3`, `import requests`
-1. use `requests.get(host)` to check connectivity. Some interesting hostnames
-to try talking to are:
-    * http://binder/, the binderhub service
-    * http://hub:8081/hub/api, the jupyterhub API
-    * http://proxy-public/hub/api, the CHP route that redirects you to the
-      jupyterhub API (content of the response should be equal)
-    * http://google.com/, the internet
-    * the CHP API needs a token so run: `headers={'Authorization': 'token ' + os.environ['CONFIGPROXY_AUTH_TOKEN']}`
-      and then`requests.get('http://proxy-api:8001/api/routes', headers=headers)`
-
-To find out hostnames to try look at the `metadata.name` field of a kubernetes
-service in the helm chart. You should be able to connect to each of them using
-the name as the hostname. Take care to use the right port, not all of them are
-listening on 80.
-
 ### Banning traffic
 
 Sometimes there's bad traffic, either malicious or accidental,

--- a/docs/source/common_problems.md
+++ b/docs/source/common_problems.md
@@ -40,3 +40,74 @@ Build pods will not be working, and the `dind` pods are stuck in `CrashLoopBacko
 4. Delete the `dind` pod (k8s will automatically create a new one)
 
        kubectl --namespace=<ns> delete pod <dind-pod-name>
+
+## Networking Errors
+
+Sometimes there are networking errors between pods, or between one pod and
+all other pods. This section covers how to debug and correct for networking
+on the Kubernetes deployment.
+
+### Manually confirm network between pods is working
+
+To confirm that binderhub can talk to jupyterhub, to the internet in general, or
+you want to confirm for yourself that there is no connectivity problem between
+pods follow this recipe.
+
+1. connect to the pod you want to use as "source", for example the jupyterhub
+pod: `kubectl --namespace=prod exec -it hub-989cc9bd-bbkbk /bin/bash`
+1. start `python3`, `import requests`
+1. use `requests.get(host)` to check connectivity. Some interesting hostnames
+   to try talking to are:
+    * http://binder/, the binderhub service
+    * http://hub:8081/hub/api, the jupyterhub API
+    * http://proxy-public/hub/api, the CHP route that redirects you to the
+      jupyterhub API (content of the response should be equal)
+    * http://google.com/, the internet
+    * the CHP API needs a token so run: `headers={'Authorization': 'token ' + os.environ['CONFIGPROXY_AUTH_TOKEN']}`
+      and then`requests.get('http://proxy-api:8001/api/routes', headers=headers)`
+    * Other hostnames within the Kubernetes deployment. To find out hostnames
+      to try look at the `metadata.name` field of a kubernetes
+      service in the helm chart. You should be able to connect to each of them using
+      the name as the hostname. Take care to use the right port, not all of them are
+      listening on 80.
+
+Here's a code snippet to try all of the above in quick succession:
+
+```python
+import requests
+import os
+urls = ["binder/", "hub:8081/hub/api", "proxy-public/hub/api", "google.com/"]
+for url in urls:
+    resp = requests.get("http://" + url)
+    print('{}: {}'.format(url, resp))
+```
+
+### Spikes in traffic
+
+Spikes in traffic can cause congestion, slowness, or surface bugs in the
+deployment. Here are some ways to detect spikes.
+
+#### Spikes to `mybinder.org`
+
+Spikes to `mybinder.org` are most-easily detected by going to the project's
+Google Analytics page. Look at the "real-time" page and see if there is a big
+shift from typical patterns of behavior.
+
+#### Spikes to the `/build` API
+
+Sometimes there are spikes to the BinderHub build API, which we cannot capture
+with Google Analytics. Spikes to the build API usually come from a single
+repository, and can be found with the following command.
+
+To list the API requests to `/build`:
+
+```python
+kubectl --namespace=prod logs -l component=controller | grep '/build'
+```
+
+and to list the number of API requests to `/build` that contain a particular
+word:
+
+```python
+kubectl --namespace=prod logs -l component=controller | grep '/build' | grep <word-name> | wc -l
+```

--- a/docs/source/incident-reports/2018-07-30-jupyterlab-build-cpu-saturate.md
+++ b/docs/source/incident-reports/2018-07-30-jupyterlab-build-cpu-saturate.md
@@ -49,7 +49,6 @@ This is the utilization behavior seen:
 
 Behavior is once again going wrong. Launches taking forever to load. We note
 a lot of networky-looking problems in the logs.
-Noted lots of
 
 ### 13:41
 

--- a/docs/source/incident-reports/2018-07-30-jupyterlab-build-cpu-saturate.md
+++ b/docs/source/incident-reports/2018-07-30-jupyterlab-build-cpu-saturate.md
@@ -1,0 +1,123 @@
+# 2018-07-30 JupyterLab builds saturate BinderHub CPU
+
+## Summary
+
+Binder wasn't properly building pods and launches weren't working. It was
+decided that:
+
+1. The `jupyterlab-demo` repo updated itself, triggering a build
+1. The update to `jupyterlab-demo` installed a newer version of JupyterLab
+1. `repo2docker` needed a loooong time installing this (perhaps because of webpack size issues)
+1. Since the repository gets a lot of traffic, each request to launch while
+   the build is still happening eats up CPU in the Binder pod
+1. The Binder pod was thus getting saturated and behaving strangely, causing
+   the outage
+1. Banning the `jupyterlab-demo` repository resolved the CPU saturation issue.
+
+## Timeline
+
+All times in PST (UTC-7)
+
+### 2018-07-30 ca. 11:20
+
+[Gitter Link](https://gitter.im/jupyterhub/binder?at=5b5f56df12f1be7137683cbc)
+
+We notice that launches are not happening as expected. Cluster utilization is very low,
+suggesting that pods aren't being created.
+
+### 11:22
+
+* Notice an SSL protocol error:
+
+  ```
+  tornado.curl_httpclient.CurlError: HTTP 599: Unknown SSL protocol error in connection to gcr.io:443
+  ```
+
+* Binder pod is deleted and launches return to normal.
+
+### 12:19
+
+* Launches aren't working again, taking a very long time to start up
+* Deleted binder and hub pods
+* This resolved the issue a second time.
+
+This is the utilization behavior seen:
+
+![](https://files.gitter.im/jupyterhub/binder/3cSB/thumb/image.png)
+
+### 13:29
+
+Behavior is once again going wrong. Launches taking forever to load. We note
+a lot of networky-looking problems in the logs.
+Noted lots of
+
+### 13:41
+
+Deleted several evicted pods. Pods are often evicted because of low resources
+available and `kubelet` evicts in order to free up resources for more important
+services.
+
+### 14:01
+
+Confirm that networking seems to be find between production pods.
+
+[Gitter link](https://gitter.im/jupyterhub/binder?at=5b5f7caecb4d5b036ca97bd9)
+
+### 14:16
+
+Note that the CPU utilization of the BinderHub pod is at 100%. If we restart
+Binder pod, the new one gradually increases CPU utilization until it hits
+100%, then problems begin.
+
+This explains the short-term fixes of deleting the `binder` pod from before.
+
+### 14:45
+
+We realize that the `jupyterlab-demo` repository has been updated and has
+a lot of traffic. This seems to be causing strange behavior because it is
+still building.
+
+[Gitter link](https://gitter.im/jupyterhub/binder?at=5b5f86b33e264c713850cb5c)
+
+### 15:11
+
+`jupyterlab-demo` repository is banned, and behavior subsequently returns to
+normal.
+
+Post-mortem suggests this is the problem:
+
+1. The `jupyterlab-demo` repo updated itself, triggering a build
+1. The update to `jupyterlab-demo` installed a newer version of JupyterLab
+1. `repo2docker` needed a loooong time installing this (perhaps because of webpack size issues)
+1. Since the repository gets a lot of traffic, each request to launch while
+   the build is still happening eats up CPU in the Binder pod
+1. The Binder pod was thus getting saturated and behaving strangely, causing
+   the outage
+1. Banning the `jupyterlab-demo` repository resolved the CPU saturation issue.
+
+## Lessons learned
+
+### What went well
+
+- the binder team did a great job of distributed debugging and got this fixed
+  relatively quickly once the error was spotted!
+
+### What went wrong
+
+- It took a while before we realized launch behavior was going wonky. We really
+  could use a notifier for the team :-/
+
+## Action items
+
+These are only sample subheadings. Every action item should have a GitHub issue
+(even a small skeleton of one) attached to it, so these do not get forgotten.
+
+### Process improvements
+
+1. set up notifications of downtime ([issue](https://github.com/jupyterhub/mybinder.org-deploy/issues/611))
+
+### Technical improvements
+
+1. Find a way to gracefully handle repositories that take a long time to build (https://github.com/jupyterhub/binderhub/issues/624)
+1. Find a way to avoid overloading the Binder CPU when a repository is building
+   and also getting a lot of traffic at the same time. (https://github.com/jupyterhub/binderhub/issues/624)

--- a/docs/source/incident_reporting.rst
+++ b/docs/source/incident_reporting.rst
@@ -26,6 +26,7 @@ Incident history
    :maxdepth: 1
    :caption: Incidents
 
+   incident-reports/2018-07-30-jupyterlab-build-cpu-saturate.md
    incident-reports/2018-07-08-podsnips-aplenty.md
    incident-reports/2018-04-18-cull-flood.md
    incident-reports/2018-03-31-server-start-fail.md


### PR DESCRIPTION
an incident report for a recent outage where jupyterlab-demo builds were taking a long time and eating up all the binderhub CPU