### PR TITLE
Trust X-Forwarded-For headers in the redirector

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -243,7 +243,7 @@ def main():
     enable_pretty_logging()
 
     app = make_app()
-    app.listen(8080)
+    app.listen(8080, xheaders=True)
     tornado.ioloop.IOLoop.current().start()
 
 


### PR DESCRIPTION
This way we get the real IP addresses of people visiting mybinder.org in the logs.