### PR TITLE
Bring in repo2docker changes to work around pip bug

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:9c2c7b6a
+      build_image: jupyter/repo2docker:8597520e
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
The latest version of pip (19.0.2) have a bug related to cache dirs
https://github.com/pypa/pip/issues/6197


This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/9c2c7b6a...8597520e
