### PR TITLE
Pin Sphinx to <3

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=1.8.2
+sphinx>=1.8.2,<3
 recommonmark
 https://github.com/pandas-dev/pandas-sphinx-theme/archive/ade576c92cfe46a372b6783fb83f45c44fc67976.zip

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.8.2,<3
 recommonmark
-https://github.com/pandas-dev/pandas-sphinx-theme/archive/ade576c92cfe46a372b6783fb83f45c44fc67976.zip
+pydata-sphinx-theme==0.1.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pandas_sphinx_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
The docs build failed in https://github.com/jupyterhub/mybinder.org-deploy/pull/1410
```
#!/bin/bash -eo pipefail
cd docs
make html

Running Sphinx v3.0.1
making output directory... done

Theme error:
no theme named 'pandas_sphinx_theme' found (missing theme.conf?)
Makefile:20: recipe for target 'html' failed
make: *** [html] Error 2

Exited with code exit status 2
```
https://circleci.com/gh/jupyterhub/mybinder.org-deploy/433

This is to see whether it's due to the new release of Sphinx.