### PR TITLE
Redirect z2jh.jupyter.org to RTD site for HTTPS

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -168,6 +168,10 @@ redirector:
       host:
         from: docs.mybinder.org
         to: mybinder.readthedocs.io
+    - type: host
+      host:
+        from: z2jh.jupyter.org
+        to: zero-to-jupyterhub.readthedocs.io
     # - type: host
     #   host:
     #     from: playground.mybinder.org


### PR DESCRIPTION
We use a cloudflare page rule to redirect z2jh.jupyter.org
to RTD. However, this doesn't work with HTTPS, since our cloudflare
HTTPS setting is set to 'Full' not 'Flexible'. 'Full' requires
the backing server (in this case mybinder.org, since that is where
the A record points to now) listen on 443 and do the redirect
appropriately. This makes it work with https too. We can remove
the cloudflare page rule in the future if we want to.