### PR TITLE
reduce traffic to GESIS to 0 temporarily for 07.10

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,7 +420,7 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 80
+      weight: 81
       health: https://gke.mybinder.org/health
       prime: true
     ovh:
@@ -429,5 +429,5 @@ federationRedirect:
       health: https://ovh.mybinder.org/health
     gesis:
       url: https://notebooks.gesis.org/binder
-      weight: 1
+      weight: 0
       health: https://notebooks.gesis.org/binder/health


### PR DESCRIPTION
Hi, on 07.10 there will be maintenance on one of our servers. We don't expect downtime but since it is our big server, we will lose big amount of resources temporarily (less capacity of having user pods) and we expect that everything will be slow (the other server has to download docker images from hub).

It would be perfect if we could have this PR merged during Sunday. When the maintenance is done, I will make another PR to increase it again. Maybe that time we even increase it to 5% :)