### PR TITLE
Set redirect code back to 307

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -198,7 +198,7 @@ class RedirectHandler(RequestHandler):
         # redirect = url_concat(host_name + uri, {'binder_launch_host': 'https://mybinder.org/'})
         redirect = host_name + uri
         app_log.info('Redirecting {} to {}'.format(path, host_name))
-        self.redirect(redirect, status=302)
+        self.redirect(redirect, status=307)
 
 
 class ActiveHostsHandler(RequestHandler):


### PR DESCRIPTION
302 was checked for CORS-related issues, but not it.

This reverts commit 3caa5d5d93b471172f9315c8ec11da2cfb280581.