### PR TITLE
enable networkpolicies

### DIFF
--- a/mybinder/templates/netpol.yaml
+++ b/mybinder/templates/netpol.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.binderhub.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: binder-users
+  labels:
+    app: binderhub
+    component: user-netpol
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    # apply this to both places user code runs: dind and singleuser-server
+    matchExpressions:
+      - key: component
+        operator: In
+        values:
+          - singleuser-server
+          - dind
+    matchLabels:
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  # block ingress unless explicitly allowed by other policies
+  ingress: []
+  egress:
+    # allow DNS resolution in the cluster
+    # it would be nicer to be able to pin this to only the kube-dns service,
+    # but we can only seem to select *pods* not *services* as the destination
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+    # allow access to the world,
+    # but not the cluster
+    - ports:
+        {{ range $port := .Values.binderhub.networkPolicy.egress.tcpPorts }}
+        - port: {{ $port }}
+          protocol: TCP
+        {{ end }}
+      to:
+      - ipBlock:
+          cidr: {{ .Values.binderhub.networkPolicy.egress.cidr }}
+          except:
+            - 169.254.169.254/32
+            - 10.0.0.0/8
+{{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,4 +1,14 @@
 binderhub:
+  networkPolicy:
+    enabled: true
+    egress:
+      tcpPorts:
+        - 80 # http
+        - 443 # https
+        - 9418 # git
+        - 873 # rsync
+        - 1094 # xroot
+      cidr: 0.0.0.0/0
   extraConfig:
     # Add banned repositories to the list below
     # They should be strings that will match "^<org-name>/<repo-name>.*"
@@ -69,12 +79,16 @@ binderhub:
       # maxAge is 6 hours: 6 * 3600 = 21600
       maxAge: 21600
     hub:
+      networkPolicy:
+        enabled: true
       extraConfigMap:
         cors: *cors
       extraConfig:
         neverRestart: |
           c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
     proxy:
+      networkPolicy:
+        enabled: true
       service:
         type: ClusterIP
       chp:
@@ -94,6 +108,10 @@ binderhub:
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
     singleuser:
+      networkPolicy:
+        enabled: true
+        egress: []
+
       initContainers:
       - name: tc-init
         image: minrk/tc-init:0.0.4


### PR DESCRIPTION
hub chart has network policies for limiting network access to/from pods on a more fine-grained level. This enables those policies.

apply network policies to both dind and user pods (this is why it's not in singleuser.networkPolicy.egress)

- disables user access to cluster net
- should eliminate the need for the ports part of our firewall script, causing egress to be updated on deploy, rather than separately