### PR TITLE
CI: updating kubectl so expected flags exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_deploy:
 - |
   # Stage 1: Install Kubectl
   mkdir -p ${HOME}/bin
-  curl -L https://storage.googleapis.com/kubernetes-release/release/v1.11.4/bin/linux/amd64/kubectl > ${HOME}/bin/kubectl
+  curl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl > ${HOME}/bin/kubectl
   chmod +x ${HOME}/bin/kubectl
 - |
   # Stage 1: Install helm


### PR DESCRIPTION
#1418 failed when merged into staging because kubectl was outdated and didn't contain the `--timeout` flag for the `kubectl rollout status` command in the version we currently use.

I think it should work fine to use a very modern client no matter what the k8s clusters we work against.