### PR TITLE
Treat weight zero hosts as if they didn't exist

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -97,8 +97,8 @@ class RedirectHandler(RequestHandler):
     def prepare(self):
         # copy hosts config in case it changes while we are iterating over it
         hosts = dict(self.settings["hosts"])
-        self.host_names = [c["url"] for c in hosts.values()]
-        self.host_weights = [c["weight"] for c in hosts.values()]
+        self.host_names = [c["url"] for c in hosts.values() if c["weight"] > 0]
+        self.host_weights = [c["weight"] for c in hosts.values() if c["weight"] > 0]
 
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Origin", "*")

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -423,3 +423,7 @@ federationRedirect:
       weight: 100
       health: https://gke.mybinder.org/versions
       prime: true
+    ovh:
+      url: https://ovh.mybinder.org
+      weight: 0
+      health: https://ovh.mybinder.org/versions


### PR DESCRIPTION
The federation proxy would treat hosts with weight zero as if they were
still part of the rotation when checking if a cookie based decision was
still valid. This PR fixes that and adds OVH back with weight zero.