### PR TITLE
Update Binderhub to revision 4635c23

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-331ab96
+   version: 0.1.0-4635c23
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Follow up #683  and #682 

This is a BinderHub  version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/331ab96...4635c23

The problem with the previous PR was that I took the new revision number from `scripts/list_new_commits.py` but not every commit to BinderHub results in a new helm chart revision.