### PR TITLE
Increasing OVH to 15%

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,10 +420,10 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 100
+      weight: 85
       health: https://gke.mybinder.org/health
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 15
       health: https://ovh.mybinder.org/health


### PR DESCRIPTION
Increasing traffic again. With the new health checker that (hopefully) correctly considers the health of the respective docker registries we should have less need to reduce the traffic manually as it will be taken care of automatically.