### PR TITLE
Disable redirector on staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_deploy:
   python ./deploy.py staging staging
 - |
   # Stage 4, Step 2: Verify staging works
-  travis_retry py.test -vx -n 2 --binder-url=https://gke.staging.mybinder.org --hub-url=https://hub.gke.staging.mybinder.org
+  travis_retry py.test -vx -n 2 --binder-url=https://staging.mybinder.org --hub-url=https://hub.gke.staging.mybinder.org
 - |
   # Stage 5, Step 1: Post message to Grafana that deployment to production has started
   source secrets/grafana-api-key

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -11,6 +11,7 @@ binderhub:
     hosts:
       - gke.staging.mybinder.org
       - gke2.staging.mybinder.org
+      - staging.mybinder.org
 
   jupyterhub:
     singleuser:
@@ -109,7 +110,7 @@ gcsProxy:
 
 federationRedirect:
   host: staging.mybinder.org
-  enabled: true
+  enabled: false
   hosts:
     gke:
       url: https://gke.staging.mybinder.org


### PR DESCRIPTION
This PR will disable the redirector on staging. The goal of this exercise is to find out if we can do this without causing a big interruption. Knowing we can back out of the switch to using a redirector will be useful when we enable it on production.

ref: #999