### PR TITLE
rm logout button from notebook ui

### DIFF
--- a/mybinder/files/etc/jupyter/templates/page.html
+++ b/mybinder/files/etc/jupyter/templates/page.html
@@ -1,0 +1,2 @@
+{% extends "templates/page.html" %}
+{% block login_widget %}{% endblock %}


### PR DESCRIPTION
This is non-appendix part of https://github.com/jupyterhub/mybinder.org-deploy/pull/788.

This removes logout button from notebooks. I think it is confusing and not needed since there is Quit button.