### PR TITLE
Expose archived events at archive.analytics.mybinder.org

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -204,3 +204,8 @@ matomo:
 eventsArchiver:
   sourceBucket: mybinder-events-raw-export
   destinationBucket: mybinder-events-archive
+
+gcsProxy:
+  buckets:
+    - name: mybinder-events-archive
+      host: archive.analytics.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -96,3 +96,8 @@ matomo:
 eventsArchiver:
   sourceBucket: mybinder-staging-events-raw-export
   destinationBucket: mybinder-staging-events-archive
+
+gcsProxy:
+  buckets:
+    - name: mybinder-staging-events-archive
+      host: archive.analytics.staging.mybinder.org

--- a/images/events-archiver/events-indexer.py
+++ b/images/events-archiver/events-indexer.py
@@ -10,6 +10,7 @@ import json
 import argparse
 import sys
 from dateutil.parser import parse
+import mimetypes
 from datetime import datetime
 import tempfile
 from google.cloud import logging, storage
@@ -88,16 +89,19 @@ def main():
         jsonlfile.seek(0)
 
         if not args.dry_run:
-            bucket.blob('index.html').upload_from_file(htmlfile)
+            html_blob = bucket.blob('index.html')
+            html_blob.upload_from_file(htmlfile, content_type='text/html')
             bucket.blob('index.jsonl').upload_from_file(jsonlfile)
 
 
     print(STATIC_FILES, file=sys.stderr)
+
     # Upload static assets
     for static_file in STATIC_FILES:
         blob_name = os.path.relpath(static_file, HERE)
-        bucket.blob(blob_name).upload_from_filename(static_file)
-
+        static_blob = bucket.blob(blob_name)
+        mimetype, _ = mimetypes.guess_type(static_file)
+        static_blob.upload_from_filename(static_file, content_type=mimetype)
         
 
 if __name__ == '__main__':

--- a/images/events-archiver/index.html
+++ b/images/events-archiver/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <link rel="stylesheet" href="bootstrap-4.1.3.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO">
+    <link rel="stylesheet" href="static/bootstrap-4.1.3.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO">
     <style>
     </style>
     <title>MyBinder.org Events Archive</title>

--- a/mybinder/templates/gcs-proxy/configmap.yaml
+++ b/mybinder/templates/gcs-proxy/configmap.yaml
@@ -1,0 +1,50 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: gcs-proxy-config
+  labels:
+    app: gcs-proxy
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  # NGINX config influenced by https://github.com/presslabs/gs-proxy
+  proxy.conf: |
+      upstream gs {
+            server                   storage.googleapis.com:443;
+            keepalive                128;
+      }
+
+      {{- range $bucket := .Values.gcsProxy.buckets }}
+      server {
+            listen 80;
+            server_name {{ $bucket.host }};
+            if ( $request_method !~ "GET|HEAD" ) {
+                  return 405;
+            }
+
+            location / {
+                  rewrite /$ /index.html;
+
+                  proxy_set_header    Host storage.googleapis.com;
+                  proxy_pass          https://gs/{{ $bucket.name }}$uri;
+                  proxy_http_version  1.1;
+                  proxy_set_header    Connection "";
+
+                  proxy_intercept_errors on;
+                  proxy_hide_header       alt-svc;
+                  proxy_hide_header       X-GUploader-UploadID;
+                  proxy_hide_header       alternate-protocol;
+                  proxy_hide_header       x-goog-hash;
+                  proxy_hide_header       x-goog-generation;
+                  proxy_hide_header       x-goog-metageneration;
+                  proxy_hide_header       x-goog-stored-content-encoding;
+                  proxy_hide_header       x-goog-stored-content-length;
+                  proxy_hide_header       x-goog-storage-class;
+                  proxy_hide_header       x-xss-protection;
+                  proxy_hide_header       accept-ranges;
+                  proxy_hide_header       Set-Cookie;
+                  proxy_ignore_headers    Set-Cookie;
+            }
+      }
+      {{ end }}

--- a/mybinder/templates/gcs-proxy/deployment.yaml
+++ b/mybinder/templates/gcs-proxy/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcs-proxy
+  labels:
+    app: gcs-proxy
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: gcs-proxy
+      component: nginx
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.gcsProxy.replicas }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/gcs-proxy/configmap.yaml") . | sha256sum }}
+      labels:
+        app: gcs-proxy
+        component: nginx
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      nodeSelector: {{ toJson .Values.gcsProxy.nodeSelector }}
+      volumes:
+        - name: config
+          configMap:
+            name: gcs-proxy-config
+      containers:
+      - name: nginx
+        image: nginx:1.13.6
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - mountPath: /etc/nginx/conf.d/
+            name: config

--- a/mybinder/templates/gcs-proxy/ingress.yaml
+++ b/mybinder/templates/gcs-proxy/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gcs-proxy
+  labels:
+    app: gcs-proxy
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    {{ range $bucket := .Values.gcsProxy.buckets }}
+    - host: {{ $bucket.host | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: gcs-proxy
+              servicePort: 80
+    {{ end }}
+  tls:
+    - secretName: kubelego-tls-gcs-proxy
+      hosts:
+      {{- range $bucket := .Values.gcsProxy.buckets }}
+      - {{ $bucket.host }}
+      {{- end }}

--- a/mybinder/templates/gcs-proxy/pdb.yaml
+++ b/mybinder/templates/gcs-proxy/pdb.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: gcs-proxy
+  labels:
+    app: gcs-proxy
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      app: gcs-proxy
+      component: nginx

--- a/mybinder/templates/gcs-proxy/service.yaml
+++ b/mybinder/templates/gcs-proxy/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcs-proxy
+  labels:
+    app: gcs-proxy
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    app: gcs-proxy
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -288,6 +288,10 @@ matomo:
     name: matomo
     tables_prefix: matomo_
 
+gcsProxy:
+  replicas: 1
+  nodeSelector: {}
+
 eventsArchiver:
   image:
     name: jupyterhub/mybinder-extraevents-archiver


### PR DESCRIPTION
- GCS can't do HTTPS when exposing objects publicly, so have a
  a simple nginx deployment + ingress to proxy them.
- Content-Type and Path related fixes for the website

Ref #789 