### PR TITLE
Ban shishirchoudharygic/mltraining

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,6 +48,7 @@ binderhub:
         - ^ines/spacy-binder.*
         - ^soft4voip/rak.*
         - ^hmharshit/cn-ait.*
+        - ^shishirchoudharygic/mltraining/*
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:25ebca04


### PR DESCRIPTION
shishirchoudharygic/mltraining is launching and launching and launching new pods but never seems to do anything with them. I posted on their repo earlier today shishirchoudharygic/mltraining#1 asking if they knew what is happening. Banning for now to see if that provokes a reaction.

My assumption is that it is some browser/script/JS/event stream thing gone awry.