### PR TITLE
bumping binderhub w/ links to docs on loading page

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-7c3271e
+   version: 0.2.0-2fe6278
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link below for a diff of new changes:

BinderHub: https://github.com/jupyterhub/binderhub/compare/7c3271e...2fe6278

Main changes are:

* More updates from @captainsafia 's awesome JS refactoring
* Link to docs in loading page