### PR TITLE
Redirect matomo.mybinder.org to matomo URL

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -176,6 +176,10 @@ redirector:
       host:
         from: status.mybinder.org
         to: mybinder.readthedocs.io/en/latest/status.html
+    - type: url
+      host:
+        from: matomo.mybinder.org
+        to: mybinder.org/matomo/index.php
 
 matomo:
   replicas: 3


### PR DESCRIPTION
Easier to remember & type.

Fixes #747 