### PR TITLE
bump binderhub chart 13b65e2...b0ac9a8

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-13b65e2
+   version: 0.1.0-b0ac9a8
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
gets some urlpath/filepath edge case fixes

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/13b65e2...b0ac9a8