### PR TITLE
Reduce OVH quota

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -3,7 +3,7 @@ projectName: ovh
 binderhub:
   config:
     BinderHub:
-      pod_quota: 50
+      pod_quota: 30
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       sticky_builds: true


### PR DESCRIPTION
Seems like using the docker hub registry doesn't really improve the launch success rate.