### PR TITLE
bring gesis binder back into federation

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -3,7 +3,6 @@ projectName: binder-staging
 binderhub:
   config:
     BinderHub:
-      pod_quota: 0
       hub_url: https://hub.gke.staging.mybinder.org
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
@@ -120,11 +119,11 @@ federationRedirect:
       versions: https://gke.staging.mybinder.org/versions
     ovh:
       url: https://gke2.staging.mybinder.org
-      weight: 0
+      weight: 1
       health: https://gke2.staging.mybinder.org/health
       versions: https://gke2.staging.mybinder.org/versions
     # unset the gesis and turing entries
     gesis:
-      weight: 1
+      weight: 0
     turing:
       weight: 0

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -431,7 +431,7 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     gesis:
       url: https://gesis.mybinder.org
-      weight: 0
+      weight: 15
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     turing:


### PR DESCRIPTION
Yesterday in the team meeting we decided to bring GESIS Binder back. 

https://github.com/jupyterhub/mybinder.org-deploy/issues/1344#issuecomment-601030580