### PR TITLE
Flush events-archiver output to stdout immediately

### DIFF
--- a/images/events-archiver/Dockerfile
+++ b/images/events-archiver/Dockerfile
@@ -6,5 +6,5 @@ ADD . .
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
-
-CMD ["/srv/run.py"]
+# Python seems to never wanna flush to stdout without the '-u'
+CMD ["python3", "-u", "/srv/run.py"]

--- a/images/events-archiver/run.py
+++ b/images/events-archiver/run.py
@@ -11,7 +11,6 @@ log_name = 'binderhub-events-text'
 source_bucket = os.environ['SOURCE_BUCKET']
 destination_bucket = os.environ['DESTINATION_BUCKET']
 
-
 while True:
     now = datetime.utcnow()
 


### PR DESCRIPTION
Otherwise we were getting 0 log output. Buffer too big?

Ref #789 