### PR TITLE
Merge pull request #1330 from betatim/bump-r2d-356ea10

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -69,7 +69,7 @@ binderhub:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:0.10.0-133.gdb9f1ff
+      build_image: jupyter/repo2docker:0.10.0-159.g356ea10
       per_repo_quota: 100
       per_repo_quota_higher: 200
 


### PR DESCRIPTION
Contains:
* https://github.com/jupyter/repo2docker/pull/838
* https://github.com/jupyter/repo2docker/pull/793
* https://github.com/jupyter/repo2docker/pull/839
* https://github.com/jupyter/repo2docker/pull/840



This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/db9f1ff...356ea10
