### PR TITLE
Wait for 300s before rechecking an unhealthy cluster

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -165,7 +165,7 @@ async def health_check(host, active_hosts):
         # and wait longer than usual to check it again
         jitter = check_config["jitter"] * (0.5 - random.random())
         IOLoop.current().call_later(
-            2 * (1 + jitter) * check_config["period"], health_check, host, active_hosts
+            30 * (1 + jitter) * check_config["period"], health_check, host, active_hosts
         )
 
     else:


### PR DESCRIPTION
Increase the "lag" in how long we wait before rechecking a cluster to avoid flipflopping too much between "healthy" and "unhealthy".