### PR TITLE
Increase nginx-ingress replicas

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -295,7 +295,7 @@ nginx-ingress:
                 values:
                 - controller
             topologyKey: kubernetes.io/hostname
-    replicaCount: 2
+    replicaCount: 3
     scope:
       enabled: true
     config:


### PR DESCRIPTION
Earlier today we were briefly serving invalid SSL certificates, some
people report problems like this when their pods are out of resources.
