### PR TITLE
Use database for matomo sessions

### DIFF
--- a/mybinder/templates/matomo/configmap.yaml
+++ b/mybinder/templates/matomo/configmap.yaml
@@ -28,6 +28,9 @@ data:
     trusted_hosts[] = {{ $host | quote}}
     {{ end }}
 
+    ; Use database for sessions, since we run multiple copies of matomo
+    session_save_handler = dbtable
+
     [PluginsInstalled]
     PluginsInstalled[] = "Diagnostics"
     PluginsInstalled[] = "Login"


### PR DESCRIPTION
By default it uses filestorage for sessions. This does not
work when running multiple copies as we do, and causes XSRF
errors (and other screwups). Since we do not have that many
admin users, the database is a good place for session storage.

Fixes #784 