### PR TITLE
Automatically publish cloud compute costs

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -202,9 +202,11 @@ matomo:
 
 analyticsPublisher:
   project: binder-prod
+  destinationBucket: mybinder-events-archive
   events:
     sourceBucket: mybinder-events-raw-export
-    destinationBucket: mybinder-events-archive
+  billing:
+    sourceBucket: binder-billing
 
 gcsProxy:
   buckets:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -97,9 +97,9 @@ matomo:
 
 analyticsPublisher:
   project: binder-staging
+  destinationBucket: mybinder-staging-events-archive
   events:
     sourceBucket: mybinder-staging-events-raw-export
-    destinationBucket: mybinder-staging-events-archive
 
 gcsProxy:
   buckets:

--- a/docs/source/analytics/cloud-costs.rst
+++ b/docs/source/analytics/cloud-costs.rst
@@ -1,0 +1,32 @@
+.. _analytics/cloud-costs:
+
+================
+Cloud Costs Data
+================
+
+In an effort to be more transparent about how we use our funds,
+we publish the amount of money spent each day in cloud
+compute costs for running mybinder.org.
+
+Interpreting the data
+=====================
+
+You can find the data in the `Analytics Archive
+<https://archive.analytics.mybinder.org>`_ at `cloud-costs.jsonl
+<https://archive.analytics.mybinder.org/cloud-costs.jsonl>`_. Each line in
+the file is a JSON object, with the following keys:
+
+#. **startTime** and **endTime**
+
+   The start and end of the billing period this item represents. These
+   times are inclusive, and in pacific time observing DST (so PDT or PST).
+   The timezone choice is unfortunate, but unfortunately our cloud provider
+   (Google Cloud Platform) provides detailed billing reports in this timezone
+   only.
+
+#. **cost**
+
+   The cost of all cloud compute resources used during this time period. This
+   is denominated in US Dollars.
+
+The lines are sorted by ``startTime``.

--- a/docs/source/analytics/cloud-costs.rst
+++ b/docs/source/analytics/cloud-costs.rst
@@ -4,7 +4,7 @@
 Cloud Costs Data
 ================
 
-In an effort to be more transparent about how we use our funds,
+In an effort to be transparent about how we use our funds,
 we publish the amount of money spent each day in cloud
 compute costs for running mybinder.org.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,7 @@ Analytics
    :maxdepth: 2
 
    analytics/events-archive
+   analytics/cloud-costs
 
 Incident Reports
 ----------------

--- a/images/analytics-publisher/cloudcosts.py
+++ b/images/analytics-publisher/cloudcosts.py
@@ -79,6 +79,8 @@ def publish_daily_cost(
 
         blob.upload_from_file(target_buffer)
 
+    return sorted_items
+
 def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument(

--- a/images/analytics-publisher/cloudcosts.py
+++ b/images/analytics-publisher/cloudcosts.py
@@ -1,0 +1,123 @@
+"""
+Produces daily summaries of GCP spending data.
+"""
+import argparse
+import json
+import subprocess
+import csv
+import sys
+from google.cloud import storage
+import io
+import tempfile
+from dateutil.parser import parse
+
+
+def totals_from_csv(file):
+    totals = {}
+    reader = csv.DictReader(file)
+    for row in reader:
+        totals[row['Start Time']] = totals.get(row['Start Time'], 0) + float(row['Cost'])
+
+    return totals
+
+
+def totals_from_json(file):
+    totals = {}
+    for item in json.load(file):
+        cost = float(item['cost']['amount'])
+        start_time = item['startTime']
+        totals[start_time] = totals.get(start_time, 0) + cost
+
+    return totals
+
+def publish_daily_cost(
+        billing_bucket_name, target_bucket_name, target_object_name,
+        kind='json', debug=False, dry_run=False
+    ):
+    totals = {}
+    client = storage.Client()
+
+    bucket = storage.Bucket(client, billing_bucket_name)
+    if kind == 'csv':
+        prefix='report-'
+    else:
+        prefix='billing-'
+    blobs = bucket.list_blobs(prefix=prefix)
+
+    for blob in blobs:
+        buffer = io.StringIO(blob.download_as_string().decode())
+
+        if kind == 'csv':
+            current_totals = totals_from_csv(buffer)
+        else:
+            current_totals = totals_from_json(buffer)
+
+        for start_time, cost in current_totals.items():
+            totals[start_time] = totals.get(start_time, 0) + cost
+
+
+    # We want to push out sorted jsonl
+    sorted_items = [
+        { 'date': start_time, 'cost': cost }
+        for start_time, cost in totals.items()
+    ]
+
+    sorted_items.sort(key=lambda d: d['date'])
+
+    if debug:
+        print(json.dumps(sorted_items, indent=4))
+
+    if not dry_run:
+        target_bucket = storage.Bucket(client, target_bucket_name)
+        blob = target_bucket.blob(target_object_name)
+
+        target_buffer = io.StringIO()
+        for item in sorted_items:
+            target_buffer.write(json.dumps(item) + '\n')
+
+        target_buffer.seek(0)
+
+        blob.upload_from_file(target_buffer)
+
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        'billing_bucket_name',
+        help='Name of bucket GCP billing data is exported to'
+    )
+    argparser.add_argument(
+        'target_bucket_name',
+        help='Name of bucket to push aggregate daily data to'
+    )
+    argparser.add_argument(
+        'target_object_name',
+        help='Name of object to output containing aggregate daily data'
+    )
+    argparser.add_argument(
+        '--kind',
+        choices=('csv', 'json'),
+        help='Content Type of billing data export available in bucket',
+        default='json'
+    )
+    argparser.add_argument(
+        '--debug',
+        help='Print daily billing data to stdout',
+        action='store_true',
+        default=False
+    )
+    argparser.add_argument(
+        '--dry-run',
+        help='Do not push output to output GCS bucket',
+        action='store_true',
+        default=False
+    )
+
+    args = argparser.parse_args()
+    publish_daily_cost(
+        args.billing_bucket_name, args.target_bucket_name, args.target_object_name,
+        args.kind, args.debug, args.dry_run
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/images/analytics-publisher/run.py
+++ b/images/analytics-publisher/run.py
@@ -44,13 +44,14 @@ while True:
         # Only publish cloudCosts if it is enabled.
         # We disable this for binder staging, since all our billing
         # exports are in prod only.
-        publish_daily_cost(
+        cloud_costs = publish_daily_cost(
             billing_bucket_name=config['cloudCosts']['sourceBucket'],
             target_bucket_name=config['destinationBucket'],
             target_object_name=config['cloudCosts']['fileName'],
             kind=config['cloudCosts']['kind']
         )
 
+        print("Uploaded cloud costs for {} days".format(len(cloud_costs)))
 
     print("Generating index")
     index_events(project_name, config['destinationBucket'])

--- a/mybinder/templates/analytics-publisher/deployment.yaml
+++ b/mybinder/templates/analytics-publisher/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         app: analytics-publisher
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/analytics-publisher/configmap.yaml") . | sha256sum }}
     spec:
       volumes:
       - name: secrets

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -330,5 +330,11 @@ analyticsPublisher:
   events:
     logName: binderhub-events-text
   image:
-    name: jupyterhub/mybinder-extraevents-archiver
-    tag: set-by-chartpress
+    name:
+    tag:
+  cloudCosts:
+    # All billing info goes into same bucket in prod, to which staging has access
+    enabled: true
+    sourceBucket: binder-billing
+    fileName: cloud-costs.jsonl
+    kind: csv


### PR DESCRIPTION
- Works with CSV & JSON exports
- Exports aggregate data to Google Cloud Storage

TODO:

- [x] Run automatically 
- [x] Add documentation on using and interpreting this
- [ ] Publicize this in the index page

Fixes #345 