### PR TITLE
Make analytics events flat

### DIFF
--- a/images/events-archiver/events-archiver.py
+++ b/images/events-archiver/events-archiver.py
@@ -93,7 +93,12 @@ def main():
             temp.seek(0)
 
             for line in temp:
-                event = process_event(json.loads(json.loads(line)['jsonPayload']['message']))
+                event = json.loads(json.loads(line)['jsonPayload']['message'])
+                # Account for time when 'event' was nested
+                if 'event' in event:
+                    event.update(event['event'])
+                    del event['event']
+                event = process_event(event)
                 if args.debug:
                     print(event)
                 if not args.dry_run:

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.1.0-70d53fe
+   version: 0.1.0-88fd96d
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -3,7 +3,7 @@ etcJupyter:
     NotebookApp:
       allow_origin: '*'
       tornado_settings:
-        trust_xheaders: True
+        trust_xheaders: true
       # shutdown the server after no activity
       shutdown_no_activity_timeout: 600
 
@@ -19,7 +19,7 @@ etcJupyter:
       # a kernel with open connections but no activity still counts as idle
       # this is what allows us to shutdown servers
       # when people leave a notebook open and wander off
-      cull_connected: True
+      cull_connected: true
 
 binderhub:
 


### PR DESCRIPTION
- Bumps BinderHub to deploy https://github.com/jupyterhub/binderhub/pull/710
- Makes events-archiver work with newer format

See discussion in https://github.com/jupyterhub/mybinder.org-deploy/issues/789#issuecomment-436154158
for rationale for flattening.

Ref #789 