### PR TITLE
adding binder buttons to Notebook UI

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,13 +1,17 @@
 import os
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
 
-federation_host = 'https://mybinder.org'
-current_hosts = ['https://gke.mybinder.org', 'https://ovh.mybinder.org']
-binder_url = os.environ.get('BINDER_URL', federation_host)
-persistent_binder_url = os.environ.get('PERSISTENT_BINDER_URL', '')
-for h in current_hosts:
-    binder_url = binder_url.replace(h, federation_host)
-    persistent_binder_url = persistent_binder_url.replace(h, federation_host)
+
+def make_federation_url(url):
+    federation_host = 'https://mybinder.org'
+    if not url:
+        return federation_host
+    url_parts = url.split('/v2/', 1)
+    return federation_host + '/v2/' + url_parts[-1]
+
+
+binder_url = make_federation_url(os.environ.get('BINDER_URL', ''))
+persistent_binder_url = make_federation_url(os.environ.get('PERSISTENT_BINDER_URL', ''))
 
 c.NotebookApp.jinja_template_vars.update({
     'binder_url': binder_url,

--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,5 +1,17 @@
 import os
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
+
+federation_host = 'https://mybinder.org'
+current_hosts = ['https://gke.mybinder.org', 'https://ovh.mybinder.org']
+binder_url = os.environ.get('BINDER_URL', federation_host)
+persistent_binder_url = os.environ.get('PERSISTENT_BINDER_URL', '')
+for h in current_hosts:
+    binder_url = binder_url.replace(h, federation_host)
+    persistent_binder_url = persistent_binder_url.replace(h, federation_host)
+
 c.NotebookApp.jinja_template_vars.update({
-    'binder_url': os.environ.get('BINDER_URL', 'https://mybinder.org'),
+    'binder_url': binder_url,
+    'persistent_binder_url': persistent_binder_url,
+    'repo_url': os.environ.get('REPO_URL', ''),
+    'ref_url': os.environ.get('REF_URL', ''),
 })

--- a/mybinder/files/etc/jupyter/templates/login.html
+++ b/mybinder/files/etc/jupyter/templates/login.html
@@ -1,6 +1,13 @@
 {% extends "templates/login.html" %}
-{% block site %}
 
+{% block header_buttons %}
+{% block login_widget %}
+{% endblock %}
+<span class="flex-spacer"></span>
+{{super()}}
+{% endblock header_buttons %}
+
+{% block site %}
 <div id="ipython-main-app" class="container">
   <h1>Binder inaccessible</h1>
   <h2>

--- a/mybinder/files/etc/jupyter/templates/page.html
+++ b/mybinder/files/etc/jupyter/templates/page.html
@@ -1,2 +1,38 @@
 {% extends "templates/page.html" %}
-{% block login_widget %}{% endblock %}
+
+{% block header_buttons %}
+
+{% block login_widget %}
+{% endblock %}
+
+{% if ref_url %}
+<span>
+    <a id="visit-repo-link" href="{{ ref_url }}" class="btn btn-default btn-sm navbar-btn" target="_blank"
+       style="margin-right: 2px; margin-left: 4px;">Visit repo</a></span>
+{% endif %}
+
+{% if persistent_binder_url  %}
+<span>
+    <button id="copy-binder-link" title="Copy binder link to clipboard" class="btn btn-default btn-sm navbar-btn"
+            style="margin-right: 0; margin-left: 2px;"
+            data-url="{{ persistent_binder_url }}" onclick="copy_link_into_clipboard(this);">
+      Copy Binder link
+    </button>
+</span>
+{% endif %}
+
+{% endblock header_buttons %}
+
+{% block script %}
+{% if persistent_binder_url  %}
+<script type='text/javascript'>
+    function copy_link_into_clipboard(b) {
+        var $temp = $("<input>");
+        $(b).parent().append($temp);
+        $temp.val($(b).data('url')).select();
+        document.execCommand("copy");
+        $temp.remove();
+    }
+</script>
+{% endif %}
+{% endblock %}

--- a/mybinder/files/etc/jupyter/templates/tree.html
+++ b/mybinder/files/etc/jupyter/templates/tree.html
@@ -1,0 +1,17 @@
+{% extends "templates/tree.html" %}
+
+{% block headercontainer %}
+  <span class="flex-spacer"></span>
+{% endblock %}
+
+{% block header_buttons %}
+  {{super()}}
+  {% if shutdown_button %}
+    <span id="shutdown_widget">
+      <button id="shutdown" class="btn btn-sm navbar-btn"
+              title="{% trans %}Stop the Jupyter server{% endtrans %}">
+          {% trans %}Quit{% endtrans %}
+      </button>
+    </span>
+  {% endif %}
+{% endblock header_buttons %}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -68,6 +68,13 @@ binderhub:
       build_image: jupyter/repo2docker:0.10.0-100.g0dba611
       per_repo_quota: 100
       per_repo_quota_higher: 200
+      appendix: |
+        USER root
+        ENV BINDER_URL={binder_url}
+        ENV PERSISTENT_BINDER_URL={persistent_binder_url}
+        ENV REPO_URL={repo_url}
+        ENV REF_URL={ref_url}
+        USER $NB_USER
 
       banner_message: |
         <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a> and <a href="https://www.ovh.com/">OVH</a> for sponsoring our computers 🎉!</div>


### PR DESCRIPTION
for https://github.com/jupyterhub/binderhub/issues/674

This PR adds 2 buttons into Notebook UI:
- Visit repo: opens the repo url in new tab
- Copy Binder link: copies the binder launch url into clipboard

In `jupyter_notebook_config.py` there are 4 template variables defined with different urls, here is an example:
- `repo_url`: https://github.com/bitnik/simple-binder-repo-2
- `ref_url`: https://github.com/bitnik/simple-binder-repo-2/tree/79540e5802824cdf6432d4bc22ad7849ed4cd6b0
- `binder_url`: https://mybinder.org/v2/gh/bitnik/simple-binder-repo-2/master
- `persistent_binder_url`: https://mybinder.org/v2/gh/bitnik/simple-binder-repo-2/79540e5802824cdf6432d4bc22ad7849ed4cd6b0

These template variables takes values from env variabels. For that I used `appendix` of BinderHub. But I have an idea to get rid of appendix. I think we can define these env variables during build process in binder. I will make a PR for that.

I updated notebook templates (they are mounted into user pods as cofigmaps) to add buttons, so `custom.js` is not used anymore. And I used `ref_url` for "Visit repo" button and `persistent_binder_url` for "Copy Binder link" button. In [login.html](https://github.com/gesiscss/mybinder.org-deploy/blob/57be8dfd1ad5f6a5ea2640994d413cabd5e04e79/mybinder/files/etc/jupyter/templates/login.html#L14-L30) `binder_url` was used and I didn't change it. Should we use `repo_url` and `binder_url` pair or `ref_url` and `persistent_binder_url` pair or a mix of them?