### PR TITLE
Banning soft4voip/rak

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -21,6 +21,7 @@ binderhub:
       c.GitHubRepoProvider.banned_specs = [
         # e.g. '^org/repo.*',
         '^ines/spacy-binder.*',
+        '^soft4voip/rak.*',
       ]
   service:
     type: ClusterIP
@@ -146,7 +147,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:2ebc87b 
+    repo2dockerImage: jupyter/repo2docker:2ebc87b
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
https://github.com/soft4voip/rak looks to be a mining repo with a miner from https://github.com/fireice-uk/xmr-stak