### PR TITLE
Add pod anti-affinity to federation redirect

### DIFF
--- a/mybinder/templates/federation-redirect/deployment.yaml
+++ b/mybinder/templates/federation-redirect/deployment.yaml
@@ -14,6 +14,16 @@ spec:
       app: federation-redirect
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - federation-redirect
+        topologyKey: "kubernetes.io/hostname"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Keep our federation redirectors on different nodes. This
way they don't both become unavailable if the node is
cordoned.