### PR TITLE
update binderhub chart 6e8f9dc...2801aaf

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-6e8f9dc
+   version: 0.1.0-2801aaf
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
gets user scheduler from the hub chart
This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/6e8f9dc...2801aaf