### PR TITLE
Assign resource requests and limits to pods

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -21,7 +21,7 @@ binderhub:
     resources:
       requests:
         cpu: "2"
-        memory: 1Gi
+        memory: 8Gi
       limits:
         cpu: "5"
         memory: 12Gi

--- a/mybinder/templates/analytics-publisher/deployment.yaml
+++ b/mybinder/templates/analytics-publisher/deployment.yaml
@@ -42,3 +42,10 @@ spec:
           - name: config
             mountPath: /etc/analytics-publisher
             readOnly: true
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 200Mi
+          limits:
+            cpu: 0.2
+            memory: 300Mi

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -245,6 +245,13 @@ nginx-ingress:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '10254'
   controller:
+    resources:
+      requests:
+        cpu: 0.5
+        memory: 240Mi
+      limits:
+        cpu: 0.8
+        memory: 240Mi
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This assigns memory and compute to some pods that didnn't have any resources assigned so far. `kubectl top pod <podname>` showed each using more than 50MB which is why they got a limit+request. There are more without any resources that use below that threshold. Let's see how this goes.