### PR TITLE
Revert "Ban SamLau95/nbinteract-image"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -6,7 +6,6 @@ binderhub:
       c.GitHubRepoProvider.banned_specs = [
         # e.g. '^org/repo.*',
         '^ines/spacy-binder.*',
-        '^SamLau95/nbinteract-image.*',
       ]
   service:
     type: ClusterIP


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#624

This un-bands the nbinteract-image repository, which should now be updated to avoid the runaway binder requests problem we had before.

## How to know if there is still a problem

If we notice any of the following things, we should probably re-ban nbinteract:

1. Lots of `/build` hits from the nbinteract repo (use something like `kubectl logs -f prod-nginx-ingress-controller-7b4fdbdcc8-6rf58 nginx-ingress-controller | grep "GET /build/gh/SamLau95/nbinteract-image"`) 
2. nbinteract relatively quickly uses up its full 100 pod allotment.

Note that it may take some time for this bug to surface, since it requires a particular pattern of behavior for the user that I'm not sure how to replicate.

cc @samlau95 and @betatim 