### PR TITLE
bump binderhub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-47ed8cd
+   version: 0.1.0-4922ddf
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
gets the split build/launch metrics, which should improve prometheus performance over time

https://github.com/jupyterhub/binderhub/compare/47ed8cd...4922ddf