### PR TITLE
Go to a slightly older version of BinderHub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-d164cdb
+   version: 0.2.0-6bfd93b
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump, however we are going backwards to an older commit. This is because #896 went too far forwards. I think chart-press doesn't build a new chart if there were no changes to the helm chart. In this case the newer commits only changed the documentation and so didn't result in a new chart being published to https://jupyterhub.github.io/helm-chart/#development-releases-binderhub

I used `scripts/list_new_commits.py` to find the new commit to use for the bump in #896 and it only looks at the GitHub commit history, not which charts are published. Maybe we can teach it to also check the charts and issue a warning for when there is a misalignment. It is probably easy for a human to track down why there is a difference and if it is harmless or not but very hard for an automated script to decide (no chart because chart building broke or because there shouldn't be a new chart).