### PR TITLE
Change the repo2docker image prefix

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,7 +10,7 @@ binderhub:
     BinderHub:
       build_node_selector: *userNodeSelector
       hub_url: https://hub.mybinder.org
-      image_prefix: gcr.io/binder-prod/r2d-aee37be-
+      image_prefix: gcr.io/binder-prod/r2d-72d7634-
       google_analytics_code: "UA-101904940-1"
       google_analytics_domain: "mybinder.org"
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,7 +4,7 @@ binderhub:
   config:
     BinderHub:
       hub_url: https://hub.staging.mybinder.org
-      image_prefix: gcr.io/binder-staging/r2d-aee37be-
+      image_prefix: gcr.io/binder-staging/r2d-72d7634-
 
   ingress:
     hosts:


### PR DESCRIPTION
We are updating the prefix to remove all images with an old version of
the notebook from our build cache.