### PR TITLE
25 placeholders on prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -84,7 +84,7 @@ binderhub:
             - hub.mybinder.org
     scheduling:
       userPlaceholder:
-        replicas: 10
+        replicas: 25
       userScheduler:
         nodeSelector: *coreNodeSelector
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -175,7 +175,7 @@ binderhub:
         enabled: true
       userPlaceholder:
         enabled: true
-        replicas: 0
+        # replicas set in config/<deployment>
     singleuser:
       networkPolicy:
         enabled: true


### PR DESCRIPTION
since it takes ~2 minutes to get a new node and we launch ~10 users per minute. This should trigger autoscale ~1 minute sooner than the current 10.

we can check [this chart](https://grafana.mybinder.org/d/nDQPwi7mk/node-activity?orgId=1&from=now-24h&to=now&panelId=43&fullscreen) to see if this seems like enough, and turn it up more, if we want.