### PR TITLE
Remove defunct playground config

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -249,12 +249,6 @@ binderhub:
               add:
                 - NET_ADMIN
 
-playground:
-  image:
-    name: yuvipanda/play.nteract.io
-    tag: v0.2
-  replicas: 1
-
 nginx-ingress:
   rbac:
     create: true


### PR DESCRIPTION
We used to have a play.mybinder.org, but don't anymore.
Use https://play.nteract.io/ instead
