### PR TITLE
bump binderhub chart 2b368e4...275f286

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-2b368e4
+   version: 0.2.0-275f286
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
kubespawner 0.10


<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/2b368e4...275f286