### PR TITLE
fix status redirect

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -172,7 +172,7 @@ redirector:
       host:
         from: playground.mybinder.org
         to: play.nteract.io
-    - type: host
+    - type: url
       host:
         from: status.mybinder.org
         to: mybinder.readthedocs.io/en/latest/status.html

--- a/mybinder/templates/redirector/configmap.yaml
+++ b/mybinder/templates/redirector/configmap.yaml
@@ -9,6 +9,10 @@ data:
           listen 80;
           server_name {{ $redirect.host.from }};
 
+    {{- if (eq $redirect.type "url") }}
+          rewrite (.*) https://{{ $redirect.host.to }} redirect;
+    {{- else }}
           rewrite (.*) https://{{ $redirect.host.to }}$1 redirect;
+    {{- end }}
     }
     {{ end }}


### PR DESCRIPTION
since host redirect preserves path and thus sends to `status.html/` which 404s