### PR TITLE
fix nodeSelector for nginx-ingress.controller

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -144,8 +144,8 @@ prometheus:
           secretName: kubelego-tls-prometheus
 
 nginx-ingress:
-  nodeSelector: *coreNodeSelector
   controller:
+    nodeSelector: *coreNodeSelector
     service:
       loadBalancerIP: 35.202.202.188
     replicaCount: 2


### PR DESCRIPTION
it was set at the wrong level, having no effect

related to #885. I don't think that would have come up if we were doing what we thought we were all along.