### PR TITLE
reduce user cpu request to ~0

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -33,7 +33,7 @@ binderhub:
         guarantee: 512M
         limit: 2G
       cpu:
-        guarantee: 0.1
+        guarantee: 0.01
         limit: 1
     hub:
       nodeSelector: *coreNodeSelector


### PR DESCRIPTION
with our smaller nodes, the 0.1 cpu request is triggering the autoscaler because 0.1 * 80 = 8 cpus, all we have on a node, so it's cpu requests that are triggering autoscaling.