### PR TITLE
Send 5% of traffic to OVH

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -405,10 +405,10 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 100
+      weight: 95
       health: https://gke.mybinder.org/versions
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 5
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
The issue with the registry was related to a restart of the kubernetes cluster that hosts the registry. @mael-le-gal is still finding out why exactly this lead to the registry becoming unavailable.

As the downtime wasn't related to our usage we are bringing OVH back to 5% of traffic with a plan to step it up to 15% over the next few working days.