### PR TITLE
Changing the OVH registry to use (second try)

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -6,6 +6,8 @@ binderhub:
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       image_prefix: dlqpwel7.gra5.container-registry.ovh.net/binder/r2d-f18835fd-
+    DockerRegistry:
+      token_url: https://dlqpwel7.gra5.container-registry.ovh.net/service/token?service=harbor-registry
   registry:
     url: https://dlqpwel7.gra5.container-registry.ovh.net
     username: cLxohgOONW


### PR DESCRIPTION
Second try for https://github.com/jupyterhub/mybinder.org-deploy/pull/1054

This time we also added a token url like so :  

```
DockerRegistry:
    token_url: https://dlqpwel7.gra5.container-registry.ovh.net/service/token?service=harbor-registry
```