### PR TITLE
[MRG] Move the turing cluster to the staging federation

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -134,8 +134,11 @@ federationRedirect:
       weight: 1
       health: https://gke2.staging.mybinder.org/health
       versions: https://gke2.staging.mybinder.org/versions
-    # unset the gesis and turing entries
-    gesis:
-      weight: 0
     turing:
+      url: https://turing.mybinder.org
+      weight: 1
+      health: https://turing.mybinder.org/health
+      versions: https://turing.mybinder.org/versions
+    # unset the gesis entry
+    gesis:
       weight: 0

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -438,10 +438,7 @@ federationRedirect:
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     turing:
-      url: https://turing.mybinder.org
-      weight: 1
-      health: https://turing.mybinder.org/health
-      versions: https://turing.mybinder.org/versions
+      weight: 0
 
 certmanager:
   ingressShim:


### PR DESCRIPTION
The Turing cluster will be maintained/unavailable so we are moving it
to the staging federation. We want to see if the federation redirect/health checks are good enough that the cluster will be automatically removed from the set of healthy hosts during the maintenance window or not.

closes #1425

Leaving this for @sgibson91 to merge. I think this is what needs changing, at least it is what I'd change. If you spot something else let me know and we can add it.