### PR TITLE
Merge pull request #1314 from betatim/disable-cert-manager

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,5 +1,6 @@
 tags:
   kubelego: true
+  certmanager: false
 
 etcJupyter:
   jupyter_notebook_config.json:


### PR DESCRIPTION
This explicitly disables cert-manager for staging, OVH and GKE.