### PR TITLE
bump grafana, prometheus charts

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -3,10 +3,10 @@ dependencies:
    version: 0.20.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
-   version: 6.2.1
+   version: 7.4.4
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
-   version: 1.2.0
+   version: 1.18.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: kube-lego
    version: 0.4.2

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -267,6 +267,7 @@ grafana:
       kubernetes.io/tls-acme: 'true'
   persistence:
     enabled: true
+    size: 1Gi
     accessModes:
       - ReadWriteOnce
 


### PR DESCRIPTION
and ensure grafana chart has capacity defined

0 capacity fails as invalid with kube 1.11, while it was treated as the wildly excessive 500G default previously.

Reclaim policy has been set to Retain to ensure that volumes aren't lost, and snapshopts have been taken of our prometheus and grafana volumes on prod.