### PR TITLE
Deploy matomo to track user activities

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.1.12
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-5737187
+   version: 0.1.0-be00d27
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -50,6 +50,29 @@ binderhub:
     imageGCThresholdHigh: 80
     imageGCThresholdLow: 40
 
+  extraFooterScripts:
+    00-matomo-tracking: |
+      // Only load Matomo if DNT is not set.
+      // This respects user preferences, and gives us a full score on uBlock origin
+      if (navigator.doNotTrack != "1" && // Most Firefox & Chrome
+        window.doNotTrack != "1" && // IE & Safari
+        navigator.msDoNotTrack != "1" // Old IE
+      ) {
+      console.log("Loading Matomo tracking, since Do Not Track is off");
+        var _paq = _paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+          var u="//" + window.location.hostname + "/matomo/";
+          _paq.push(['setTrackerUrl', u+'piwik.php']);
+          _paq.push(['setSiteId', '1']);
+          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+          g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+        })();
+      }
+
+
   jupyterhub:
     cull:
       # cull every 11 minutes so it is out of phase


### PR DESCRIPTION
- This is in addition to Google Analytics, which we would like
  to remove in the medium to short term
- We don't load anything at all if DNT is set by the user. This
  respects user privacy & gives us a 100% score on uBlock - otherwise
  uBlock blocks the matomo script & gives us a non 100% score.

Ref #725

