### PR TITLE
Correct getenv reference in deploy.py

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -16,7 +16,7 @@ HERE = os.path.dirname(__file__)
 ABSOLUTE_HERE = os.path.dirname(os.path.realpath(__file__))
 
 # Get helm version environment variable
-HELM_VERSION = os.get_env("HELM_VERSION", None)
+HELM_VERSION = os.getenv("HELM_VERSION", None)
 if HELM_VERSION is None:
     raise Exception("HELM_VERSION environment variable must be set")
 


### PR DESCRIPTION
Correcting a typo in `deploy.py`. `os.get_env()` --> `os.getenv()`.