### PR TITLE
adding about page text

### DIFF
--- a/config/localonly/binderhub_config.py
+++ b/config/localonly/binderhub_config.py
@@ -1,0 +1,13 @@
+from binderhub.repoproviders import FakeProvider
+
+c.BinderHub.use_registry = False
+c.BinderHub.builder_required = False
+c.BinderHub.repo_providers = {'gh': FakeProvider}
+c.BinderHub.tornado_settings.update({'fake_build':True})
+
+c.BinderHub.about_message = ('<br /><p style="width: 650px; margin: 0px auto;">mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />'
+                             'The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>, which is a fiscally '
+                             'sponsored project of <a href="https://numfocus.org/">NumFocus</a>, a US 501c3 non-profit.<br /><br />'
+                             'For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a '
+                             'security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />'
+                             'For more information about the Binder Project, see <a href="https://docs.mybinder.org/about">the About Binder page</a></p>')

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -102,7 +102,7 @@ binderhub:
                                    "The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>, which is a fiscally "
                                    "sponsored project of <a href="https://numfocus.org/">NumFocus</a>, a US 501c3 non-profit.<br /><br />"
                                    "For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a "
-                                   "security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />"
+                                   "security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a>.<br /><br />"
                                    "For more information about the Binder Project, see <a href="https://docs.mybinder.org/about">the About Binder page</a></p>")
 
   registry:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -96,6 +96,14 @@ binderhub:
           # for now. Should be fixed in https://github.com/googleapis/google-cloud-python/pull/6293
           return [JSONCloudLoggingHandler(client, name='binderhub-events-text')]
       c.EventLog.handlers_maker = _make_eventsink_handler
+    # Configure the extra HTML displayed at mybinder.org/about
+    02-about: |
+      c.BinderHub.about_message = ("<p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />"
+                                   "The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>, which is a fiscally "
+                                   "sponsored project of <a href="https://numfocus.org/">NumFocus</a>, a US 501c3 non-profit.<br /><br />"
+                                   "For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a "
+                                   "security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />"
+                                   "For more information about the Binder Project, see <a href="https://docs.mybinder.org/about">the About Binder page</a></p>")
 
   registry:
     url: https://gcr.io


### PR DESCRIPTION
Now that https://github.com/jupyterhub/binderhub/pull/729 is in mybinder.org (mybinder.org/about) this attempts to configure the page to add the extra text that @betatim suggested. I used the documentation that was provided in that PR, and I *think* this is where the text needs to go in the helm chart but I'm not really sure. @betatim do you have any guidance there?

To try and demo the CSS and wording locally, I followed the pattern in the [binder docs](https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md#pure-html--css--js-development) and copied a config file for local stuff. I added it to the repo in case it's useful to use for local development when we don't have access to minikube (I don't have it on my windows machine). Is there any way that we can import values into the localonly config *from* the helm chart? (e.g. everything that isn't explicitly over-written by the localonly config?) Maybe @yuvipanda or @minrk have ideas on that one?

Either way, here is what it looks like when I serve locally:

![image](https://user-images.githubusercontent.com/1839645/49055775-7e4f3300-f1be-11e8-83e2-1bc2270d8dc2.png)

