### PR TITLE
Enable sticky builds on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -6,6 +6,7 @@ binderhub:
       hub_url: https://hub.gke.staging.mybinder.org
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
+      sticky_builds: true
 
   ingress:
     hosts:


### PR DESCRIPTION
This enabled "sticky builds" on staging.

The result should be that a particular repo is always built on the same node (as long as the cluster remains unchanged). After some testing we should try and enable it on production as well.