### PR TITLE
Update repo2docker and bump r2d prefix

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -20,7 +20,7 @@ binderhub:
       memory: 2Gi
 
   registry:
-    prefix: gcr.io/binder-prod/r2d-05168b0-
+    prefix: gcr.io/binder-prod/r2d-aee37be-
 
   hub:
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
       - staging.mybinder.org
 
   registry:
-    prefix: gcr.io/binder-staging/r2d-05168b0-
+    prefix: gcr.io/binder-staging/r2d-aee37be-
 
   hub:
     url: https://hub.staging.mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -118,7 +118,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:d4c9c88
+    repo2dockerImage: jupyter/repo2docker:aee37be
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
This is a  repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/d4c9c88...aee37be
