### PR TITLE
Use a ClusterIssuer by default

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -213,5 +213,5 @@ cert-manager:
     enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
-    defaultIssuerKind: "Issuer"
+    defaultIssuerKind: "ClusterIssuer"
     defaultACMEChallengeType: "http01"


### PR DESCRIPTION
Change the ingress shim used by the turing cluster to use a `ClusterIssuer` as the default issuer kind.