### PR TITLE
Use initcontainers + rw volume for matomo config

### DIFF
--- a/mybinder/templates/matomo/deployment.yaml
+++ b/mybinder/templates/matomo/deployment.yaml
@@ -27,26 +27,27 @@ spec:
       - name: matomo-config
         configMap:
           name: matomo-config
-      containers:
-      - name: piwik
-        image: matomo:3.5.1-apache
-        lifecycle:
-          # matomo wants to chown its config.ini.php file.
-          # configmaps are mounted as readonly, so this doesn't work
-          # postStart copies our config file into default path, so matomo will start.
-          # This should ideally be using emptyDir + initContainer, since postStart ordering
-          # is not guaranteed. However, there are other config files in /var/www/html/config that
-          # we do not really wanna overwrite.
-          postStart:
-            exec:
-              command:
-                # use /bin/sh so we can glob
-                - /bin/sh
-                - -c
-                - cp /etc/matomo-config/* /var/www/html/config/
+      - name: matomo-config-rw
+        emptyDir: {}
+      initContainers:
+      - name: matomo-config-cp
+        image: alpine:3.6
+        command:
+          - /bin/sh
+        args:
+          - -c
+          - cp /etc/matomo-config/* /etc/matomo-config-rw/
         volumeMounts:
           - name: matomo-config
             mountPath: /etc/matomo-config
+          - name: matomo-config-rw
+            mountPath: /etc/matomo-config-rw
+      containers:
+      - name: piwik
+        image: matomo:3.5.1-fpm
+        volumeMounts:
+          - name: matomo-config-rw
+            mountPath: /var/www/html/config/
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.11
         command:


### PR DESCRIPTION
This is the 'right way' to copy config files into a directory
in kubernetes. Every other way is broken and deprecated.

- postStart lifecycle is too non-deterministic to work
- matomo itself requires chownability of config.php.ini

Ref #712 