### PR TITLE
Undo changes to try out cert-manager

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,9 +1,5 @@
 projectName: binder-staging
 
-tags:
-  kubelego: false
-  certmanager: true
-
 binderhub:
   config:
     BinderHub:
@@ -17,11 +13,6 @@ binderhub:
     hosts:
       - gke.staging.mybinder.org
       - gke2.staging.mybinder.org
-    tls:
-      - secretName: certmanager-tls-binderhub-staging
-        hosts:
-          - gke.staging.mybinder.org
-          - gke2.staging.mybinder.org
 
   jupyterhub:
     singleuser:
@@ -35,7 +26,7 @@ binderhub:
       hosts:
         - hub.gke.staging.mybinder.org
       tls:
-        - secretName: certmanager-tls-jupyterhub-staging
+        - secretName: kubelego-tls-jupyterhub-staging
           hosts:
             - hub.gke.staging.mybinder.org
     scheduling:
@@ -49,7 +40,7 @@ grafana:
     tls:
       - hosts:
           - grafana.staging.mybinder.org
-        secretName: certmanager-tls-grafana
+        secretName: kubelego-tls-grafana
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -70,7 +61,7 @@ prometheus:
       tls:
         - hosts:
             - prometheus.staging.mybinder.org
-          secretName: certmanager-tls-prometheus
+          secretName: kubelego-tls-prometheus
 
 nginx-ingress:
   controller:


### PR DESCRIPTION
This undoes the changes from #1369 and #1368. It seems that the partial cert-manager install attempts in the past have left stuff behind that is hard to remove completely and so all attempts to add it now end with weird errors about resources which are present in the cluster not being found.