### PR TITLE
[Example] Add Some basic CI tests for PRs

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,27 @@
+name: Flake8
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+      - name: Lint all Python files with Flake8
+        run: |
+          flake8 **/*.py

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Install git-crypt
         run: |
           git clone https://github.com/AGWA/git-crypt.git
+          cd git-crypt
           make
           make install PREFIX=/usr/local
-      

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -38,4 +38,4 @@ jobs:
           git clone https://github.com/AGWA/git-crypt.git
           cd git-crypt
           make
-          make install PREFIX=/usr/local
+          make install PREFIX=${PWD}

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -1,0 +1,41 @@
+name: Lint and Validate
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint-and-validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Installation/setup steps
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
+      - name: Install Helm
+        run: |
+          wget https://get.helm.sh/helm-v2.11.0-linux-amd64.tar.gz
+          tar -zxvf helm-v2.11.0-linux-amd64.tar.gz
+          sudo cp linux-amd64/helm /usr/local/bin/helm
+      - name: Install kubeval
+        run: |
+          wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+          tar xf kubeval-linux-amd64.tar.gz
+          sudo cp kubeval /usr/local/bin
+      - name: Install git-crypt
+        run: |
+          git clone https://github.com/AGWA/git-crypt.git
+          make
+          make install PREFIX=/usr/local
+      

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -39,3 +39,4 @@ jobs:
           cd git-crypt
           make
           make install PREFIX=${PWD}
+          cd .. && ls

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -39,4 +39,28 @@ jobs:
           cd git-crypt
           make
           make install PREFIX=${PWD}
-          cd .. && ls
+      - name: Unlock secrets
+        run: |
+          git-crypt/git-crypt unlock ${{ secrets.gitcryptSecret }}
+
+      # Now lint and validate the helm chart for each cluster
+      - name: Lint and Validate staging
+        run: |
+          python scripts/lint-and-validate.py --values config/staging.yaml secrets/config/staging.yaml secrets/config/common.yaml
+
+      - name: Lint and Validate prod
+        run: |
+          python scripts/lint-and-validate.py --values config/prod.yaml secrets/config/prod.yaml secrets/config/common.yaml
+
+      - name: Lint and Validate OVH
+        run: |
+          python scripts/lint-and-validate.py --values config/ovh.yaml secrets/config/ovh.yaml secrets/config/common.yaml
+
+      - name: Lint and Validate Turing
+        run: |
+          python scripts/lint-and-validate.py --values config/turing.yaml secrets/config/turing.yaml secrets/config/common.yaml
+
+      - name: Clean up
+        if: always()  # Always run this step
+        run: |
+          rm -rf scripts/rendered-templates

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,27 @@
+name: yamllint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
+      - name: Lint all yaml/yml files
+        run: |
+          yamllint **/*.yaml **/*.yml

--- a/scripts/lint-and-validate.py
+++ b/scripts/lint-and-validate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Lints and validates the chart's template files and their rendered output
+without any cluster interaction. For this script to function, you must install
+yamllint and kubeval.
+
+- https://github.com/adrienverge/yamllint
+
+pip install yamllint
+
+- https://github.com/instrumenta/kubeval
+
+LATEST=curl --silent \
+    "https://api.github.com/repos/instrumenta/kubeval/releases/latest" |
+    grep '"tag_name":' |
+    sed -E 's/.*"([^"]+)".*/\1/'
+wget https://github.com/instrumenta/kubeval/releases/download/$LATEST/kubeval-linux-amd64.tar.gz
+tar xf kubeval-darwin-amd64.tar.gz
+mv kubeval /usr/local/bin
+"""
+
+import os
+import sys
+import argparse
+import glob
+import pipes
+import subprocess
+
+os.chdir(os.path.dirname(sys.argv[0]))
+
+
+def check_call(cmd, **kwargs):
+    """Run a subcommand and exit if it fails"""
+    try:
+        subprocess.check_call(cmd, **kwargs)
+    except subprocess.CalledProcessError as e:
+        print(
+            "`{}` exited with status {}".format(
+                " ".join(map(pipes.quote, cmd)), e.returncode
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(e.returncode)
+
+
+def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
+    """Calls `helm lint`, `helm template`, `yamllint` and `kubeval`."""
+
+    print("### Clearing output directory")
+    check_call(["mkdir", "-p", output_dir])
+    check_call(["rm", "-rf", output_dir + "/*"])
+
+    print("### Linting started")
+    print("### 1/4 - helm lint: lint helm templates")
+    helm_lint_cmd = ["helm", "lint", "../../jupyterhub", "--values", values]
+    if debug:
+        helm_lint_cmd.append("--debug")
+    check_call(helm_lint_cmd)
+
+    print("### 2/4 - helm template: generate kubernetes resources")
+    helm_template_cmd = [
+        "helm",
+        "template",
+        "../../jupyterhub",
+        "--values",
+        values,
+        "--output-dir",
+        output_dir,
+    ]
+    if debug:
+        helm_template_cmd.append("--debug")
+    check_call(helm_template_cmd)
+
+    print("### 3/4 - yamllint: yaml lint generated kubernetes resources")
+    check_call(["yamllint", "-c", yamllint_config, output_dir])
+
+    print("### 4/4 - kubeval: validate generated kubernetes resources")
+    for kubernetes_version in kubernetes_versions.split(","):
+        print("#### kubernetes_version ", kubernetes_version)
+        for filename in glob.iglob(output_dir + "/**/*.yaml", recursive=True):
+            check_call(
+                [
+                    "kubeval",
+                    filename,
+                    "--kubernetes-version",
+                    kubernetes_version,
+                    "--strict",
+                ]
+            )
+
+    print()
+    print(
+        "### Linting and validation of helm templates and generated " +
+        "kubernetes resources OK!"
+    )
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run helm lint and helm template with the --debug flag",
+    )
+    argparser.add_argument(
+        "--values",
+        default="lint-and-validate-values.yaml",
+        help="Specify Helm values in a YAML file (can specify multiple)",
+    )
+    argparser.add_argument(
+        "--kubernetes-versions",
+        default="1.15.0",
+        help='Comma-separated list of Kubernetes versions to validate against',
+    )
+    argparser.add_argument(
+        "--output-dir",
+        default="rendered-templates",
+        help="Output directory for the rendered templates. " +
+             "Warning: content will be wiped.",
+    )
+    argparser.add_argument(
+        "--yamllint-config",
+        default="yamllint-config.yaml",
+        help="Specify a yamllint config",
+    )
+
+    args = argparser.parse_args()
+
+    lint(
+        args.yamllint_config,
+        args.values,
+        args.kubernetes_versions,
+        args.output_dir,
+        args.debug,
+    )

--- a/scripts/yamllint-config.yaml
+++ b/scripts/yamllint-config.yaml
@@ -1,0 +1,49 @@
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: false   # Default: true (*)
+    min-spaces-from-content: 2
+  comments-indentation: {}
+  document-end: disable
+  document-start: disable           # Default: { present: true }
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  empty-values:
+    forbid-in-block-mappings: false
+    forbid-in-flow-mappings: false
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: 2                       # Default: consistent
+    indent-sequences: whatever      # Default true (**)
+    check-multi-line-strings: false
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable              # Default: { max: 80, ... }
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  octal-values:
+    forbid-implicit-octal: false
+    forbid-explicit-octal: false
+  trailing-spaces: disable
+  truthy:
+    level: warning


### PR DESCRIPTION
This PR uses GitHub Actions to add some basic CI tests to provide feedback in PRs (not just on merge to master). These tests **do not** block merging of PRs on failure.

Added actions:

- Check linting of Python scripts with Flake8
- Check linting of YAML with yamllint
- Lint and Validate script for helm charts from [zero-to-jupyterhub-k8s repo](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/master/tools/templates)
- Check linting and validate the charts of all deployments which are configured from this repo

### Future work

I'd like to work towards CI that can help us verify a deployment before we hit merge. This would most likely involve spinning up a new cluster. However, I think this would be possible given the work going on in integrating k8s and Actions happening at the minute (e.g. https://github.com/Azure/actions#deploy-to-kubernetes this is probably Azure specific). Failing that, we could create our own action that would run a docker container that does the deployment, runs tests and tears down following [this example](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-a-docker-container-action) and piggy-backing on the code in https://github.com/alan-turing-institute/binderhub-deploy (or https://github.com/alan-turing-institute/binderhub-deploy-gke if I ever get back around to it).

Related discussion: https://github.com/jupyterhub/mybinder.org-deploy/pull/1317#issuecomment-576564422 https://github.com/jupyterhub/mybinder.org-deploy/pull/1317#issuecomment-576586207 https://github.com/jupyterhub/mybinder.org-deploy/pull/1317#issuecomment-576609134 https://github.com/jupyterhub/mybinder.org-deploy/pull/1317#issuecomment-577165080