### PR TITLE
[MRG] Increase memory request and limit of nginx-ingress

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -263,10 +263,10 @@ nginx-ingress:
     resources:
       requests:
         cpu: 0.5
-        memory: 280Mi
+        memory: 380Mi
       limits:
         cpu: 0.8
-        memory: 340Mi
+        memory: 440Mi
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Since the switch to the new node pool our nginx pods are using more
memory and as a result keep getting killed because they exceed their
limit.


<img width="1173" alt="Screenshot 2019-10-16 at 07 14 59" src="https://user-images.githubusercontent.com/1448859/66890003-f50e3e00-efd3-11e9-8d9e-08698d595e81.png">
