### PR TITLE
Use the new per spec config system

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -55,6 +55,10 @@ binderhub:
         - ^jupyter/.*
         - ^jupyterhub/.*
         - ^jupyter-widgets/.*
+      spec_config:
+        - pattern: ^ipython/ipython-in-depth.*
+          config:
+            quota: 128
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
Increases the limit for the iPython demo repo linked from
try.jupyter.org to 128.

If this works well we can start migrating other repos to this setup.