### PR TITLE
Remove GESIS from the staging federation

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -115,10 +115,12 @@ federationRedirect:
     gke:
       url: https://gke.staging.mybinder.org
       weight: 4
-      health: https://gke.staging.mybinder.org/versions
+      health: https://gke.staging.mybinder.org/health
+      versions: https://gke.staging.mybinder.org/versions
     ovh:
       url: https://gke2.staging.mybinder.org
       weight: 1
-      health: https://gke2.staging.mybinder.org/versions
+      health: https://gke2.staging.mybinder.org/health
+      versions: https://gke2.staging.mybinder.org/versions
     # unset the gesis entry
     gesis: null

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -120,3 +120,5 @@ federationRedirect:
       url: https://gke2.staging.mybinder.org
       weight: 1
       health: https://gke2.staging.mybinder.org/versions
+    # unset the gesis entry
+    gesis: null

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -53,6 +53,15 @@ else:
     app_log.warning("Using default config!")
 
 
+# Remove empty entries from CONFIG["hosts"], these can happen because we
+# can't remove keys in our helm templates/config files. All we can do is
+# set them to Null/None. We need to turn the keys into a list so that we
+# can modify the dict while iterating over it
+for h in list(CONFIG["hosts"].keys()):
+    if CONFIG["hosts"][h] is None:
+        CONFIG["hosts"].pop(h)
+
+
 class ProxyHandler(RequestHandler):
     def initialize(self, host):
         self.host = host


### PR DESCRIPTION
Helm merges the different config files instead of overwriting them. This means we ended up with Gesis as part of the staging federation which wasn't intended.

The health and versions endpoints hadn't been updated in a while either.