### PR TITLE
Revert "Update PDB for analytics publisher"

### DIFF
--- a/mybinder/templates/analytics-publisher/pdb.yaml
+++ b/mybinder/templates/analytics-publisher/pdb.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: analytics-publisher
+  name: events-archiver
   labels:
-    app: analytics-publisher
+    app: events-archiver
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#855

Renaming the PDB fails with "Error: UPGRADE FAILED: no PodDisruptionBudget with the name "analytics-publisher" found". Let's see if we can change the selector only as that is what I wanted to change anyway.