### PR TITLE
Switch to using absolute disk usage for DIND on OVH

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -125,6 +125,7 @@ grafana:
           isDefault: true
           editable: false
 
+
 prometheus:
   server:
     ingress:
@@ -137,6 +138,14 @@ prometheus:
         - hosts:
             - prometheus-mybinder.mybinder.ovh
           secretName: tls-crt
+
+
+imageCleaner:
+  # Use 40GB as upper limit, size is given in bytes
+  imageGCThresholdHigh: 40e9
+  imageGCThresholdLow: 30e9
+  imageGCThresholdType: "absolute"
+
 
 nginx-ingress:
   controller:


### PR DESCRIPTION
On the OVH cluster the DIND and K8S dockerds both use the same partition
to store images. As both check the relative usage of the partition to
decide when to act the DIND GC job ends up deleting all images everytime
it runs because the disk is too full (and just removing the DIND images
doesn't drop it far enough). This switches it to use a size in GB as
limit. This should balance the disk usage between the two dockerds.

The "absolute" image-cleaner uses a much less efficient method for determining
how full the disk is (think `du` vs `df`). Maybe we need to increase the interval at
which it runs or do something smarter/more of an approximation when [re-computing the size](https://github.com/jupyterhub/binderhub/blob/7c503589c07a36c5f8454a214afdd38300cfdc71/helm-chart/images/image-cleaner/image-cleaner.py#L177) (for example subtracting the size of the image we just deleted).