### PR TITLE
Define URLs for Turing federation member

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -438,7 +438,11 @@ federationRedirect:
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     turing:
+      turing:
+      url: https://turing.mybinder.org
       weight: 0
+      health: https://turing.mybinder.org/health
+      versions: https://turing.mybinder.org/versions
 
 certmanager:
   ingressShim:


### PR DESCRIPTION
Fixes a problem in the federation config from #1426 

We can't remove all the details about an entry. Instead we only set the weight to zero. This is something we could improve about the federation proxy. Right now if the config is not like it expects it, it will crash.

What saved us from a total outage on mybinder.org is that we run two replicas and only one of them got replaced with the crashing version.