### PR TITLE
enable event log on turing

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -8,8 +8,6 @@ letsencrypt:
   contactEmail: drsarahlgibson@gmail.com
 
 binderhub:
-  extraConfig:
-    01-eventlog: ""
   config:
     BinderHub:
       pod_quota: 20
@@ -49,6 +47,18 @@ binderhub:
         hosts:
           - binder.mybinder.turing.ac.uk
           - turing.mybinder.org
+
+  extraVolumes:
+    - name: event-secret
+      secret:
+        secretName: events-archiver-secret
+  extraVolumeMounts:
+    - name: event-secret
+      mountPath: /event-secret
+      readOnly: true
+  extraEnv:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /event-secret/service-account.json
 
   jupyterhub:
     hub:

--- a/docs/source/operation_guide/federation.rst
+++ b/docs/source/operation_guide/federation.rst
@@ -15,6 +15,7 @@ the BinderHub federation, who is in it, how to join it, etc, see
 gke.mybinder.org
 ovh.mybinder.org
 gesis.mybinder.org
+turing.mybinder.org
 ==========================  ========  ===============  ==============  =============== =====
 
 .. raw:: html
@@ -24,6 +25,7 @@ gesis.mybinder.org
        "https://gke.mybinder.org",
        "https://ovh.mybinder.org",
        "https://gesis.mybinder.org",
+       "https://turing.mybinder.org",
    ]
 
    // Use a dictionary to store the rows that should be updated


### PR DESCRIPTION
required two manual out-of-band steps:

1. create service account in google cloud console with Logs Writer role,
2. create a kubernetes secret containing the key for that service account

This is copying what is in the configuration for other non-GKE clusters

In the future, I think we should try to:

1. fully document the out-of-band steps needed for fully adding a cluster to the federation
1. store the service-account credentials in the encrypted secrets in this repo
1. deliver them to the cluster as secrets from this repo, so that the updates can be fully automatically with PRs here
