### PR TITLE
[ISSUE-1160] Switching on ovh traffic

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,12 +420,12 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 99
+      weight: 85
       health: https://gke.mybinder.org/health
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 14
       health: https://ovh.mybinder.org/health
     gesis:
       url: https://notebooks.gesis.org/binder


### PR DESCRIPTION
Upgraded the ovh cluster from `1.11.x` to `1.14.x` => everything is green on my side so I think we can switch on the traffic on `ovh` again :)