### PR TITLE
compatibility with notebook < 5.1.0

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,6 +1,6 @@
 import os
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
-
+c.NotebookApp.jinja_environment_options = {'extensions': ['jinja2.ext.i18n']}
 
 def make_federation_url(url):
     federation_host = 'https://mybinder.org'


### PR DESCRIPTION
<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

This PR fixes the issue with compatibility with notebook servers < 5.1.0. 

The issue was that notebook server < 5.1.0 crashed when rendering the tree view with the templates injected by mybinder.org. The problem was due to the missing jinja2 extension in nb 5.0.0.

For details, see the thread at discourse: 

[Binder displays 500 internal server error when launching a built image](https://discourse.jupyter.org/t/binder-displays-500-internal-server-error-when-launching-a-built-image/2597/7)