### PR TITLE
Add hmharshit/mltraining which is a fork of a previously banned repo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -49,6 +49,7 @@ binderhub:
         - ^soft4voip/rak.*
         - ^hmharshit/cn-ait.*
         - ^shishirchoudharygic/mltraining.*
+        - ^hmharshit/mltraining.*
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:80b979f8


### PR DESCRIPTION
Bans this fork as well. There has been no response on the issue in the repo that I posted when we banned this before.

ref: #974 