### PR TITLE
Add cert-manager repo to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_deploy:
   # Stage 2, Step 2: Set up helm!
   helm init --client-only
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+  helm repo add cert-manager https://charts.jetstack.io
   helm repo update
   (cd mybinder && helm dep up)
 - |


### PR DESCRIPTION
Fixing travis error:

```
Error: no repository definition for https://charts.jetstack.io. Please add them via 'helm repo add'
```