### PR TITLE
unban jlab demo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -7,7 +7,6 @@ binderhub:
         # e.g. '^org/repo.*',
         '^ines/spacy-binder.*',
         '^SamLau95/nbinteract-image.*',
-        '^jupyterlab/jupyterlab-demo.*',
       ]
   service:
     type: ClusterIP


### PR DESCRIPTION
This unbans the jupyterlab demo repository.

I'm a bit confused about banning now, since it seems that the `spacy` binder is also banned, but AFAIK that website still works. @minrk do you know what's up?