### PR TITLE
analytics-publisher: Bump jinja2 version

### DIFF
--- a/images/analytics-publisher/requirements.txt
+++ b/images/analytics-publisher/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-logging==1.8.0
 python-dateutil==2.7.5
 google-cloud-storage==1.13.0
-jinja2==2.10
+jinja2==2.10.1


### PR DESCRIPTION
Fix for a sandbox security escape (https://nvd.nist.gov/vuln/detail/CVE-2019-10906)
in jinja2. We are not affected by this particular vulnerability
but is good to upgrade regardless.