### PR TITLE
Remove status.mybinder.org redirect

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -161,10 +161,6 @@ redirector:
       host:
         from: playground.mybinder.org
         to: play.nteract.io
-    - type: host
-      host:
-        from: status.mybinder.org
-        to: mybinder.readthedocs.io/en/latest/status.html
 
 matomo:
   replicas: 3


### PR DESCRIPTION
The redirect currently fails and we have triggered the Let's encrypt
rate limit which means docs.mybinder.org has become unavailable. For the
moment removing status.mybinder.org to test if we can recover.

Related to #766 