### PR TITLE
No memory limit for builds and unban rasa_core repo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -46,7 +46,6 @@ binderhub:
         # e.g. '^org/repo.*'
         - ^ines/spacy-binder.*
         - ^soft4voip/rak.*
-        - ^RasaHQ/rasa_core.*
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:bc9554e1

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -50,7 +50,6 @@ binderhub:
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:bc9554e1
-      build_memory_limit: "3G"
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
Undo the attempts to limit the memory used during builds (#953 and #954)

Also remove the ban of the rasa_core repository (see https://github.com/RasaHQ/rasa/issues/3134#issuecomment-487035066)