### PR TITLE
re-enable image cleaner

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -69,7 +69,7 @@ binderhub:
             - NET_ADMIN
 
   imageCleaner:
-    enabled: false
+    enabled: true
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80


### PR DESCRIPTION
now that we have long-running nodes again, images are piling up in dind and we need to clean them out