### PR TITLE
[MRG] Switch to cert-manager from kubelego on OVH

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -1,5 +1,9 @@
 projectName: ovh
 
+tags:
+  kubelego: false
+  certmanager: true
+
 binderhub:
   config:
     BinderHub:
@@ -201,3 +205,12 @@ gcsProxy:
   buckets:
     - name: mybinder-staging-events-archive
       host: archive-analytics-staging-mybinder.mybinder.ovh
+
+
+cert-manager:
+  webhook:
+    enabled: false
+  ingressShim:
+    defaultIssuerName: "letsencrypt-prod"
+    defaultIssuerKind: "ClusterIssuer"
+    defaultACMEChallengeType: "http01"


### PR DESCRIPTION
Follow up to #1415 that installs cert-manager on OVH.

There were no cRDs on the cluster so we didn't have to delete any.

I installed cert-manager v0.12 with `kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml` and then merged this PR.