### PR TITLE
Revert "Increase the limit of a california-civic-data-coalition repository"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,9 +63,6 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        - pattern: ^california-civic-data-coalition/first-python-notebook-binder.*
-          config:
-            quota: 150
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1391

This repo never saw action so I'm removing the increased limit again to do some housekeeping.