### PR TITLE
Add image cleaner absolute size to turing config

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -117,6 +117,12 @@ binderhub:
         enabled: true
         replicas: 5
 
+  imageCleaner:
+    # Use 40GB as upper limit, size is given in bytes
+    imageGCThresholdHigh: 40e9
+    imageGCThresholdLow: 30e9
+    imageGCThresholdType: "absolute"
+
 grafana:
   ingress:
     annotations:


### PR DESCRIPTION
Sometimes the nodes on the Turing cluster are put into a `Ready,SchedulingDisabled` state. This PR tests if the issue is related to `dind` and `dockerd` garbage cleaning by implementing the absolute image size to be cleaned as in https://github.com/jupyterhub/binderhub/pull/1019