### PR TITLE
[MRG] Update prometheus chart to version 9.1.2

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
    version: 0.20.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
-   version: 7.4.4
+   version: 9.1.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
    version: 1.18.0


### PR DESCRIPTION
This brings us to version 2.11.1 of Prometheus from 2.5.0.

This will drop our default retention period to 15d instead of 60d. A few days ago we exceeded the disk space on the OVH cluster that was available for prometheus. Hopefully dropping the retention period will prevent that from happening in the future.