### PR TITLE
Revert "staging grafana allow_embedding"

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -55,8 +55,6 @@ grafana:
           access: direct
           isDefault: true
           editable: false
-  grafana.ini:
-    allow_embedding: true
 
 prometheus:
   server:


### PR DESCRIPTION
After merging https://github.com/jupyterhub/mybinder.org-deploy/pull/1410
```
curl -IL grafana.staging.mybinder.org
```
still outputs a `x-frame-options: deny`

I suspect either more changes are needed, or my Helm chart config (I used https://github.com/helm/charts/blob/95a25a1f283ffc56b92fc2b493c1756a8d76d4f5/stable/grafana/values.yaml#L385-L396 for reference but that is for chart version `5.0.13` whereas mybinder.org uses `3.10.0`:
https://github.com/jupyterhub/mybinder.org-deploy/blob/a77410f5efad59038cea6fe2e94d14fb4c20e1de/mybinder/requirements.yaml#L8-L9

Reverting the PR so that staging and prod are the same until someone else has time to investigate.