### PR TITLE
analytics-publisher: Cleanup cloud costs schema

### DIFF
--- a/docs/source/analytics/cloud-costs.rst
+++ b/docs/source/analytics/cloud-costs.rst
@@ -16,7 +16,12 @@ You can find the data in the `Analytics Archive
 <https://archive.analytics.mybinder.org/cloud-costs.jsonl>`_. Each line in
 the file is a JSON object, with the following keys:
 
-#. **startTime** and **endTime**
+#. **version**
+
+   Currently *1*, will be incremented when the structure of this format
+   changes.
+
+#. **start_time** and **end_time**
 
    The start and end of the billing period this item represents. These
    times are inclusive, and in pacific time observing DST (so PDT or PST).
@@ -29,4 +34,4 @@ the file is a JSON object, with the following keys:
    The cost of all cloud compute resources used during this time period. This
    is denominated in US Dollars.
 
-The lines are sorted by ``startTime``.
+The lines are sorted by ``start_time``.

--- a/images/analytics-publisher/cloudcosts.py
+++ b/images/analytics-publisher/cloudcosts.py
@@ -26,7 +26,7 @@ def totals_from_json(file):
     totals = {}
     for item in json.load(file):
         cost = float(item['cost']['amount'])
-        time_range = (item['startTime'], item['endTime'])
+        time_range = (item['start_time'], item['end_time'])
         totals[time_range] = totals.get(time_range, 0) + cost
 
     return totals
@@ -59,11 +59,16 @@ def publish_daily_cost(
 
     # We want to push out sorted jsonl
     sorted_items = [
-        { 'startTime': start_time, 'endTime': end_time, 'cost': cost }
+        {
+            'version': 1,
+            'start_time': start_time,
+            'end_time': end_time,
+            'cost': cost
+        }
         for (start_time, end_time), cost in totals.items()
     ]
 
-    sorted_items.sort(key=lambda d: d['startTime'])
+    sorted_items.sort(key=lambda d: d['start_time'])
 
     if debug:
         for item in sorted_items:


### PR DESCRIPTION
1. Use underscores rather than camelCase, to match python
   conventions
2. Add a 'version' field so we can do clean upgrades when
   needed