### PR TITLE
force upgrade flag needed in deploy.py, not travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_deploy:
   chmod 0600 secrets/*key
 - |
   # Stage 2, Step 2: Set up helm!
-  helm init --client-only --force-upgrade
+  helm init --client-only
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
   helm repo add cert-manager https://charts.jetstack.io
   helm repo update

--- a/deploy.py
+++ b/deploy.py
@@ -67,7 +67,7 @@ def setup_auth_gcloud(release, cluster):
 
 def setup_helm(release):
     """ensure helm is up to date"""
-    subprocess.check_call(['helm', 'init', '--upgrade'])
+    subprocess.check_call(['helm', 'init', '--upgrade', '--force-upgrade'])
 
     deployment = json.loads(subprocess.check_output([
         'kubectl',


### PR DESCRIPTION
This PR moves the `--force-upgrade` flag from the travis file to deploy.py