### PR TITLE
Temporarily ban the jupyter lab demo repo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -45,6 +45,7 @@ binderhub:
       banned_specs:
         # e.g. '^org/repo.*'
         - ^ines/spacy-binder.*
+        - jupyterlab/jupyterlab-demo.*
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true


### PR DESCRIPTION
Since we cleared our docker image cache we have been learning things about our software :)

One problem relates to very popular repos that take a long time to build. For example the jupyter lab repo. We limit the number of concurrent builds of repositories so that the cluster doesn't get swamped just building. We allocated N*2 threads to allow N concurrent builds. We need N*2 threads as each build uses one to execute the build and one to stream the logs. When there are N concurrent builds new builds have to wait to start. That is the theory.

In practice what seems to happen is for lab lots of people watch the one build that is happening. In the progress they use up all the N*2 threads. As an end result we are only running one build, with lots of builds getting queued.

<img width="1058" alt="Screen Shot 2019-03-24 at 22 17 32" src="https://user-images.githubusercontent.com/1448859/54886521-0a314d00-4e89-11e9-9e9e-61884e7a80d3.png">

"Builds started by the hub" shows how many builds are waiting to happen. The sharp drop happened when I removed the lab build pod.

We need a proper fix for this. As a temporary measure we will start a build of the lab repo, then ban it and when it build is complete, unban the repo again. This means that while the build is running visitors will see a message telling them that the repo has been temporarily banned (not ideal). However they will also not use up a thread for watching the repo build which means others can go ahead and build their repositories.