### PR TITLE
Bump repo2docker to b3583029

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:9766c954
+      build_image: jupyter/repo2docker:b3583029
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This is a long overdue update, this means there is a risk that things will break :-/

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/9766c954...b3583029