### PR TITLE
[MRG] Enable translation Jinja extension for old notebooks

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,5 +1,16 @@
+import notebook
 import os
+
+from distutils.version import LooseVersion as V
+
+
 c.NotebookApp.extra_template_paths.append('/etc/jupyter/templates')
+
+
+# For old notebook versions we have to explicitly enable the translation
+# extension
+if V(notebook.__version__) < V('5.1.0'):
+    c.NotebookApp.jinja_environment_options = {'extensions': ['jinja2.ext.i18n']}
 
 
 def make_federation_url(url):


### PR DESCRIPTION
Following up #1250 and #1247

This checks the version of the notebook and only explicitly adds the translation extension for older versions.