### PR TITLE
repo2docker: 9bcc41af...746e4d92

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -49,7 +49,7 @@ binderhub:
         - ^RasaHQ/rasa_core.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:9bcc41af
+      build_image: jupyter/repo2docker:746e4d92
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/9bcc41af...746e4d9