### PR TITLE
Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!--
+Welcome!
+
+✨✨✨✨
+This is the **deployment repository** for mybinder.org. If you've got
+a question or comment about the Binder Project, then please open an issue
+at https://github.com/jupyterhub/binder/issues/new.
+
+Thanks!
+✨✨✨✨
+-->


### PR DESCRIPTION
This adds an issue template directing people to the binder repository instead of this one. cc @betatim 