### PR TITLE
bump repo2docker d2e69ba...2ebc87b

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -146,7 +146,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:d2e69ba 
+    repo2dockerImage: jupyter/repo2docker:2ebc87b 
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
Gets Python 3.7 support

https://github.com/jupyter/repo2docker/compare/d2e69ba...2ebc87b
