### PR TITLE
Automatically deploy ovh ingress for the 'ovh.mybinder.org' certificate

### DIFF
--- a/config/ovh/ovh_mybinder_org_ingress.yaml
+++ b/config/ovh/ovh_mybinder_org_ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ovh-mybinder-org
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: ovh.mybinder.org
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: binder
+              servicePort: 8585
+  tls:
+    - secretName: kubelego-tls-binder-ovh
+      hosts:
+        - "ovh.mybinder.org"

--- a/deploy.py
+++ b/deploy.py
@@ -32,6 +32,22 @@ def setup_auth_ovh(release, cluster):
     print(stdout.decode('utf8'))
 
 
+def setup_ovh_ingress_link(release):
+    """
+    Setup the Ingress link ovh.mybinder.org -> binder.mybinder.ovh
+    """
+    ovh_ingress_path = os.path.join(ABSOLUTE_HERE, 'config', 'ovh', 'ovh_mybinder_org_ingress.yaml')
+    stdout = subprocess.check_output([
+        'kubectl',
+        'apply',
+        '-f',
+        ovh_ingress_path,
+        '-n',
+        release
+    ])
+    print(stdout.decode('utf8'))
+
+
 def setup_auth_gcloud(release, cluster):
     """
     Set up GCloud + Kubectl authentication for talking to a given cluster
@@ -165,6 +181,7 @@ def main():
 
     if args.cluster == 'binder-ovh':
         setup_auth_ovh(args.release, args.cluster)
+        setup_ovh_ingress_link(args.release)
     else:
         setup_auth_gcloud(args.release, args.cluster)
 

--- a/docs/source/production_environment.md
+++ b/docs/source/production_environment.md
@@ -167,6 +167,14 @@ recommend running the standard Kubernetes debugging commands with the
 kubectl --namespace=<my-namespace> logs <kube-lego-object>
 ```
 
+### Exceptions on the OVH cluster
+
+On the OVH cluster all the binder components use a specific certificate on `*.mybinder.ovh` domain.
+
+Traffic for `ovh.mybinder.org` is redirected with a CNAME on `binder.mybinder.ovh`. That's why the OVH cluster should be able to serve 2 different certificates.
+
+- The `*.mybinder.ovh` certificate is managed by ingresses in the ovh helm configuration.
+- The `ovh.mybinder.org` certificate is managed by a specific ingress and `kube-lego` on the launch of `deploy.py` on the ovh stack.
 
 ## Secrets
 


### PR DESCRIPTION
On the OVH k8s instance we need to automatically deploy a specific ingress for serving the correct certificate if user are coming from the `ovh.mybinder.org` url.

I choose to do this outside the helm deployment because it is very specific to the ovh deployment.