### PR TITLE
Increase memory request and limit for nginx-ingress

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -252,10 +252,10 @@ nginx-ingress:
     resources:
       requests:
         cpu: 0.5
-        memory: 240Mi
+        memory: 280Mi
       limits:
         cpu: 0.8
-        memory: 240Mi
+        memory: 340Mi
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The ingress has been OOMKilled a few times today so increasing its
memory limit and request.