### PR TITLE
Bump DIND version

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -151,10 +151,6 @@ binderhub:
 
   dind:
     enabled: true
-    daemonset:
-      image:
-        name: docker
-        tag: 18.09.2-dind
 
   imageCleaner:
     enabled: true


### PR DESCRIPTION
By removing the explicit version here we go to the BinderHub default
which is 19.x
