### PR TITLE
Scrape mysqld metrics from matomo to prometheus

### DIFF
--- a/mybinder/templates/matomo/deployment.yaml
+++ b/mybinder/templates/matomo/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: matomo
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    component: matomo
 spec:
   replicas: {{ .Values.matomo.replicas }}
   selector:
@@ -14,6 +15,7 @@ spec:
       app: matomo
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
+      component: matomo
   template:
     metadata:
       annotations:
@@ -23,6 +25,7 @@ spec:
         app: matomo
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        component: matomo
     spec:
       automountServiceAccountToken: false
       volumes:

--- a/mybinder/templates/matomo/mysqld-exporter/deployment.yaml
+++ b/mybinder/templates/matomo/mysqld-exporter/deployment.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.matomo.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matomo-mysqld-exporter
+  labels:
+    app: matomo
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mysqld-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: matomo
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+      component: mysqld-exporter
+  template:
+    metadata:
+      annotations:
+        checksum/matomo-mysqld-secret: {{ include (print $.Template.BasePath "/matomo/mysqld-exporter/secret.yaml") . | sha256sum }}
+        # Scrape for mysql metrics
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9104"
+      labels:
+        app: matomo
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        component: mysqld-exporter
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      containers:
+      - name: prometheus-mysqld-exporter
+        image: prom/mysqld-exporter:v0.11.0
+        env:
+          - name: DATA_SOURCE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: matomo-mysqld-secret
+                key: prometheus.mysqld.data-source
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        command:
+          - /cloud_sql_proxy
+          - -instances={{ .Values.matomo.db.instanceName }}=tcp:3306
+          - -credential_file=/secrets/cloudsql/credentials.json
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+          - name: cloudsql-instance-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+{{- end }}

--- a/mybinder/templates/matomo/mysqld-exporter/secret.yaml
+++ b/mybinder/templates/matomo/mysqld-exporter/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.matomo.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: matomo-mysqld-secret
+  labels:
+    app: matomo
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: mysqld-exporter
+type: Opaque
+data:
+  prometheus.mysqld.data-source: {{ printf "%s:%s@(127.0.0.1:3306)/" .Values.matomo.db.username .Values.matomo.db.password | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
This helps us monitor state of Matomo MySQL database
and diagnose performance issues if they occur.

Separate deployment for metrics, since we might have
multiple copies of matomo running.

Ref #725