### PR TITLE
Staging Grafana allow_embedding

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -52,6 +52,8 @@ grafana:
           access: direct
           isDefault: true
           editable: false
+  grafana.ini:
+    allow_embedding: true
 
 prometheus:
   server:


### PR DESCRIPTION
This is an attempt to fix https://github.com/jupyterhub/binder/issues/195 on staging

The latest Grafana has an `allow_embedding` option that defaults to `false`:
https://grafana.com/docs/grafana/latest/installation/configuration/#allow-embedding

The latest Grafana Helm chart has a `grafana.ini` section:
https://github.com/helm/charts/blob/95a25a1f283ffc56b92fc2b493c1756a8d76d4f5/stable/grafana/values.yaml#L385-L396

The current mybinder Grafana config doesn't have a `grafana.ini` section which I think means it should be inheriting the default, but we should ideally check.

## Testing whether this works

Currently
```
$ curl -IL grafana.staging.mybinder.org
```
includes this header
```
x-frame-options: deny
```
Hopefully when this is merged the above header should be different or omitted- and assuming nothing else breaks this can be copied to prod