### PR TITLE
run matomo on a core node

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -167,6 +167,7 @@ redirector:
         to: mybinder.readthedocs.io/en/latest/status.html
 
 matomo:
+  nodeSelector: *coreNodeSelector
   db:
     instanceName: binder-prod:us-central1:matomo
   trustedHosts:

--- a/mybinder/templates/matomo/deployment.yaml
+++ b/mybinder/templates/matomo/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         component: matomo
     spec:
       automountServiceAccountToken: false
+      nodeSelector: {{ toJson .Values.matomo.nodeSelector }}
       volumes:
       - name: cloudsql-instance-credentials
         secret:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -257,6 +257,7 @@ proxyPatches:
 
 matomo:
   enabled: true
+  nodeSelector: {}
   replicas: 1
   service:
     type: ClusterIP


### PR DESCRIPTION
matomo was interrupted because it was hanging out with user pods. It got booted due to running out of pods on user nodes.