### PR TITLE
Fix typo in run.bash

### DIFF
--- a/images/events-archiver/run.bash
+++ b/images/events-archiver/run.bash
@@ -8,6 +8,6 @@ do
             ${PROJECT_NAME} \
             binderhub-events-text \
             ${SOURCE_BUCKET} \
-            ${DESTINATION_BUCKET} \
+            ${DESTINATION_BUCKET}
     sleep 2h
 done


### PR DESCRIPTION
Followup #809

Ref #789 