### PR TITLE
Update repo2docker to a161b09 -> 5cdd0ee

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -166,7 +166,7 @@ binderhub:
         CULL_KERNEL_TIMEOUT: '600'
         CULL_INTERVAL: '60'
   build:
-    repo2dockerImage: jupyter/repo2docker:a161b09
+    repo2dockerImage: jupyter/repo2docker:5cdd0ee
     appendix: |
       USER root
       ENV BINDER_URL={binder_url}


### PR DESCRIPTION
Gets basic `nix` support.

This is a repo2docker version bump. See the link
below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/a161b09...5cdd0ee