### PR TITLE
Increase memory allocated to the CHP

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -62,10 +62,10 @@ binderhub:
       chp:
         resources:
           requests:
-            memory: 256Mi
+            memory: 320Mi
             cpu: "0.1"
           limits:
-            memory: 256Mi
+            memory: 320Mi
             cpu: "0.5"
       nginx:
         resources:


### PR DESCRIPTION
The CHP has been killed a few times over the last few days because of
hitting the memory limit. Increasing the limit a bit.
