### PR TITLE
apply prometheus annotations to hub service

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -151,6 +151,10 @@ binderhub:
       extraConfig:
         neverRestart: |
           c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
+      service:
+        annotations:
+          prometheus.io/scrape: 'true'
+          prometheus.io/path: '/hub/metrics'
     proxy:
       networkPolicy:
         enabled: true


### PR DESCRIPTION
so that hub metrics get scraped

the chart has these on the pod instead, which prometheus doesn't pick up