### PR TITLE
Set badge base URL for all clusters

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -4,6 +4,7 @@ binderhub:
   config:
     BinderHub:
       hub_url: https://hub-binder.mybinder.ovh
+      badge_base_url: https://mybinder.org
       image_prefix: binder-registry.mybinder.ovh/binder-ovh/r2d-f18835fd-
     DockerRegistry:
       token_url: https://auth-binder-registry.mybinder.ovh/auth?service=binder-registry

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,6 +10,7 @@ binderhub:
     BinderHub:
       build_node_selector: *userNodeSelector
       hub_url: https://hub.mybinder.org
+      badge_base_url: https://mybinder.org
       image_prefix: gcr.io/binder-prod/r2d-f18835fd-
       google_analytics_code: "UA-101904940-1"
       google_analytics_domain: "mybinder.org"

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -4,6 +4,7 @@ binderhub:
   config:
     BinderHub:
       hub_url: https://hub.gke.staging.mybinder.org
+      badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
 
   ingress:


### PR DESCRIPTION
This sets the "base URL" used to generate badges for all three of our clusters. staging will use `staging.mybinder.org`. OVH and prod will use `mybinder.org` as base URL.