### PR TITLE
fix pretty logging after google misconfigures root logger

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -80,6 +80,11 @@ binderhub:
     01-eventlog: |
       import google.cloud.logging
       import google.cloud.logging.handlers
+      # importing google cloud configures a root log handler,
+      # which prevents tornado's pretty-logging
+      import logging
+      logging.getLogger().handlers = []
+
       class JSONCloudLoggingHandler(google.cloud.logging.handlers.CloudLoggingHandler):
           def emit(self, record):
               record.name = None


### PR DESCRIPTION
importing google logging attempts to configure the root logger, which it shouldn't. When the root logger is configured, tornado's enable_pretty_logging is a no-op because it assumes (accurately) that the logger is already configured.