### PR TITLE
Disable user scheduler on OVH which isn't auto-scaling

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -92,8 +92,12 @@ binderhub:
             - hub-binder.mybinder.ovh
 
     scheduling:
+      userScheduler:
+        enabled: false
+      podPriority:
+        enabled: false
       userPlaceholder:
-        replicas: 2
+        enabled: false
 
 grafana:
   ingress:


### PR DESCRIPTION
There is no cluster autoscaler on OVH so we don't need to be smart about
scheduling pods. Experimenting what things look like without the custom
scheduler.