### PR TITLE
bump repo2docker image b61e374...72d7634

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:b61e374
+      build_image: jupyter/repo2docker:72d7634
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
this is the 0.7.0 release

this is a repo2docker version bump. See the link below for changes

https://github.com/jupyter/repo2docker/compare/b61e374...72d7634