### PR TITLE
Deploy binderhub with trailing slash fix

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-b0ac9a8
+   version: 0.1.0-3fbbd73
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/b0ac9a8...3fbbd73

* switch image cleaner to use inodes or disk space https://github.com/jupyterhub/binderhub/pull/664
* fix trailing slash handling