### PR TITLE
further lower pod memory request to 450M

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -30,7 +30,7 @@ binderhub:
     singleuser:
       nodeSelector: *userNodeSelector
       memory:
-        guarantee: 512M
+        guarantee: 450M
         limit: 2G
       cpu:
         guarantee: 0.01


### PR DESCRIPTION
should get 100 users on a node instead of current 88

allocatable memory on highmem-8: 48537252Ki == 46.2GB

To fit 100 users on a node, each request must be < 460M

[this chart](https://grafana.mybinder.org/d/nDQPwi7mk/node-activity?refresh=1m&panelId=7&fullscreen&orgId=1&from=now-7d&to=now) shows that we have never used more than ~20GB of memory on a user node with the ~100 users we've been running on the highmem-16 nodes.