### PR TITLE
bump binderhub 5b7685a...5f82a56

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-5b7685a
+   version: 0.1.0-5f82a56
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -117,7 +117,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:d2f7ebd
+    repo2dockerImage: jupyter/repo2docker:dce3042
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
should fix accumulating completed builds

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/5b7685a...5f82a56

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/d2f7ebd...dce3042