### PR TITLE
Reduce OVH quota

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -3,7 +3,7 @@ projectName: ovh
 binderhub:
   config:
     BinderHub:
-      pod_quota: 120
+      pod_quota: 80
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       image_prefix: dlqpwel7.gra5.container-registry.ovh.net/binder/r2d-f18835fd-


### PR DESCRIPTION
It feels like the number of launch failures has increased/clusters more since we switched the way repos are assigned to clusters. reducing the quota for now to see if that improves things again. Mostly trying stuff to gain some experience with how things behave.