### PR TITLE
Increase OVH cluster to 5% of traffic

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -401,9 +401,9 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 98
+      weight: 95
       health: https://gke.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 2
+      weight: 5
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
With the launch event logging in place, let's increase the traffic to 5%.