### PR TITLE
bump binderhub chart ad582a5...e539e64

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-ad582a5
+   version: 0.1.0-e539e64
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
adds pdb, replica support to binderhub pod

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/ad582a5...e539e64