### PR TITLE
Do not mount serviceaccount in matomo pod

### DIFF
--- a/mybinder/templates/matomo/deployment.yaml
+++ b/mybinder/templates/matomo/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: false
       volumes:
       - name: cloudsql-instance-credentials
         secret:


### PR DESCRIPTION
This denies it authenticated access of any sort to the k8s API.

Ref #725 