### PR TITLE
[MRG] Update our launch test to a new ref that works

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -9,7 +9,7 @@ def test_launch_binder(binder_url):
     """
     # Known good version of this repo
     repo = 'binder-examples/requirements'
-    ref = '082b794'
+    ref = 'fa84f12'
     build_url = binder_url + '/build/gh/{repo}/{ref}'.format(repo=repo, ref=ref)
     r = requests.get(build_url, stream=True)
     r.raise_for_status()


### PR DESCRIPTION
This new ref works with the newer version of repo2docker that uses a
different version of Python.

This should fix our CI which is currently failing.