### PR TITLE
Bump prometheus memory request / limit

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -125,10 +125,10 @@ prometheus:
     resources:
       requests:
         cpu: "2"
-        memory: 12Gi
+        memory: 16Gi
       limits:
         cpu: "2"
-        memory: 12Gi
+        memory: 16Gi
     persistentVolume:
       # Use a large SSD Volume in production
       size: 2000Gi


### PR DESCRIPTION
It has been crashlooping for a while with OOMKills.

Ref #761 