### PR TITLE
Disable link-tracking in matomo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -65,7 +65,6 @@ binderhub:
         var _paq = _paq || [];
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
         _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
         (function() {
           var u="//" + window.location.hostname + "/matomo/";
           _paq.push(['setTrackerUrl', u+'piwik.php']);


### PR DESCRIPTION
This was counting all links being clicked from
mybinder.org. This is not something we wanna track,
so let's kill it.

Ref #725 