### PR TITLE
Fix pod antiaffinity spec, add unschedulable toleration

### DIFF
--- a/mybinder/templates/federation-redirect/deployment.yaml
+++ b/mybinder/templates/federation-redirect/deployment.yaml
@@ -14,16 +14,6 @@ spec:
       app: federation-redirect
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - federation-redirect
-        topologyKey: "kubernetes.io/hostname"
   template:
     metadata:
       labels:
@@ -33,6 +23,18 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/federation-redirect/configmap.yaml") . | sha256sum }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - federation-redirect
+              topologyKey: "kubernetes.io/hostname"
       volumes:
       - name: config
         configMap:
@@ -51,5 +53,10 @@ spec:
           limits:
             cpu: 0.2
             memory: 300Mi
+      tolerations:
+      - key: "node.kubernetes.io/unschedulable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 30
 
 {{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -274,6 +274,11 @@ nginx-ingress:
       limits:
         cpu: 0.8
         memory: 500Mi
+    tolerations:
+      - key: "node.kubernetes.io/unschedulable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 30
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Let the pod reschedule itself when the node it is on gets cordoned.

I think the way the pod anti-affinity was specified so far was wrong and hence had no effect.

The new toleration causes the pod to reschedule itself when the node gets cordoned.