### PR TITLE
Add GESIS to the banner

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -77,7 +77,7 @@ binderhub:
         USER $NB_USER
 
       banner_message: |
-        <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a> and <a href="https://www.ovh.com/">OVH</a> for sponsoring our computers 🎉!</div>
+        <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a>, <a href="https://www.ovh.com/">OVH</a> and <a href="https://www.gesis.org/en/home">GESIS</a> for sponsoring our computers 🎉!</div>
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />
         The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>, which is a fiscally


### PR DESCRIPTION
This adds a link to the GESIS homepage to the banner as they are now receiving as much traffic as OVH.