### PR TITLE
Reduce OVH fractionn while we fix the GitHub API issue

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -403,9 +403,9 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 75
+      weight: 95
       health: https://gke.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 25
+      weight: 5
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
Launches on the OVH cluster are failing because we have exceeded our GitHub API limit. While we investigate -> reduce traffic to OVH.