### PR TITLE
Revert "compatibility with notebook < 5.1.0"

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,6 +1,6 @@
 import os
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
-c.NotebookApp.jinja_environment_options = {'extensions': ['jinja2.ext.i18n']}
+
 
 def make_federation_url(url):
     federation_host = 'https://mybinder.org'


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1247

Seeing the following exception when starting our CI repo:
```
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/jupyter-notebook", line 11, in <module>
    sys.exit(main())
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/traitlets/config/application.py", line 657, in launch_instance
    app.initialize(argv)
  File "</srv/conda/envs/notebook/lib/python3.7/site-packages/decorator.py:decorator-gen-7>", line 2, in initialize
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/notebook/notebookapp.py", line 1630, in initialize
    self.init_webapp()
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/notebook/notebookapp.py", line 1378, in init_webapp
    self.jinja_environment_options,
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/notebook/notebookapp.py", line 159, in __init__
    default_url, settings_overrides, jinja_env_options)
  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/notebook/notebookapp.py", line 181, in init_settings
    env = Environment(loader=FileSystemLoader(template_path), extensions=['jinja2.ext.i18n'], **jenv_opt)
TypeError: type object got multiple values for keyword argument 'extensions'
```

So reverting for the moment to investigate.