### PR TITLE
Upgrade from certmanager 0.12.0.beta1 to 0.12.0

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
    tags:
      - kubelego
  - name: cert-manager
-   version: v0.12.0-beta.1
+   version: v0.12.0
    repository: https://charts.jetstack.io
    tags:
      - certmanager


### PR DESCRIPTION
This will update the version of the certmanager chart from 0.12.0.beta1 to 0.12.0. I think this will be mostly a none event and just housekeeping.