### PR TITLE
Keep empty string when there is no env variable

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -5,7 +5,7 @@ c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
 def make_federation_url(url):
     federation_host = 'https://mybinder.org'
     if not url:
-        return federation_host
+        return ''
     url_parts = url.split('/v2/', 1)
     return federation_host + '/v2/' + url_parts[-1]
 


### PR DESCRIPTION
Follow up to #1202 that keeps the empty string for situations where the environment doesn't contain any information for the buttons.