### PR TITLE
Allow enabling / disabling matomo with a flag

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -82,6 +82,7 @@ redirector:
         to: play.nteract.io
 
 matomo:
+  enabled: true
   db:
     instanceName: binder-staging:us-central1:matomo
   trustedHosts:

--- a/mybinder/templates/matomo/configmap.yaml
+++ b/mybinder/templates/matomo/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -88,3 +89,4 @@ data:
     PluginsInstalled[] = "ProfessionalServices"
     PluginsInstalled[] = "UserId"
     PluginsInstalled[] = "CustomPiwikJs"
+{{- end }}

--- a/mybinder/templates/matomo/deployment.yaml
+++ b/mybinder/templates/matomo/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,3 +75,4 @@ spec:
           - name: cloudsql-instance-credentials
             mountPath: /secrets/cloudsql
             readOnly: true
+{{- end }}

--- a/mybinder/templates/matomo/ingress.yaml
+++ b/mybinder/templates/matomo/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -26,3 +27,4 @@ spec:
       {{ range $host := .Values.matomo.ingress.hosts }}
       - {{ $host }}
       {{- end }}
+{{- end }}

--- a/mybinder/templates/matomo/netpol.yaml
+++ b/mybinder/templates/matomo/netpol.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -45,3 +46,4 @@ spec:
             # Ideally, we should only allow outgoing connections to
             # CloudSQL & Google's OAuth servers.
             cidr: 0.0.0.0/0
+{{- end }}

--- a/mybinder/templates/matomo/pdb.yaml
+++ b/mybinder/templates/matomo/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -14,3 +15,4 @@ spec:
       app: matomo
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
+{{- end }}

--- a/mybinder/templates/matomo/service.yaml
+++ b/mybinder/templates/matomo/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.matomo.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     - name: matomo
       protocol: TCP
       port: 9000
+{{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -257,6 +257,7 @@ proxyPatches:
     "/user": "service:proxy-patches"
 
 matomo:
+  enabled: true
   replicas: 1
   service:
     type: ClusterIP


### PR DESCRIPTION
Ref #725 

Followup #734, which fails because we don't setup the configmap properly.