### PR TITLE
Increase the limit of a california-civic-data-coalition repository

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,6 +63,9 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
+        - pattern: ^california-civic-data-coalition/first-python-notebook-binder.*
+          config:
+            quota: 150
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
ref: https://github.com/jupyterhub/team-compass/issues/270

Increasing the limit to 150 concurrent instances.