### PR TITLE
bump binderhub e539e64...13b65e2

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-e539e64
+   version: 0.1.0-13b65e2
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
fixes typo in binderhub pdb

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/e539e64...13b65e2