### PR TITLE
updating repo2docker image

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -65,7 +65,7 @@ binderhub:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:0.10.0-123.gf79bf04
+      build_image: jupyter/repo2docker:0.10.0-125.g94d492e
       per_repo_quota: 100
       per_repo_quota_higher: 200
 


### PR DESCRIPTION

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/f79bf04...94d492e
