### PR TITLE
Reduce OVH weight

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -426,13 +426,13 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 66
+      weight: 84
       health: https://gke.mybinder.org/health
       versions: https://gke.mybinder.org/versions
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 19
+      weight: 1
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     gesis:


### PR DESCRIPTION
There is an issue with the docker registry we are using at OVH which means
new builds can't push their images and pulls for rare images are failing.

