### PR TITLE
Lower traffic fraction sent to OVH

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -401,9 +401,9 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 90
+      weight: 95
       health: https://gke.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 10
+      weight: 5
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
The current cluster can't schedule more than 40 user pods so for the
moment we reduce the amount of traffic sent there.

<img width="503" alt="Screen Shot 2019-06-11 at 15 50 17" src="https://user-images.githubusercontent.com/1448859/59277552-b270d980-8c60-11e9-83d3-7dfbecddf293.png">

One small mystery is why there are over 40 pods here in the first place as there are only ~300 pods on GKE and I thought we are sending 10% of the traffic ... :-)

<img width="506" alt="Screen Shot 2019-06-11 at 15 50 24" src="https://user-images.githubusercontent.com/1448859/59277677-ea781c80-8c60-11e9-88d7-b1a01dcb08e9.png">
