### PR TITLE
Remove --wait and move --timeout from helm to kubectl

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -218,21 +218,14 @@ def deploy(release):
 
     # Explicitly wait for all deployments and daemonsets to be fully rolled out
     print(BOLD + GREEN + f"Waiting for all deployments and daemonsets in {release} to be ready" + NC, flush=True)
-    deployments = subprocess.check_output([
+    deployments_and_daemonsets = subprocess.check_output([
         'kubectl',
         '--namespace', release,
-        'get', 'deployments',
+        'get', 'deployments,daemonsets',
         '-o', 'name'
     ]).decode().strip().split('\n')
 
-    daemonsets = subprocess.check_output([
-        'kubectl',
-        '--namespace', release,
-        'get', 'daemonsets',
-        '-o', 'name'
-    ]).decode().strip().split('\n')
-
-    for d in deployments + daemonsets:
+    for d in deployments_and_daemonsets:
         subprocess.check_call([
             'kubectl', 'rollout', 'status',
             '--namespace', release,

--- a/deploy.py
+++ b/deploy.py
@@ -207,9 +207,7 @@ def deploy(release):
         release,
         'mybinder',
         '--force',
-        '--wait',
         '--cleanup-on-fail',
-        '--timeout', '600',
         '-f', os.path.join('config', release + '.yaml'),
         '-f', os.path.join('secrets', 'config', 'common.yaml'),
         '-f', os.path.join('secrets', 'config', release + '.yaml'),
@@ -238,6 +236,7 @@ def deploy(release):
         subprocess.check_call([
             'kubectl', 'rollout', 'status',
             '--namespace', release,
+            '--timeout', '5m',
             '--watch', d
         ])
 


### PR DESCRIPTION
Using --wait with helm is risky, because any cancellation during the
wait can let us fail to do the --cleanup-on-fail, which is the failsafe
to avoid getting stranded resources that are unmanaged according to helm
which can cause subsequent upgrade failures because "<...> already
exists."

Closes #1417 which describes the issue further.