### PR TITLE
[MRG] Add a Jitsi link to our page template

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -20,11 +20,12 @@ binder_persistent_request = os.environ.get('BINDER_PERSISTENT_REQUEST', '')
 
 repo_url = os.environ.get('BINDER_REPO_URL', '')
 
-if repo_url:
+# Roll this out only for binder-example repos to gain experience
+if repo_url and "binder-example" in repo_url:
     # Need a simple way to generate a stable but unique value for every repo
     # that we can then use to create a Jitsi meet URL
     unique = hashlib.md5(repo_url.encode())[:10]
-    jitsi_url = 'https://meet.jit.si/mybinder.org-%s#config.startWithAudioMuted=true&config.prejoinPageEnabled=true' % unique
+    jitsi_url = 'https://meet.jit.si/mybinder.org-%s#config.startWithVideoMuted=true&config.startWithAudioMuted=true&config.prejoinPageEnabled=true' % unique
 else:
     jitsi_url = ''
 

--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -24,7 +24,7 @@ repo_url = os.environ.get('BINDER_REPO_URL', '')
 if repo_url and "binder-example" in repo_url:
     # Need a simple way to generate a stable but unique value for every repo
     # that we can then use to create a Jitsi meet URL
-    unique = hashlib.md5(repo_url.encode())[:10]
+    unique = hashlib.md5(repo_url.encode())
     jitsi_url = 'https://meet.jit.si/mybinder.org-%s#config.startWithVideoMuted=true&config.startWithAudioMuted=true&config.prejoinPageEnabled=true' % unique
 else:
     jitsi_url = ''

--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -1,5 +1,6 @@
 import notebook
 import os
+import hashlib
 
 from distutils.version import LooseVersion as V
 
@@ -17,9 +18,20 @@ binder_launch_host = os.environ.get('BINDER_LAUNCH_HOST', '')
 binder_request = os.environ.get('BINDER_REQUEST', '')
 binder_persistent_request = os.environ.get('BINDER_PERSISTENT_REQUEST', '')
 
+repo_url = os.environ.get('BINDER_REPO_URL', '')
+
+if repo_url:
+    # Need a simple way to generate a stable but unique value for every repo
+    # that we can then use to create a Jitsi meet URL
+    unique = hashlib.md5(repo_url.encode())[:10]
+    jitsi_url = 'https://meet.jit.si/mybinder.org-%s#config.startWithAudioMuted=true&config.prejoinPageEnabled=true' % unique
+else:
+    jitsi_url = ''
+
 c.NotebookApp.jinja_template_vars.update({
     'binder_url': binder_launch_host+binder_request,
     'persistent_binder_url': binder_launch_host+binder_persistent_request,
-    'repo_url': os.environ.get('BINDER_REPO_URL', ''),
+    'repo_url': repo_url,
     'ref_url': os.environ.get('BINDER_REF_URL', ''),
+    'jitsi_url': jitsi_url,
 })

--- a/mybinder/files/etc/jupyter/templates/page.html
+++ b/mybinder/files/etc/jupyter/templates/page.html
@@ -5,6 +5,11 @@
 {% block login_widget %}
 {% endblock %}
 
+{% if jitsi_url %}
+    <a id="visit-repo-link" href="{{ jitsi_url }}" class="btn btn-default btn-sm navbar-btn" target="_blank"
+       style="margin-right: 2px; margin-left: 4px;">Start Video Chat</a></span>
+{% endif %}
+
 {% if ref_url %}
 <span>
     <a id="visit-repo-link" href="{{ ref_url }}" class="btn btn-default btn-sm navbar-btn" target="_blank"

--- a/mybinder/files/etc/jupyter/templates/page.html
+++ b/mybinder/files/etc/jupyter/templates/page.html
@@ -7,7 +7,7 @@
 
 {% if jitsi_url %}
     <a id="visit-repo-link" href="{{ jitsi_url }}" class="btn btn-default btn-sm navbar-btn" target="_blank"
-       style="margin-right: 2px; margin-left: 4px;">Start Video Chat</a></span>
+       style="margin-right: 2px; margin-left: 4px;">Join this repo's Video Chat</a></span>
 {% endif %}
 
 {% if ref_url %}


### PR DESCRIPTION
This gives every Binder a unique Jitsi room that people can join to talk
about that particular repository.

When people click the link to the jitsi room they arrive on a "entrance" page, so people aren't immediately "live" in the conference call. They also join audio muted. I think this could be super useful ... or super weird. I think we should run it for a bit and see what happens.

Original idea and inspiration via @yuvipanda https://twitter.com/yuvipanda/status/1263355644184158208