### PR TITLE
Bump OVH cluster down to 0 because it's down

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,10 +420,10 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 85
+      weight: 100
       health: https://gke.mybinder.org/versions
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 15
+      weight: 0
       health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
This bumps the OVH usage to 0 because their hub isn't spawning new servers