### PR TITLE
[MRG] Increase limit to 200 for guiwitz/neubias_academy_biapy

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,7 +63,7 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        - pattern: ^hugobowne/COVID-19-EDA-tutorial.*
+        - pattern: ^guiwitz/neubias_academy_biapy.*
           config:
             quota: 200
 


### PR DESCRIPTION
This will lift the limit for a repository used during a "at home" school for image processing.

More details in https://github.com/jupyterhub/mybinder.org-deploy/issues/1430
