### PR TITLE
revert misuse of urljoin in federation redirector

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -7,7 +7,6 @@ import tornado
 import tornado.ioloop
 import tornado.web
 import tornado.options
-from urllib.parse import urljoin
 from tornado.gen import sleep
 from tornado.ioloop import IOLoop
 from tornado.log import enable_pretty_logging, app_log
@@ -131,8 +130,7 @@ class RedirectHandler(RequestHandler):
             host_name = random.choices(self.host_names, self.host_weights)[0]
         self.set_cookie("host", host_name, path=uri)
 
-        url = urljoin(host_name, uri)
-        self.redirect(url)
+        self.redirect(host_name + uri)
 
 
 class ActiveHostsHandler(RequestHandler):

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -51,14 +51,17 @@ if os.path.exists(config_path):
 else:
     app_log.warning("Using default config!")
 
-
-# Remove empty entries from CONFIG["hosts"], these can happen because we
-# can't remove keys in our helm templates/config files. All we can do is
-# set them to Null/None. We need to turn the keys into a list so that we
-# can modify the dict while iterating over it
 for h in list(CONFIG["hosts"].keys()):
+    # Remove empty entries from CONFIG["hosts"], these can happen because we
+    # can't remove keys in our helm templates/config files. All we can do is
+    # set them to Null/None. We need to turn the keys into a list so that we
+    # can modify the dict while iterating over it
     if CONFIG["hosts"][h] is None:
         CONFIG["hosts"].pop(h)
+    # remove trailing slashes in host urls
+    # these can cause 404 after redirection (RedirectHandler) and we don't realize it
+    else:
+        CONFIG["hosts"][h]["url"] = CONFIG["hosts"][h]["url"].rstrip("/")
 
 
 class ProxyHandler(RequestHandler):


### PR DESCRIPTION
closes https://github.com/jupyterhub/mybinder.org-deploy/issues/1204

That was my fault, sorry. I misused the `urljoin()`. The problem is that `urljoin("https://notebooks.gesis.org/binder", "/build/gh/binder-examples/requirements/master")` outputs "https://notebooks.gesis.org/build/gh/binder-examples/requirements/master" (without bhub base url `/binder`) where I expected to have "https://notebooks.gesis.org/binder/build/gh/binder-examples/requirements/master". 

And users get "Failed to connect to event stream" error message.