### PR TITLE
Decrease total number of pods per node

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -42,7 +42,7 @@ binderhub:
     singleuser:
       nodeSelector: *userNodeSelector
       memory:
-        guarantee: 450M
+        guarantee: 550M
         limit: 2G
       cpu:
         guarantee: 0.01


### PR DESCRIPTION
This increases the memory guaranteed to each user pod as a way to reduce
the number of pods per node.

The motivation for doing this is to see if we can lower the load average per node a bit to make things fell "snappier". I think it is easy to compute how much this will cost us extra but I have no idea how much we'd have to reduce the load to get that "snappier" feeling. hence just trying some values.