### PR TITLE
Make the federation redirector smarter

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -400,11 +400,14 @@ federationRedirect:
   check:
     period: 10
     jitter: 0.1
+    retries: 3
+    timeout: 2
   hosts:
     gke:
       url: https://gke.mybinder.org
       weight: 100
       health: https://gke.mybinder.org/versions
+      prime: true
     ovh:
       url: https://ovh.mybinder.org
       weight: 0


### PR DESCRIPTION
Instead of removing a cluster after one failed health check retry them
before removing them from the rotation. Allow a target to be marked as a
"prime" that will never be removed from the rotation, even if it is
unhealthy.