### PR TITLE
Bump binderhub to d164cdb

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-b593363
+   version: 0.2.0-d164cdb
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Brings in change to the liveness probe extending the timeout

https://github.com/jupyterhub/binderhub/compare/b593363...d164cdb