### PR TITLE
Increase nginx-ingress memory limits

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -263,10 +263,10 @@ nginx-ingress:
     resources:
       requests:
         cpu: 0.5
-        memory: 380Mi
+        memory: 440Mi
       limits:
         cpu: 0.8
-        memory: 440Mi
+        memory: 500Mi
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
We still keep bumping into the limit, so increasing it again. At some point we might need to investigate why it is so large.