### PR TITLE
Reduce traffic to OVH as the registry there has problems

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,10 +420,10 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 85
+      weight: 100
       health: https://gke.mybinder.org/health
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 15
+      weight: 0
       health: https://ovh.mybinder.org/health


### PR DESCRIPTION
Interestingly calling `/health` on ovh.mybinder.org doesn't show any
problems with the registry.
