### PR TITLE
Bump repo2docker to fix conda bug

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:8597520e
+      build_image: jupyter/repo2docker:9766c954
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This updates repo2docker to a version that correctly pins conda. We previously weren't pinning it properly and as a result got hit by a recently introduced bug in conda

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/9c2c7b6a...9766c954
