### PR TITLE
Increase matomo replicas to 3 & make at least 1 available

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -167,6 +167,7 @@ redirector:
         to: mybinder.readthedocs.io/en/latest/status.html
 
 matomo:
+  replicas: 3
   nodeSelector: *coreNodeSelector
   db:
     instanceName: binder-prod:us-central1:matomo

--- a/mybinder/templates/matomo/pdb.yaml
+++ b/mybinder/templates/matomo/pdb.yaml
@@ -8,8 +8,12 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-
+  # Use 1.0 rather than 1, since `gt` only works with floats
+  {{ if gt .Values.matomo.replicas 1.0 }}
+  minAvailable: 1
+  {{ else }}
   minAvailable: 0
+  {{ end }}
   selector:
     matchLabels:
       app: matomo


### PR DESCRIPTION
We don't wanna lose metrics if possible. So we run 3 copies
of matomo, and make sure at least 1 is available during
scaling and other changes.

Ref #725 
