### PR TITLE
Add some placeholder pods to OVH

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -99,7 +99,7 @@ binderhub:
       podPriority:
         enabled: false
       userPlaceholder:
-        enabled: false
+        enabled: 5
 
 grafana:
   ingress:

--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -97,7 +97,7 @@ binderhub:
       userScheduler:
         enabled: false
       podPriority:
-        enabled: false
+        enabled: true
       userPlaceholder:
         enabled: 5
 


### PR DESCRIPTION
With placeholder pods in place we can figure out the capacity
of the OVH cluster without having to risk actual user pods
being above the limit.

My idea is that we can keep increasing usage of the cluster until we see that not all placeholder pods can be scheduled any more. This tells us how many user pods can be scheduled in total without the need to have actual user's pods in a pending state.