### PR TITLE
Revert "binderhub: 0.2.0-n126.h5a1202f...0.2.0-n128.h00b0576"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -19,5 +19,5 @@ dependencies:
    tags:
      - certmanager
  - name: binderhub
-   version: 0.2.0-n128.h00b0576
+   version: 0.2.0-n126.h5a1202f
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1372

When visiting a page like https://staging.mybinder.org/v2/gh/binder-examples/conda/master we get "Error resolving ref for gh:binder-examples/conda/master: HTTP 401: Unauthorized". Investigating.