### PR TITLE
Revert "Update BinderHub chart"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-5d0cedb
+   version: 0.1.0-331ab96
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#682

"Invalid Binderhub version" during deploy. Typo?