### PR TITLE
[MRG] Replace hard-coded helm version with environment variable in deploy.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ before_deploy:
 - |
   # Stage 2, Step 2: Set up helm!
   helm init --client-only
-  echo ${TRAVIS_HELM_VERSION}
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
   helm repo add jetstack https://charts.jetstack.io
   helm repo update

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_deploy:
   # Doing this here, since git crypt doesn't like unclean checkouts
 - |
   # Stage 4, Step 1: Deploy to staging
-  python ./deploy.py staging staging
+  HELM_VERSION=${TRAVIS_HELM_VERSION} python ./deploy.py staging staging
 - |
   # Stage 4, Step 2: Verify staging works
   travis_retry py.test -vx -n 2 --binder-url=https://gke.staging.mybinder.org --hub-url=https://hub.gke.staging.mybinder.org
@@ -92,13 +92,13 @@ before_deploy:
     "$(echo -en ${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${TRAVIS_REPO_SLUG}/pull/${PULL_REQUEST_ID})"
 - |
   # Stage 5, Step 2: Deploy to production
-  python ./deploy.py prod prod-a
+  HELM_VERSION=${TRAVIS_HELM_VERSION} python ./deploy.py prod prod-a
 - |
   # Stage 5, Step 3: Deploy to production on ovh k8s
-  python ./deploy.py ovh binder-ovh
+  HELM_VERSION=${TRAVIS_HELM_VERSION} python ./deploy.py ovh binder-ovh
 - |
   # Stage 5, Step 4: Deploy to production on Turing k8s
-  python ./deploy.py turing turing
+  HELM_VERSION=${TRAVIS_HELM_VERSION} python ./deploy.py turing turing
 - |
   # Stage 5, Step 5: Verify production works
   travis_retry py.test -vx -n 2 --binder-url=https://gke.mybinder.org --hub-url=https://hub.gke.mybinder.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_deploy:
   chmod +x ${HOME}/bin/kubectl
 - |
   # Stage 1: Install helm
-  curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  TRAVIS_HELM_VERSION=v2.11.0
+  curl -L https://storage.googleapis.com/kubernetes-helm/helm-${TRAVIS_HELM_VERSION}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
   mv ${HOME}/linux-amd64/helm ${HOME}/bin/helm
 - |
   # Stage 1: Install git-crypt
@@ -61,7 +62,6 @@ before_deploy:
 - |
   # Stage 2, Step 2: Set up helm!
   helm init --client-only
-  TRAVIS_HELM_VERSION=`helm version -c --short | sed 's/.*v\([0-9\.]*\).*/\1/'`
   echo ${TRAVIS_HELM_VERSION}
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
   helm repo add jetstack https://charts.jetstack.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ before_deploy:
 - |
   # Stage 2, Step 2: Set up helm!
   helm init --client-only
+  TRAVIS_HELM_VERSION=`helm version -c --short | sed 's/.*v\([0-9\.]*\).*/\1/'`
+  echo ${TRAVIS_HELM_VERSION}
   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
   helm repo add jetstack https://charts.jetstack.io
   helm repo update

--- a/deploy.py
+++ b/deploy.py
@@ -18,7 +18,7 @@ ABSOLUTE_HERE = os.path.dirname(os.path.realpath(__file__))
 # Get helm version environment variable
 HELM_VERSION = os.get_env("HELM_VERSION", None)
 if HELM_VERSION is None:
-    raise Exception("HELM_VERSION environment version must be set")
+    raise Exception("HELM_VERSION environment variable must be set")
 
 def setup_auth_turing(cluster):
     """

--- a/deploy.py
+++ b/deploy.py
@@ -15,6 +15,10 @@ NC = subprocess.check_output(['tput', 'sgr0']).decode()
 HERE = os.path.dirname(__file__)
 ABSOLUTE_HERE = os.path.dirname(os.path.realpath(__file__))
 
+# Get helm version environment variable
+HELM_VERSION = os.get_env("HELM_VERSION", None)
+if HELM_VERSION is None:
+    raise Exception("HELM_VERSION environment version must be set")
 
 def setup_auth_turing(cluster):
     """
@@ -113,23 +117,23 @@ def setup_helm(release):
         flush=True
     )
 
-    # Now check if the version of helm matches v2.11.0 which travis is expecting
-    if client_version != "v2.11.0":
-        # The local helm version is not v2.11.0 - user needs to change the installation
+    # Now check if the version of helm matches that which travis is expecting
+    if client_version != HELM_VERSION:
+        # The local helm version is not what was expected - user needs to change the installation
         raise Exception(
-            "You are not running helm v2.11.0 which is the version our continuous deployment system uses.\n" +
+            f"You are not running helm {HELM_VERSION} which is the version our continuous deployment system uses.\n" +
             "Please change your installation and try again.\n"
         )
-    elif (client_version == "v2.11.0") and (client_version != server_version):
+    elif (client_version == HELM_VERSION) and (client_version != server_version):
         # The correct local version of helm is installed, but the server side
         # has previously accidentally been upgraded. Perform a force-upgrade
-        # to bring the server side back to v2.11.0
+        # to bring the server side back to matching version
         raise Exception(
             "Helm client and server versions do not match. Performing a force upgrade often resolves this issue." +
             "Please run the following command and re-execute this script.\n\n\t" +
             "helm init --upgrade --force-upgrade"
         )
-    elif (client_version == "v2.11.0") and (client_version == server_version):
+    elif (client_version == HELM_VERSION) and (client_version == server_version):
         # All is good! Perform normal helm init command.
         # We use the --client-only flag so that the Tiller installation is not affected.
         subprocess.check_call(['helm', 'init', '--client-only'])


### PR DESCRIPTION
This PR will replace the hard-coded helm version in deploy.py with an environment variable that can be set within .travis.yml. This will mean that when the helm version is bumped, it only needs to be updated in one place.

TODOS:

- [x] Update deploy.py to include a HELM_VERSION environment variable
- [x] Update .travis.yml to extract the helm version and parse to deploy.py