### PR TITLE
Add Cloud Firewall Rules for Matomo

### DIFF
--- a/docs/source/components/matomo.rst
+++ b/docs/source/components/matomo.rst
@@ -57,3 +57,25 @@ Admin access
 
 The admin username for Matomo is ``admin``. You can find the password in
 ``secret/staging.yaml`` for staging & ``secret/prod.yaml`` for prod.
+
+Security
+========
+
+PHP code is notoriously hard to secure. Matomo has had security audits,
+so it's not the worst. However, we should treat it with suspicion &
+wall off as much of it away as possible. Arbitrary code execution
+vulnerabilities often happen in PHP, so we gotta use that as our
+security model.
+
+We currently have:
+
+1. A firewall hole (in Google Cloud) allowing it access to the CloudSQL
+   instance it needs to store data in. Only port 3307 (which is used by
+   the OAuth2+ServiceAccount authenticated CloudSQLProxy) is open. This
+   helps prevent random MySQL password grabbers from inside the cluster.
+2. A Kubernetes NetworkPolicy is in place that limits what outbound
+   connections Matomo can make. This should be further tightened down -
+   ingress should only be allowed on the nginx port from our ingress
+   controllers.
+3. We do not mount a Kubernetes ServiceAccount in the Matomo pod. This
+   denies it access to the KubernetesAPI.

--- a/scripts/firewall-rules
+++ b/scripts/firewall-rules
@@ -22,6 +22,13 @@ import sys
 # CIDR for the whole world
 WORLD_CIDR = '0.0.0.0/0'
 
+# CloudSQL instances for staging & prod
+# FIXME: Find a way to use network tags instead of IPs
+MATOMO_SQL_IPS = {
+    'staging': '104.198.150.158/32',
+    'prod': '35.226.234.102/32'
+}
+
 # location of secrets directory (where ban.py lives)
 here = os.path.dirname(os.path.abspath(__file__))
 secrets = os.path.join(os.path.dirname(here), "secrets")
@@ -199,6 +206,23 @@ def main(cluster, replace=False):
         },
         rules,
         replace=replace,
+    )
+
+    # whitelist connections to CloudSQL for Matomo
+    # This target sport 3307, which is specific to CloudSQL
+    # and can be accessed only via cloud-sql proxy & its strong authentication
+    add_rule(
+        prefix + 'allow-matomo-mysql',
+        {
+            'priority': 800,
+            'description': f'Allow CloudSQL traffic to MySQL instances for matomo',
+            'direction': 'egress',
+            'destination-ranges': MATOMO_SQL_IPS[cluster],
+            'target-tags': ','.join(node_tags),
+            'allow': 'tcp:3307',
+        },
+        rules,
+        replace=replace
     )
 
 


### PR DESCRIPTION
Ref #725 

Currently, these have been hand created. That should be removed &
the script should be run under supervision.