### PR TITLE
bumping r2d 9f081a2...b61e374

### DIFF
--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -99,14 +99,16 @@ The following lines describe how to point mybinder.org to the new repo2docker im
 6. Somewhere in the file you will see `repo2dockerImage`, it will look like
    this:
 
-       repo2dockerImage: jupyter/repo2docker:65d5411
+       BinderHub:
+         build_image: jupyter/repo2docker:65d5411
 
    Where `65d5411` is the same value in `<OLD-HASH>` above.
 
 7. Replace the *old* hash that is there with what you copied in step 4.
    For example, the edited file will look similar to:
-
-       repo2dockerImage: jupyter/repo2docker:<NEW-HASH>
+       
+       BinderHub:
+         build_image: jupyter/repo2docker:<NEW-HASH>
 
 8. Merge this change to `mybinder/values.yaml` into the mybinder.org-deploy
    repository following the steps in the [Deploying a change](#deploying-a-change) section

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:9f081a2
+      build_image: jupyter/repo2docker:b61e374
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This is a repo2docker bump:

repo2docker: https://github.com/jupyter/repo2docker/compare/9f081a2...b61e374

also edits the SRE with what I think is the new syntax using the pass-through functionality on the helm chart.

cc @yuvipanda @betatim 

closes #865 (hopefully)