### PR TITLE
pin prometheus down to 2 cpus

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -113,7 +113,7 @@ prometheus:
         cpu: "2"
         memory: 16Gi
       limits:
-        cpu: "4"
+        cpu: "2"
         memory: 16Gi
     persistentVolume:
       # Use a large SSD Volume in production


### PR DESCRIPTION
since it’s running on a 4 core node and seems to be running at full tilt all the time