### PR TITLE
disable authentication on hub’s prometheus metrics

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -156,6 +156,8 @@ binderhub:
       extraConfig:
         neverRestart: |
           c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
+        noAuthMetrics: |
+          c.JupyterHub.authenticate_prometheus = False
       service:
         annotations:
           prometheus.io/scrape: 'true'


### PR DESCRIPTION
these are authenticated by default, but we don't need that for mybinder.org