### PR TITLE
Enable certmanager on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,5 +1,9 @@
 projectName: binder-staging
 
+tags:
+  kubelego: false
+  certmanager: true
+
 binderhub:
   config:
     BinderHub:
@@ -107,6 +111,14 @@ gcsProxy:
   buckets:
     - name: mybinder-staging-events-archive
       host: archive.analytics.staging.mybinder.org
+
+cert-manager:
+  webhook:
+    enabled: false
+  ingressShim:
+    defaultIssuerName: "letsencrypt-staging"
+    defaultIssuerKind: "ClusterIssuer"
+    defaultACMEChallengeType: "http01"
 
 federationRedirect:
   host: staging.mybinder.org

--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: drsarahlgibson@gmail.com
+    email: binder-team@googlegroups.com
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:
@@ -22,7 +22,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: drsarahlgibson@gmail.com
+    email: binder-team@googlegroups.com
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:


### PR DESCRIPTION
This will install cert-manager on staging. However we won't use it to request certificates yet, only install it. I also switched the contact email address to the team address as proposed in #1362

To prepare for this I ran the following commands locally:
```
$ kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/deploy/manifests/00-crds.yaml
$ kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
$ kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
```
The first two remove CRDs from old versions of cert-manager. In a "clean" cluster those should not be installed however because of our previous attempts they did exist on staging.

One way of testing if things are "working" or if there are still old versions left was to run 
```
$ kubectl get cr --all-namespaces
error: the server doesn't have a resource type "cr"
```
The error printed will only show up when something is "wrong". It is important to use the shortname `cr` and not `certificaterequests`. The latter will always print the expected output of `No resources found`. The shorthand version seems to fail when something isn't quite right yet.