### PR TITLE
Revert "repo2docker: 0.10.0-59.g649a2c6...0.10.0-78.gbfbec34"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -65,7 +65,7 @@ binderhub:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:0.10.0-78.gbfbec34
+      build_image: jupyter/repo2docker:0.10.0-59.g649a2c6
       per_repo_quota: 100
       per_repo_quota_higher: 200
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1164

```
Step 34/69 : RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/" > /etc/apt/sources.list.d/r3.6-ubuntu.list
 ---> Running in eb9cee582509
Removing intermediate container eb9cee582509
 ---> fbdd7557a542
Step 35/69 : RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 ---> Running in eb9d5a1e819e
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.agoEkwiTU1/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
gpg: keyserver receive failed: Connection timed out
Removing intermediate container eb9d5a1e819e
The command '/bin/sh -c apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9' returned a non-zero code: 2
```

reverting to debug