### PR TITLE
Add new load balancing algorithm for federation proxy

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -436,8 +436,3 @@ federationRedirect:
       weight: 19
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
-    gesis:
-      url: https://gesis.mybinder.org
-      weight: 15
-      health: https://gesis.mybinder.org/health
-      versions: https://gesis.mybinder.org/versions

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -423,6 +423,7 @@ federationRedirect:
     jitter: 0.1
     retries: 5
     timeout: 2
+  load_balancer: "rendezvous"
   hosts:
     gke:
       url: https://gke.mybinder.org


### PR DESCRIPTION
This adds a "sticky" load balancing algorithm to the federation redirector. We compute a score for a spec for each available cluster, then send the launch request to the cluster with the best score. This means that as long as the list of available clusters doesn't change the same repo will always be launched on the same cluster. This is good for caching and keeping the image caches fast/hot (and smaller).

We use the same algorithm as the "sticky builds" feature in BinderHub.

This means that the "weight" we have assigned to each of the clusters stops being used, instead we use the "quota" that each cluster can assign to itself. Why this? Because the same repo will always be sent to the same cluster. This means a (very) small cluster could be the one that receives all of https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb which is our highest traffic repo and presumably would swamp the small cluster. So we rely on the cluster telling us "I am full, please don't send more" (this is the quota setting). Once we hit that state we remove the cluster from the ranking and send traffic to the cluster that is the new number one (which is the old number two).

I will briefly enable this feature but then probably turn if off again until I had a chance to talk with @bitnik about the quota (200 right now) that is configured for Gesis. During the test I'll remove Gesis from the federation because that seems more polite than briefly sending lots of traffic on a Sunday evening.