### PR TITLE
Update PDB for analytics publisher

### DIFF
--- a/mybinder/templates/analytics-publisher/pdb.yaml
+++ b/mybinder/templates/analytics-publisher/pdb.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: events-archiver
+  name: analytics-publisher
   labels:
-    app: events-archiver
+    app: analytics-publisher
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
The PDB hadn't been updated to the new name of the analytics-publisher. As a result the pod can't be moved and is preventing scale down.