### PR TITLE
[RVW] Migrate Turing cert-manager to using ingressShim config instead of annotations

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -36,7 +36,6 @@ binderhub:
       - binder.mybinder.turing.ac.uk
       - turing.mybinder.org
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-prod
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: "true"
       https:
@@ -97,7 +96,6 @@ binderhub:
     ingress:
       enabled: true
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-prod
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
         https:
@@ -122,7 +120,6 @@ binderhub:
 grafana:
   ingress:
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-prod
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: 'true'
     hosts:
@@ -148,7 +145,6 @@ prometheus:
   server:
     ingress:
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-prod
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: 'true'
       hosts:
@@ -172,7 +168,6 @@ nginx-ingress:
 static:
   ingress:
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-prod
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: 'true'
     hosts:
@@ -212,3 +207,9 @@ gcsProxy:
   buckets:
     - name: mybinder-staging-events-archive
       host: archive-analytics-staging-mybinder.turing.10.0.0.1.xip.io
+
+cert-manager:
+  ingressShim:
+    defaultIssuerName: "letsencrypt-prod"
+    defaultIssuerKind: "Issuer"
+    defaultACMEChallengeType: "http01"

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -209,6 +209,8 @@ gcsProxy:
       host: archive-analytics-staging-mybinder.turing.10.0.0.1.xip.io
 
 cert-manager:
+  webhook:
+    enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "Issuer"


### PR DESCRIPTION
This change is at the advice of @consideRatio, see https://github.com/jupyterhub/mybinder.org-deploy/issues/1148#issuecomment-588651294 