### PR TITLE
Update repo2docker to 32e5ef2

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -148,7 +148,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:2ebc87b
+    repo2dockerImage: jupyter/repo2docker:32e5ef2
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
This brings in the possibility to select which version of Julia you want
to use in your repository.

This is a repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/2ebc87b...32e5ef2
