### PR TITLE
Revert "re-enable image cleaner"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -69,7 +69,7 @@ binderhub:
             - NET_ADMIN
 
   imageCleaner:
-    enabled: true
+    enabled: false
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#720

when the imageCleaner activated, it seemed to make mybinder.org unavailable. This doesn't really make sense that cordoning a node with the ingress-controller pod would make the cluster unavailable, but this seems to be a reliable occurrence (first observed by @betatim, I think).

Disabling for now, as disk space hasn't been causing us significant issues.