### PR TITLE
add pdbs for the pods that don't have them

### DIFF
--- a/mybinder/templates/pdb-grafana.yaml
+++ b/mybinder/templates/pdb-grafana.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: grafana
+      release: {{ .Release.Name }}

--- a/mybinder/templates/pdb-kube-lego.yaml
+++ b/mybinder/templates/pdb-kube-lego.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-lego
+  labels:
+    app: kube-lego
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: kube-lego
+      release: {{ .Release.Name }}

--- a/mybinder/templates/pdb-prometheus.yaml
+++ b/mybinder/templates/pdb-prometheus.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+    component: server
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: prometheus
+      component: server
+      release: {{ .Release.Name }}

--- a/mybinder/templates/proxy-patches/pdb.yaml
+++ b/mybinder/templates/proxy-patches/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.proxyPatches.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: proxy-patches
+  labels:
+    app: proxy-patches
+    component: proxy-patches
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: proxy-patches
+      release: {{ .Release.Name }}
+{{- end }}

--- a/mybinder/templates/redirector/deployment.yaml
+++ b/mybinder/templates/redirector/deployment.yaml
@@ -7,6 +7,8 @@ spec:
     matchLabels:
       app: redirector
       component: nginx
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
   replicas: 1
   template:
     metadata:
@@ -15,6 +17,8 @@ spec:
       labels:
         app: redirector
         component: nginx
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
     spec:
       nodeSelector: {{ toJson .Values.redirector.nodeSelector }}
       volumes:

--- a/mybinder/templates/redirector/pdb.yaml
+++ b/mybinder/templates/redirector/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: redirector
+  labels:
+    app: redirector
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: redirector
+      release: {{ .Release.Name }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,4 +1,9 @@
 binderhub:
+
+  replicas: 2
+  pdb:
+    minAvailable: 1
+
   networkPolicy:
     enabled: true
     egress:


### PR DESCRIPTION
Bumps binderhub replicas to 2 and adds/enables pdbs to most pods.

This should make it easier for certain services to get disrupted in order to facillitate things like scale-down. Services with replicas (e.g. binderhub, nginx-ingress) should be able to migrate off of nodes for scale-down without disruption.