### PR TITLE
Bring in updated binderhub chart

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-4635c23
+   version: 0.1.0-5b7685a
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Details of the changes are in https://github.com/jupyterhub/binderhub/pull/634

The innovation  to look forward to is the auto restarting of the hub.