### PR TITLE
Bump repo2docker to f18835fd and change build prefix

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,7 +10,7 @@ binderhub:
     BinderHub:
       build_node_selector: *userNodeSelector
       hub_url: https://hub.mybinder.org
-      image_prefix: gcr.io/binder-prod/r2d-72d7634-
+      image_prefix: gcr.io/binder-prod/r2d-f18835fd-
       google_analytics_code: "UA-101904940-1"
       google_analytics_domain: "mybinder.org"
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:b3583029
+      build_image: jupyter/repo2docker:f18835fd
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This brings inn the latest version of the notebook and updates some
other base dependencies.

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/b3583029...f18835fd
