### PR TITLE
update Notebook UI via appendix

### DIFF
--- a/appendix/run-appendix
+++ b/appendix/run-appendix
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+appendix_dir="$(dirname "$0")"
+# add custom.js for notebook
+# it is executed when the notebook app starts and adds binder buttons next to Quit button in the UI
+sed -i 's|{binder_url}|'"$BINDER_URL"'|g' "${appendix_dir}/static/custom.js"
+sed -i 's|{repo_url}|'"$REPO_URL"'|g' "${appendix_dir}/static/custom.js"
+mkdir -p ~/.jupyter/custom
+cat "${appendix_dir}/static/custom.js" >> ~/.jupyter/custom/custom.js
+chown -R $NB_USER:$NB_USER $HOME/.jupyter

--- a/appendix/static/custom.js
+++ b/appendix/static/custom.js
@@ -1,0 +1,35 @@
+function copy_link_into_clipboard(b) {
+    var $temp = $("<input>");
+    $(b).parent().append($temp);
+    $temp.val($(b).data('url')).select();
+    document.execCommand("copy");
+    $temp.remove();
+}
+
+function add_binder_buttons() {
+    var copy_button = '<button id="copy-{name}-link" ' +
+            '                 title="Copy {name} link to clipboard" ' +
+            '                 class="btn btn-default btn-sm navbar-btn" ' +
+            '                 style="margin-right: 4px; margin-left: 2px;" ' +
+            '                 data-url="{url}" ' +
+            '                 onclick="copy_link_into_clipboard(this);">' +
+            '         Copy {name} link</button>';
+
+    var link_button = '<a id="copy-{name}-link" ' +
+        '                 href="{url}" ' +
+        '                 class="btn btn-default btn-sm navbar-btn" ' +
+        '                 style="margin-right: 4px; margin-left: 2px;" ' +
+        '                 target="_blank">' +
+        '              Go to {name}</a>';
+
+    var s = $("<span id='binder-buttons'></span>");
+    s.append(link_button.replace(/{name}/g, 'repo').replace('{url}', '{repo_url}'));
+    s.append(copy_button.replace(/{name}/g, 'binder').replace('{url}', '{binder_url}'));
+    if ($("#ipython_notebook").length && $("#ipython_notebook>a").length) {
+        s.append(copy_button.replace(/{name}/g, 'session').replace('{url}', window.location.origin.concat($("#ipython_notebook>a").attr('href'))));
+    }
+    // add buttons at the end of header-container
+    $("#header-container").append(s);
+}
+
+add_binder_buttons();

--- a/mybinder/files/etc/jupyter/templates/page.html
+++ b/mybinder/files/etc/jupyter/templates/page.html
@@ -1,0 +1,2 @@
+{% extends "templates/page.html" %}
+{% block login_widget %}{% endblock %}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -51,6 +51,17 @@ binderhub:
       build_image: jupyter/repo2docker:5cdd0ee
       per_repo_quota: 100
 
+      appendix: |
+        USER root
+        ENV BINDER_URL={binder_url}
+        ENV REPO_URL={repo_url}
+        RUN cd /tmp \
+         && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/97827f491d45d76f5b5c35cf2612d95be6383ac0.tar.gz -O appendix.tar.gz \
+         && tar --wildcards -xzf appendix.tar.gz --strip 1 */appendix \
+         && ./appendix/run-appendix \
+         && rm -rf appendix.tar.gz appendix
+        USER $NB_USER
+
       extra_footer_scripts:
         01-matomo: |
           // Only load Matomo if DNT is not set.

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -56,7 +56,7 @@ binderhub:
         ENV BINDER_URL={binder_url}
         ENV REPO_URL={repo_url}
         RUN cd /tmp \
-         && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/97827f491d45d76f5b5c35cf2612d95be6383ac0.tar.gz -O appendix.tar.gz \
+         && wget -q https://github.com/jupyterhub/mybinder.org-deploy/archive/e2d525e176b929ba39045155fc796b0fa8d1119f.tar.gz -O appendix.tar.gz \
          && tar --wildcards -xzf appendix.tar.gz --strip 1 */appendix \
          && ./appendix/run-appendix \
          && rm -rf appendix.tar.gz appendix


### PR DESCRIPTION
Hi, sorry I had had to do this PR before as discussed in https://github.com/jupyterhub/binderhub/issues/674. If this change is not needed anymore, we can close this PR.

This PR updates appendix in order to update Notebook UI:
1. Removes logout button (I think this button is confusing, since users are not logged in and there is now Quit button.)
2. Adds binder buttons:
  - `Go to repo`: opens the source repo url in new tab
  - `Copy binder link`: copies the binder launch link into clipboard
  - `Copy session link`: copies the binder session link into clipboard. When this link is shared with another user, that user will reach to the same binder session. It will not start a new launch.

I can remove or rename buttons according to your feedback.