### PR TITLE
temporarily remove playground redirect

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -157,10 +157,10 @@ redirector:
       host:
         from: docs.mybinder.org
         to: mybinder.readthedocs.io
-    - type: host
-      host:
-        from: playground.mybinder.org
-        to: play.nteract.io
+    # - type: host
+    #   host:
+    #     from: playground.mybinder.org
+    #     to: play.nteract.io
 
 matomo:
   replicas: 3


### PR DESCRIPTION
it may allow us to request a new cert from letsencrypt without the current rate limit

If I read the [rate limit docs](https://letsencrypt.org/docs/rate-limits/) correctly, the rate limit is applied to *exact* domain combinations, so changing the list might let us ask for a new cert.