### PR TITLE
Add a PDB for the event archiver

### DIFF
--- a/mybinder/templates/events-archiver/pdb.yaml
+++ b/mybinder/templates/events-archiver/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: events-archiver
+  labels:
+    app: events-archiver
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      app: events-archiver


### PR DESCRIPTION
The archiver should not prevent scale down of a node so we give it a
minimum number of replicas of zero.