### PR TITLE
Enable federation for mybinder.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,13 +89,13 @@ before_deploy:
   python ./deploy.py prod prod-a
 - |
   # Stage 5, Step 3: Verify production works
-  travis_retry py.test -vx -n 2 --binder-url=https://mybinder.org --hub-url=https://hub.mybinder.org
+  travis_retry py.test -vx -n 2 --binder-url=https://gke.mybinder.org --hub-url=https://hub.gke.mybinder.org
 - |
   # Stage 5, Step 4: Deploy to production on ovh k8s
   python ./deploy.py ovh binder-ovh
 - |
   # Stage 5, Step 5: Verify production on ovh k8s works
-  travis_retry py.test -vx -n 2 --binder-url=https://binder.mybinder.ovh --hub-url=https://hub-binder.mybinder.ovh
+  travis_retry py.test -vx -n 2 --binder-url=https://ovh.mybinder.org --hub-url=https://hub-binder.mybinder.ovh
 
 
 env:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -78,10 +78,12 @@ binderhub:
             cpu: 1
     ingress:
       hosts:
+        - hub.mybinder.org
         - hub.gke.mybinder.org
       tls:
         - secretName: kubelego-tls-jupyterhub-prod
           hosts:
+            - hub.mybinder.org
             - hub.gke.mybinder.org
     scheduling:
       userPlaceholder:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -9,7 +9,7 @@ binderhub:
   config:
     BinderHub:
       build_node_selector: *userNodeSelector
-      hub_url: https://hub.mybinder.org
+      hub_url: https://hub.gke.mybinder.org
       badge_base_url: https://mybinder.org
       image_prefix: gcr.io/binder-prod/r2d-f18835fd-
       google_analytics_code: "UA-101904940-1"
@@ -29,7 +29,7 @@ binderhub:
 
   ingress:
     hosts:
-      - mybinder.org
+      - gke.mybinder.org
 
   resources:
     requests:
@@ -78,11 +78,11 @@ binderhub:
             cpu: 1
     ingress:
       hosts:
-        - hub.mybinder.org
+        - hub.gke.mybinder.org
       tls:
         - secretName: kubelego-tls-jupyterhub-prod
           hosts:
-            - hub.mybinder.org
+            - hub.gke.mybinder.org
     scheduling:
       userPlaceholder:
         replicas: 25
@@ -213,5 +213,5 @@ gcsProxy:
       host: archive.analytics.mybinder.org
 
 federationRedirect:
-  host: my.bndr.it
+  host: mybinder.org
   enabled: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -386,7 +386,7 @@ analyticsPublisher:
     kind: csv
 
 federationRedirect:
-  host: my.bndr.it
+  host: mybinder.org
   enabled: false
   image:
     name: set-by-chartpress
@@ -397,9 +397,9 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 4
+      weight: 98
       health: https://gke.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 1
+      weight: 2
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
This PR switches mybinder.org to be a federation. Traffic will be sent to the existing GKE cluster and the OVH cluster. The weights are set to 98 and 2 respectively. This means we will send 2% of the traffic to OVH to start with.

I built https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb and https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/master?urlpath=lab%2Ftree%2Fdemo%2FLorenz.ipynb "by hand" on the OVH cluster so that the images are available. These are the most popular repos this is why I picked them for pre-building.

ref: #999 

To back-out of this we can revert this PR and/or look at #1005 where we did this for staging.