### PR TITLE
Upgrade kube-lego version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
    version: 1.2.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: kube-lego
-   version: 0.1.12
+   version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
    version: 0.1.0-24ad99a

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -210,6 +210,8 @@ kube-lego:
     LEGO_URL: https://acme-v01.api.letsencrypt.org/directory
   rbac:
     create: true
+  image:
+    tag: 0.1.7
 
 grafana:
   ingress:


### PR DESCRIPTION
While investigating our HTTPS setup I noticed that we run an old version of kube-lego. This takes us to the latest available version before it became unmaintained.

I am not sure if this will fix the problem in #766 or not but it seems like it is worth a shot.

Would be good to get @minrk or @yuvipanda to take a look at this before deploying it. We have been rate limited for seven days with let's encrypt so not in a mega hurry to get it fixed as it is going to be a while before we get unbanned anyway. At least that is my understanding.