### PR TITLE
Revert "Reduce OVH weight"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -426,13 +426,13 @@ federationRedirect:
   hosts:
     gke:
       url: https://gke.mybinder.org
-      weight: 84
+      weight: 66
       health: https://gke.mybinder.org/health
       versions: https://gke.mybinder.org/versions
       prime: true
     ovh:
       url: https://ovh.mybinder.org
-      weight: 1
+      weight: 19
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     gesis:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1253

@mael-le-gal did some cleaning of the registry which had filled up to 95%.