### PR TITLE
Revert "Temporarily ban the jupyter lab demo repo"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -45,7 +45,6 @@ binderhub:
       banned_specs:
         # e.g. '^org/repo.*'
         - ^ines/spacy-binder.*
-        - jupyterlab/jupyterlab-demo.*
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#915 as we now have ` r2d-f18835fd-jupyterlab-2djupyterlab-2ddemo-b2f8d0 ` in our registry.