### PR TITLE
re-enable image-cleaning on dind-only

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -45,7 +45,7 @@ binderhub:
 
 
   imageCleaner:
-    enabled: false
+    enabled: true
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80


### PR DESCRIPTION
now that dind is on its own disk, this should behave better

closes #754