### PR TITLE
Restore status, playground redirects

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -168,10 +168,14 @@ redirector:
       host:
         from: docs.mybinder.org
         to: mybinder.readthedocs.io
-    # - type: host
-    #   host:
-    #     from: playground.mybinder.org
-    #     to: play.nteract.io
+    - type: host
+      host:
+        from: playground.mybinder.org
+        to: play.nteract.io
+    - type: host
+      host:
+        from: status.mybinder.org
+        to: mybinder.readthedocs.io/en/latest/status.html
 
 matomo:
   replicas: 3


### PR DESCRIPTION
Now that DNS has been migrated to cloudflare, this should work again

closes #772