### PR TITLE
Update to Sphinx≥3.0.1

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=1.8.2
+sphinx>=3.0.1
 recommonmark
 https://github.com/pandas-dev/pandas-sphinx-theme/archive/ade576c92cfe46a372b6783fb83f45c44fc67976.zip

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=3.0.1
 recommonmark
-https://github.com/pandas-dev/pandas-sphinx-theme/archive/ade576c92cfe46a372b6783fb83f45c44fc67976.zip
+pydata-sphinx-theme==0.1.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,15 +30,12 @@ from datetime import datetime
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.intersphinx', 'recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # Source parsers for things other than '.rst'
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # Use autostructify so we can get some rST in the markdown
 from recommonmark.transform import AutoStructify

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pandas_sphinx_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This is an alternative to https://github.com/jupyterhub/mybinder.org-deploy/pull/1411

- Updates the doc build to work with Sphinx 3 (Thanks @rkdarst for figuring this out in https://github.com/jupyterhub/jupyterhub/pull/3021)
- Switches to a released version of `pydata_sphinx_theme`, formerly known as `pandas_sphinx_theme`
