### PR TITLE
update core pool nodeSelector

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,7 +1,7 @@
 userNodeSelector: &userNodeSelector
   mybinder.org/pool-type: users
 coreNodeSelector: &coreNodeSelector
-  cloud.google.com/gke-nodepool: core-pool
+  mybinder.org/pool-type: core
 
 binderhub:
   build:


### PR DESCRIPTION
to match user pool selector in #677

Deployed new core pool with this label, and will finish #675 once this lands, since the nodeSelector update step added there is no longer needed.