### PR TITLE
Add anti-affinity rules for nginx-ingress

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -145,10 +145,8 @@ prometheus:
 
 nginx-ingress:
   controller:
-    nodeSelector: *coreNodeSelector
     service:
       loadBalancerIP: 35.202.202.188
-    replicaCount: 2
 
 static:
   ingress:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -63,7 +63,6 @@ nginx-ingress:
   controller:
     service:
       loadBalancerIP: 104.197.11.66
-    replicaCount: 2
 
 static:
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -244,7 +244,23 @@ nginx-ingress:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '10254'
   controller:
-    replicaCount: 5
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - nginx-ingress
+              - key: component
+                operator: In
+                values:
+                - controller
+            topologyKey: kubernetes.io/hostname
+    replicaCount: 2
     scope:
       enabled: true
     config:


### PR DESCRIPTION
This is a proposal for fixing some of #885.

Using anti-affinity rules we can organise for the nginx-ingress
controller pods to be spread over multiple nodes. This prevents an
outage from happening when that particular node gets cordoned.
nginx-ingress controllers are not selected when they are on a node
that is cordoned.

It is only a partial fix as we'd still end up with an outage if two nodes get cordoned at the same time and they both contain ingress controllers. I think spreading the pods across nodes is a good idea independent of fixing the cordoning problem fully.

I've not tested this locally because I only have one node in my minikube. This means we should deploy this when we have people around to check that it actually works.