### PR TITLE
enable podPriority, userPlaceholder

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -83,6 +83,8 @@ binderhub:
           hosts:
             - hub.mybinder.org
     scheduling:
+      userPlaceholder:
+        replicas: 10
       userScheduler:
         nodeSelector: *coreNodeSelector
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -25,6 +25,9 @@ binderhub:
         - secretName: kubelego-tls-jupyterhub-staging
           hosts:
             - hub.staging.mybinder.org
+    scheduling:
+      userPlaceholder:
+        replicas: 2
 
 grafana:
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -171,6 +171,11 @@ binderhub:
       userScheduler:
         enabled: true
         replicas: 2
+      podPriority:
+        enabled: true
+      userPlaceholder:
+        enabled: true
+        replicas: 0
     singleuser:
       networkPolicy:
         enabled: true


### PR DESCRIPTION
this gives us the headroom placeholders for early scale-up

this is what we’ve been waiting for 1.11 to enable