### PR TITLE
adding federation check page

### DIFF
--- a/docs/source/federation.rst
+++ b/docs/source/federation.rst
@@ -1,0 +1,62 @@
+===========================
+The mybinder.org Federation
+===========================
+
+The following table lists BinderHub deployments in the mybinder.org
+federation, along with the status of each.
+
+================  ===
+  URL
+================  ===
+gke.mybinder.org  ???
+ovh.mybinder.org  ???
+================  ===
+
+.. raw:: html
+
+   <script>
+   var fedUrls = [
+       "https://gke.mybinder.org",
+       "https://ovh.mybinder.org",
+   ]
+
+   // Use a dictionary to store the fields that should be updated
+   var urlFields = {};
+   fedUrls.forEach((url) => {
+      document.querySelectorAll('tr').forEach((tr) => {
+        if (tr.textContent.includes(url.replace('https://', ''))) {
+           urlFields[url] = tr.querySelectorAll('td')[1];
+        };
+      });
+   });
+
+   fedUrls.forEach((url) => {
+       var urlHealth = url + '/health'
+       var urlPrefix = url.split('//')[1].split('.')[0]
+
+       // Query the endpoint and update health icon
+       var field = urlFields[url];
+       $.getJSON(urlHealth, {})
+           .done((resp) => {
+               if (resp['ok'] == false) {
+                   setStatus(field, 'fail')
+               } else {
+                   setStatus(field, 'success')
+               }
+           })
+           .fail((resp) => {
+                setStatus(field, 'fail')
+       });
+   })
+
+   var setStatus = (field, kind) => {
+      if (kind == "success") {
+        field.textContent = "Success";
+        field.style.color = "green";
+      } else {
+        field.textContent = "Fail";
+        field.style.color = "red";
+      }
+   }
+
+   </script>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ run into when maintaining mybinder.org.
     common_problems.md
     command_snippets.md
     grafana_plots.md
+    federation.md
 
 
 Components


### PR DESCRIPTION
This adds a page to the SRE guide that should show the status of each of the BinderHubs in the federation. It:

* Loops through each binderhub deployment we list, and for each:
* Queries the `/health` endpoint
* Checks the fields that are returned
* Updates the table based on what it finds.

Any suggestions for things that should be added or changed? Otherwise I think this is good to go - it is correctly finding that the gke hub is working, and that the OVH hub is not

I just realized that we don't have docs auto-building set up for us, so in the meantime here's a screenshot of what this looks like:

![image](https://user-images.githubusercontent.com/1839645/67642705-c6457100-f8cb-11e9-88b3-b155b7aa9617.png)
