### PR TITLE
Bump BinderHub chart version

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -19,5 +19,5 @@ dependencies:
    tags:
      - certmanager
  - name: binderhub
-   version: 0.2.0-n106.hd61fc9a
+   version: 0.2.0-n120.h207ae70
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/d61fc9a...207ae70