### PR TITLE
Increase the weight of OVH

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,12 +420,12 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 85
+      weight: 80
       health: https://gke.mybinder.org/health
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 14
+      weight: 19
       health: https://ovh.mybinder.org/health
     gesis:
       url: https://notebooks.gesis.org/binder


### PR DESCRIPTION
Increase the weight with the goal of maxing out the
quota of 90 pods that we have set for OVH. When we
are above the quota OVH will be removed from the
rotation so we won't send too much traffic.