### PR TITLE
Use "weird" timeouts

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -48,7 +48,7 @@ def push_dummy_gh_branch(repo, branch, keyfile):
 
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(498)
 def test_build_binder(binder_url):
     """
     We can launch an image that we know hasn't been built

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -2,7 +2,7 @@ import json
 import pytest
 import requests
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(497)
 def test_launch_binder(binder_url):
     """
     We can launch an image that most likely already has been built.


### PR DESCRIPTION
Use longer timeouts as we seem to run into timeout issues and use "weird" values so we can see if the timout reported in the travis logs is actually caused by our timeout settinngs or somewhere else.