### PR TITLE
Enable frederick on staging, change staging hostnames around

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -3,12 +3,12 @@ projectName: binder-staging
 binderhub:
   config:
     BinderHub:
-      hub_url: https://hub.staging.mybinder.org
+      hub_url: https://hub.gke.staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
 
   ingress:
     hosts:
-      - staging.mybinder.org
+      - gke.staging.mybinder.org
 
   jupyterhub:
     singleuser:
@@ -20,11 +20,11 @@ binderhub:
         limit: 0.5
     ingress:
       hosts:
-        - hub.staging.mybinder.org
+        - hub.gke.staging.mybinder.org
       tls:
         - secretName: kubelego-tls-jupyterhub-staging
           hosts:
-            - hub.staging.mybinder.org
+            - hub.gke.staging.mybinder.org
     scheduling:
       userPlaceholder:
         replicas: 2
@@ -104,3 +104,16 @@ gcsProxy:
   buckets:
     - name: mybinder-staging-events-archive
       host: archive.analytics.staging.mybinder.org
+
+federationRedirect:
+  host: staging.mybinder.org
+  enabled: true
+  hosts:
+    gke:
+      url: https://gke.staging.mybinder.org
+      weight: 4
+      health: https://gke.staging.mybinder.org/versions
+    ovh:
+      url: https://ovh.mybinder.org
+      weight: 1
+      health: https://ovh.mybinder.org/versions

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -396,10 +396,10 @@ federationRedirect:
     jitter: 0.1
   hosts:
     gke:
-      url: https://mybinder.org
+      url: https://gke.mybinder.org
       weight: 4
-      health: https://mybinder.org/versions
+      health: https://gke.mybinder.org/versions
     ovh:
-      url: https://binder.mybinder.ovh
+      url: https://ovh.mybinder.org
       weight: 1
-      health: https://binder.mybinder.ovh/versions
+      health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
See #999 for details.

This is a trial to find out what happens when we switch a running cluster to using the federation redirector. In particular I want to check that all certificates continue to work in addition to actually sending traffic to the right places.