### PR TITLE
Add a second hostname for the staging cluster

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -10,6 +10,7 @@ binderhub:
   ingress:
     hosts:
       - gke.staging.mybinder.org
+      - gke2.staging.mybinder.org
 
   jupyterhub:
     singleuser:
@@ -115,6 +116,6 @@ federationRedirect:
       weight: 4
       health: https://gke.staging.mybinder.org/versions
     ovh:
-      url: https://ovh.mybinder.org
+      url: https://gke2.staging.mybinder.org
       weight: 1
-      health: https://ovh.mybinder.org/versions
+      health: https://gke2.staging.mybinder.org/versions


### PR DESCRIPTION
This adds a second hostname on which staging will reply `gke2.staging.mybinder.org`. This means we can configure the staging federation to use the same cluster twice instead of having to use an external cluster.