### PR TITLE
handler to show active hosts

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -132,8 +132,7 @@ class ActiveHostsHandler(RequestHandler):
         self.active_hosts = active_hosts
 
     async def get(self):
-        self.set_header("Content-type", "application/json")
-        self.write(json.dumps({"active_hosts": self.active_hosts}))
+        self.write({"active_hosts": self.active_hosts})
 
 
 async def health_check(host, active_hosts):

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -126,6 +126,16 @@ class RedirectHandler(RequestHandler):
         self.redirect(url)
 
 
+class ActiveHostsHandler(RequestHandler):
+    """Serve information about active hosts"""
+    def initialize(self, active_hosts):
+        self.active_hosts = active_hosts
+
+    async def get(self):
+        self.set_header("Content-type", "application/json")
+        self.write(json.dumps({"active_hosts": self.active_hosts}))
+
+
 async def health_check(host, active_hosts):
     check_config = CONFIG["check"]
     all_hosts = CONFIG["hosts"]
@@ -247,6 +257,7 @@ def make_app():
                 tornado.web.RedirectHandler,
                 {"url": "https://static.mybinder.org/badge.svg", "permanent": True},
             ),
+            (r"/active_hosts", ActiveHostsHandler, {"active_hosts": hosts}),
             (r".*", ProxyHandler, {"host": prime_host}),
         ],
         hosts=hosts,


### PR DESCRIPTION
It would be nice to see current list of active hosts in federation. For example at the beginning of this week, I set `pod_quota` to 0 but I was not sure if GESIS Binder was really removed from active hosts, because the number of launched pods were are not decreased as we expected.

Now I am thinking it may be even nicer to serve this data in a form that we can display in grafana.