### PR TITLE
Reduce OVH fraction to zero

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -403,9 +403,9 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 95
+      weight: 100
       health: https://gke.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 5
+      weight: 0
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
In addition to the GitHub API problem we also seem to have problems with pulling images from the registry. Reducing the traffic to zero for now.