### PR TITLE
Handle 404s for the federation redirector

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -164,6 +164,7 @@ def make_app():
                 {"url": "https://gke.mybinder.org/about", "permanent": True},
             ),
             (r"/", RedirectHandler),
+            (r".*", RedirectHandler),
         ],
         hosts=hosts,
         cookie_secret="get-me-dynamically",

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -167,7 +167,7 @@ def make_app():
         ],
         hosts=hosts,
         cookie_secret="get-me-dynamically",
-        debug=True,
+        debug=False,
     )
 
     # start monitoring all our potential hosts


### PR DESCRIPTION
Fixes #1041 

In #1041 we were talking about adding a template to properly handle errors by copying it from BinderHub (or even using `importlib.resources`). 

But we can also just add another redirect and let `gke` or `ovh` handle the 404s?

In the end the changes are:

- Set `debug=False`
- Add one more redirect handler

cc @betatim 
