### PR TITLE
Bump repo2docker to 9099def4

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,7 +48,7 @@ binderhub:
         - ^soft4voip/rak.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:bc9554e1
+      build_image: jupyter/repo2docker:9099def4
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This gives conda its own environment and gets us to conda 4.6.

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/bc9554e1...9099def4
