### PR TITLE
re-enable image cleaner on dind only

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -45,11 +45,13 @@ binderhub:
 
 
   imageCleaner:
-    enabled: false
+    enabled: true
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80
     imageGCThresholdLow: 40
+    host:
+      enabled: false
 
   extraFooterScripts:
     00-matomo-tracking: |


### PR DESCRIPTION
we've been having disk pressure issues with our long-running nodes. don't clean host images, only dind images.

Keep an eye on this one. If we see another outage like #721, we can revert it.