### PR TITLE
Federation proxy, consider capacity when picking a target

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -3,6 +3,7 @@ projectName: ovh
 binderhub:
   config:
     BinderHub:
+      pod_quota: 50
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       image_prefix: dlqpwel7.gra5.container-registry.ovh.net/binder/r2d-f18835fd-

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -215,5 +215,4 @@ gcsProxy:
       host: archive.analytics.mybinder.org
 
 federationRedirect:
-  host: mybinder.org
   enabled: true

--- a/images/federation-redirect/README.rst
+++ b/images/federation-redirect/README.rst
@@ -12,10 +12,12 @@ endpoints to a randomly chosen hub, the redirect target.
 The list of potential redirect targets is configured at start-up. Each target
 consists of a hostname, a weighting factor and a URL to check the hubs health.
 For each request a weighted random choice of all healthy targets is made and
-the visitor is redirector there.
+the visitor is redirected there.
 
 Periodically the redirector will ``GET`` the health check URL for a target. If
-it returns an error the target is removed from the list of healthy targets.
+it returns an error or any of services
+(``Docker registry``, ``JupyterHub API`` and ``Pod quota``) is unhealthy,
+the target is removed from the list of healthy targets.
 Unhealthy targets are checked less frequently but once they return to good
 health they are automatically added back to the list of viable targets.
 

--- a/images/federation-redirect/README.rst
+++ b/images/federation-redirect/README.rst
@@ -15,8 +15,8 @@ For each request a weighted random choice of all healthy targets is made and
 the visitor is redirected there.
 
 Periodically the redirector will ``GET`` the health check URL for a target. If
-it returns an error or any of services
-(``Docker registry``, ``JupyterHub API`` and ``Pod quota``) is unhealthy,
+it returns an error (if ``Docker registry`` or ``JupyterHub API`` is unhealthy)
+or the target is over its quota (``Pod quota``),
 the target is removed from the list of healthy targets.
 Unhealthy targets are checked less frequently but once they return to good
 health they are automatically added back to the list of viable targets.

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -23,13 +23,13 @@ CONFIG = {
         "gke": dict(
             url="https://gke.mybinder.org",
             weight=1,
-            health="https://gke.mybinder.org/versions",
+            health="https://gke.mybinder.org/health",
             prime=True,
         ),
         "ovh": dict(
             url="https://ovh.mybinder.org",
             weight=1,
-            health="https://ovh.mybinder.org/versions",
+            health="https://ovh.mybinder.org/health",
             # health="https://httpbin.org/status/404",
         ),
     },


### PR DESCRIPTION
For #1144:

- [ ] extend the federation proxy to take into account whether or not a hub is above its capacity when picking a target
- [x] configure pod quota of OVH as 50
- [ ] Update README.md of federation-redirect (https://github.com/jupyterhub/mybinder.org-deploy/blob/master/images/federation-redirect/README.rst)