### PR TITLE
[RVW] Add a version check before helm upgrade happens

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -130,6 +130,7 @@ def setup_helm(release):
         )
     elif (client_version == "v2.11.0") and (client_version == server_version):
         # All is good! Perform normal helm init command.
+        # We use the --client-only flag so that the Tiller installation is not affected.
         subprocess.check_call(['helm', 'init', '--client-only'])
     else:
         # This is a catch-all exception. Hopefully this doesn't execute!

--- a/deploy.py
+++ b/deploy.py
@@ -107,11 +107,10 @@ def setup_helm(release):
     server_version = subprocess.check_output(server_helm_cmd
         ).decode('utf-8').split(":")[1].split("+")[0].strip()
 
-    print(
-        "Client version: {}, Server version: {}".format(
-            client_version,
-            server_version,
-        )
+    print(BOLD + GREEN +
+        f"Client version: {client_version}, Server version: {server_version}" +
+        NC,
+        flush=True
     )
 
     # Now check if the version of helm matches v2.11.0 which travis is expecting

--- a/deploy.py
+++ b/deploy.py
@@ -127,7 +127,7 @@ def setup_helm(release):
         # to bring the server side back to v2.11.0
         raise Exception(
             "Helm client and server versions do not match. Performing a force upgrade often resolves this issue." +
-            "Please run the following command and re-execute this script.\n\n" +
+            "Please run the following command and re-execute this script.\n\n\t" +
             "helm init --upgrade --force-upgrade"
         )
     elif (client_version == "v2.11.0") and (client_version == server_version):

--- a/deploy.py
+++ b/deploy.py
@@ -112,19 +112,26 @@ def setup_helm(release):
         )
     )
 
+    # Now check if the version of helm matches v2.11.0 which travis is expecting
     if client_version != "v2.11.0":
+        # The local helm version is not v2.11.0 - user needs to change the installation
         raise Exception(
             "You are not running helm v2.11.0 which is the version our continuous deployment system uses.\n" +
             "Please change your installation and try again.\n" +
         )
     elif (client_version == "v2.11.0") and (client_version != server_version):
+        # The correct local version of helm is installed, but the server side
+        # has previously accidentally been upgraded. Perform a force-upgrade
+        # to bring the server side back to v2.11.0
         print(
             "Helm client and server versions do not match. Performing a force upgrade."
         )
         subprocess.check_call(["helm", "init", "--upgrade", "--force-upgrade"])
     elif (client_version == "v2.11.0") and (client_version == server_version):
+        # All is good! Perform normal helm init command.
         subprocess.check_call(['helm', 'init', '--upgrade'])
     else:
+        # This is a catch-all exception. Hopefully this doesn't execute!
         raise Exception("Please check your helm installation.")
 
     deployment = json.loads(subprocess.check_output([

--- a/deploy.py
+++ b/deploy.py
@@ -117,7 +117,7 @@ def setup_helm(release):
         # The local helm version is not v2.11.0 - user needs to change the installation
         raise Exception(
             "You are not running helm v2.11.0 which is the version our continuous deployment system uses.\n" +
-            "Please change your installation and try again.\n" +
+            "Please change your installation and try again.\n"
         )
     elif (client_version == "v2.11.0") and (client_version != server_version):
         # The correct local version of helm is installed, but the server side
@@ -250,17 +250,24 @@ def main():
         'cluster',
         help='Cluster to do the deployment in'
     )
+    argparser.add_argument(
+        '--local',
+        action='store_true',
+        help="If the script is running locally, skip auth and helm steps."
+    )
 
     args = argparser.parse_args()
 
-    if args.cluster == 'binder-ovh':
-        setup_auth_ovh(args.release, args.cluster)
-    elif args.cluster == 'turing':
-        setup_auth_turing(args.cluster)
-    else:
-        setup_auth_gcloud(args.release, args.cluster)
+    if not args.local:
+        if args.cluster == 'binder-ovh':
+            setup_auth_ovh(args.release, args.cluster)
+        elif args.cluster == 'turing':
+            setup_auth_turing(args.cluster)
+        else:
+            setup_auth_gcloud(args.release, args.cluster)
 
-    setup_helm(args.release)
+        setup_helm(args.release)
+
     deploy(args.release)
 
 

--- a/deploy.py
+++ b/deploy.py
@@ -123,10 +123,11 @@ def setup_helm(release):
         # The correct local version of helm is installed, but the server side
         # has previously accidentally been upgraded. Perform a force-upgrade
         # to bring the server side back to v2.11.0
-        print(
-            "Helm client and server versions do not match. Performing a force upgrade."
+        raise Exception(
+            "Helm client and server versions do not match. Performing a force upgrade often resolves this issue." +
+            "Please run the following command and re-execute this script.\n\n" +
+            "\thelm init --upgrade --force-upgrade"
         )
-        subprocess.check_call(["helm", "init", "--upgrade", "--force-upgrade"])
     elif (client_version == "v2.11.0") and (client_version == server_version):
         # All is good! Perform normal helm init command.
         subprocess.check_call(['helm', 'init', '--upgrade'])

--- a/deploy.py
+++ b/deploy.py
@@ -246,6 +246,7 @@ def main():
     # Get current working directory
     cwd = os.getcwd()
 
+    # parse command line args
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
         'release',
@@ -264,7 +265,9 @@ def main():
 
     args = argparser.parse_args()
 
+    # Check if the script is being run on travis or hand the --local flag set
     if (cwd.startswith('/home/travis')) and (not args.local):
+        # script is running on travis, proceed with auth and helm setup
         if args.cluster == 'binder-ovh':
             setup_auth_ovh(args.release, args.cluster)
         elif args.cluster == 'turing':
@@ -273,21 +276,28 @@ def main():
             setup_auth_gcloud(args.release, args.cluster)
 
         setup_helm(args.release)
+
     elif (not cwd.startswith('/home/travis')) and (not args.local):
+        # Catch the case where the script is running locally but the --local flag
+        # has not been set. Check that the user is sure that they want to do this!
         print(
             "You do not seem to be running on Travis but have not set the --local flag."
         )
 
+        # Use regex to match user input
         regex_no = re.compile("^[n|N][o|O]$")
         regex_yes = re.compile("^[y|Y][e|E][s|S]$")
         response = input("Are you sure you want to execute this script? [yes/no]: ")
 
         if regex_no.match(response):
+            # User isn't sure - exit script
             print("Exiting script.")
             sys.exit()
         elif regex_yes.match(response):
+            # User is sure - proceed
             pass
         else:
+            # User wrote something that wasn't "yes" or "no"
             raise ValueError(
                 "Unrecognised input. Expecting either yes or no."
             )

--- a/deploy.py
+++ b/deploy.py
@@ -130,7 +130,7 @@ def setup_helm(release):
         )
     elif (client_version == "v2.11.0") and (client_version == server_version):
         # All is good! Perform normal helm init command.
-        subprocess.check_call(['helm', 'init', '--upgrade'])
+        subprocess.check_call(['helm', 'init', '--client-only'])
     else:
         # This is a catch-all exception. Hopefully this doesn't execute!
         raise Exception("Please check your helm installation.")


### PR DESCRIPTION
This PR adds a helm version check into the `setup_helm` function in `deploy.py`. This will hopefully avoid the issue I got myself into where I had accidentally upgraded helm on staging to v2.14 when travis uses v2.11 - the mismatch causes helm upgrades to fail. It also implements some checks to see if the script is being run locally or not. Most often, the helm version problem occurs when the script is run locally so we ask the user if they're really sure they want to do this. We also add a `--local` flag so this input step is skipped.