### PR TITLE
disable dind image-cleaner again

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -45,7 +45,7 @@ binderhub:
 
 
   imageCleaner:
-    enabled: true
+    enabled: false
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80


### PR DESCRIPTION
it's not cooperating with kube's internal ImageGC, which causes cleaning to run constantly when the disk starts to fill up, ensuring dind's image cache is always empty.