### PR TITLE
Use GESIS Notebooks in the banner message

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -77,7 +77,7 @@ binderhub:
         USER $NB_USER
 
       banner_message: |
-        <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a>, <a href="https://www.ovh.com/">OVH</a> and <a href="https://www.gesis.org/en/home">GESIS</a> for supporting us 🎉!</div>
+        <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a>, <a href="https://www.ovh.com/">OVH</a> and <a href="https://notebooks.gesis.org">GESIS Notebooks</a> for supporting us 🎉!</div>
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />
         The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>, which is a fiscally


### PR DESCRIPTION
Sets the link to GESIS Notebooks as we are only partially funded by GESIS and referencing the project equally includes our other funders.