### PR TITLE
Switch to using meta-channel for conda

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,9 @@
 name: mybinder
 channels:
-  - conda-forge
+  # use metachannel for faster solves / less memory on RTD
+  # which has memory issues with full conda-forge
+  # only need to list 'leaf' dependencies here
+  - https://metachannel.conda-forge.org/conda-forge/python,sphinx,recommonmark
 dependencies:
 - python=3.6
 - sphinx>=1.8.2


### PR DESCRIPTION
Use a meta channel for conda in order to use less memory and make solving faster.
Right now we keep running into the memory limit of RTD. The ideas has been taken
from https://github.com/jupyterhub/jupyterhub/pull/2943

Before this PR our docs builds on RTD were failing with:
```
$ conda env create --quiet --name latest --file docs/environment.yml
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
Collecting package metadata (repodata.json): ...working... Killed


Command killed due to excessive memory consumption 
```