### PR TITLE
Bump repo2docker and binderhub

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -12,5 +12,5 @@ dependencies:
    version: 0.4.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: binderhub
-   version: 0.2.0-82fc209
+   version: 0.2.0-9f83710
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -51,7 +51,7 @@ binderhub:
         - ^shishirchoudharygic/mltraining.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:91309cab
+      build_image: jupyter/repo2docker:80b979f8
       per_repo_quota: 100
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
Combined PR to update both r2d and bhub.

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/82fc209...9f83710

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/91309cab...80b979f8
