### PR TITLE
Switch to prod Let's Encrypt instance

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -116,7 +116,7 @@ cert-manager:
   webhook:
     enabled: false
   ingressShim:
-    defaultIssuerName: "letsencrypt-staging"
+    defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "ClusterIssuer"
     defaultACMEChallengeType: "http01"
 


### PR DESCRIPTION
It seems like cert-manager is working and staging.mybinder.org now has a certificate from "staging" let's encrypt. This PR switches us to the prod LE.