### PR TITLE
Revert "Disable redirector on staging" to enable it again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_deploy:
   python ./deploy.py staging staging
 - |
   # Stage 4, Step 2: Verify staging works
-  travis_retry py.test -vx -n 2 --binder-url=https://staging.mybinder.org --hub-url=https://hub.gke.staging.mybinder.org
+  travis_retry py.test -vx -n 2 --binder-url=https://gke.staging.mybinder.org --hub-url=https://hub.gke.staging.mybinder.org
 - |
   # Stage 5, Step 1: Post message to Grafana that deployment to production has started
   source secrets/grafana-api-key

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -11,7 +11,6 @@ binderhub:
     hosts:
       - gke.staging.mybinder.org
       - gke2.staging.mybinder.org
-      - staging.mybinder.org
 
   jupyterhub:
     singleuser:
@@ -110,7 +109,7 @@ gcsProxy:
 
 federationRedirect:
   host: staging.mybinder.org
-  enabled: false
+  enabled: true
   hosts:
     gke:
       url: https://gke.staging.mybinder.org


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1005 as that was a temporary test. Nothing bad happened and this is a way that doesn't require typing to restore the previous stage.