### PR TITLE
Make gcs-proxy's nginx container name more unique

### DIFF
--- a/mybinder/templates/gcs-proxy/deployment.yaml
+++ b/mybinder/templates/gcs-proxy/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           configMap:
             name: gcs-proxy-config
       containers:
-      - name: nginx
+      - name: gcs-proxy-nginx
         image: nginx:1.13.6
         ports:
         - containerPort: 80


### PR DESCRIPTION
Easier to create a stackdriver filter to store these logs
more permanently. This lets us keep these logs for longer,
and figure out how many people are using these.

Ref #789 