### PR TITLE
Manual update of binderhub helm chart

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -19,5 +19,5 @@ dependencies:
    tags:
      - certmanager
  - name: binderhub
-   version: 0.2.0-072.544c0b1
+   version: 0.2.0-n077.hef338bc
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Henchbot is out of action at the moment so this is a manual upgrade of the binderhub helm chart version.