### PR TITLE
Increase OVH pod quota

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -3,7 +3,7 @@ projectName: ovh
 binderhub:
   config:
     BinderHub:
-      pod_quota: 90
+      pod_quota: 120
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       image_prefix: dlqpwel7.gra5.container-registry.ovh.net/binder/r2d-f18835fd-


### PR DESCRIPTION
Keep increasing the quota till we find the limit of the cluster.

I think we will be able to fit around 23 user pods onto a node.