### PR TITLE
Installing cert-manager: step 1 - adding files

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -14,3 +14,6 @@ dependencies:
  - name: binderhub
    version: 0.2.0-5b3824d
    repository: https://jupyterhub.github.io/helm-chart
+- name: cert-manager
+  version: "v0.10.0"
+  repository: "https://charts.jetstack.io"

--- a/mybinder/templates/_helpers.tpl
+++ b/mybinder/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mybinder.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mybinder.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mybinder.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/mybinder/templates/clusterissuer.yaml
+++ b/mybinder/templates/clusterissuer.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: prod
+  labels:
+    helm.sh/chart: {{ include "mybinder.chart" . }}
+    app.kubernetes.io/name: {{ include "mybinder.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: {{ .Values.letsencrypt.contactEmail }}
+    privateKeySecretRef:
+      name: prod-acme-key
+    http01: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: staging
+  labels:
+    helm.sh/chart: {{ include "mybinder.chart" . }}
+    app.kubernetes.io/name: {{ include "mybinder.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ .Values.letsencrypt.contactEmail }}
+    privateKeySecretRef:
+      name: staging-acme-key
+    http01: {}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -428,3 +428,6 @@ federationRedirect:
       weight: 1
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
+
+letsencrypt:
+  contactEmail: yuvipanda@gmail.com


### PR DESCRIPTION
This PR adds cert-manager into the mybinder chart requirements, includes some helper functions and a cluster issuer, and references the lets encrypt contact email in values.yaml.