### PR TITLE
bump binderhub chart f98a1d0…a21e7f1

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-f98a1d0
+   version: 0.2.0-a21e7f1
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
gets juptyerhub 1.0 beta 2


This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/f98a1d0...a21e7f1

which includes the corresponding jupyterhub chart bump:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/c83896f...03215dd