### PR TITLE
Limit amount of memory each build can use

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -50,6 +50,7 @@ binderhub:
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:bc9554e1
+      build_memory_limit: 3G
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This will do two things:
1. each build pod will request (and be limited to) 3GB of memory
1. the `repo2docker` command will set a memory limit in the `docker build` command it executes

The first part doesn't actually limit the memory a build can use, but it makes the scheduler aware of the fact that memory is being used.

The second part does limit how much memory the build can use.