### PR TITLE
Bump BinderHub to 10ac4d8

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-5536a0f
+   version: 0.2.0-10ac4d8
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Set pod anti-affinity on build pods so they prefer to schedule on
separate nodes.

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/5536a0f...10ac4d8