### PR TITLE
update dind image to 18.09.2

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -123,6 +123,10 @@ binderhub:
 
   dind:
     enabled: true
+    daemonset:
+      image:
+        name: docker
+        tag: 18.09.2-dind
 
   imageCleaner:
     enabled: true


### PR DESCRIPTION
will push this to the default in binderhub after deploy

for CVE-2019-5736

according to https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/ this is a known-safe version, though the [docker security scan](https://hub.docker.com/_/docker/?tab=tags) suggests that it may not be fixed.