### PR TITLE
proxy-patches needs access to the proxy

### DIFF
--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: proxy-patches
     component: proxy-patches
+    hub.jupyter.org/network-access-hub: "true"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 


### PR DESCRIPTION
This is required now that we've enabled the network policy.