### PR TITLE
k8s 1.16 compatibility

### DIFF
--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.proxyPatches.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy-patches
@@ -8,8 +8,12 @@ metadata:
     component: proxy-patches
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-
 spec:
+  selector:
+    matchLabels:
+      app: proxy-patches
+      component: proxy-patches
+      release: {{ .Release.Name }}
   replicas: 1
   template:
     metadata:
@@ -18,9 +22,9 @@ spec:
       labels:
         app: proxy-patches
         component: proxy-patches
-        hub.jupyter.org/network-access-proxy-api: "true"
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        hub.jupyter.org/network-access-proxy-api: "true"
     spec:
       nodeSelector: {{ toJson .Values.proxyPatches.nodeSelector }}
       volumes:

--- a/mybinder/templates/redirector/deployment.yaml
+++ b/mybinder/templates/redirector/deployment.yaml
@@ -1,13 +1,17 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redirector
+  labels:
+    app: redirector
+    component: nginx
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
       app: redirector
       component: nginx
-      heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
   replicas: 1
   template:


### PR DESCRIPTION
Various apiVersion for Deployment resources became unsupported in k8s
1.16, so this commit makes us use apps/v1 instead. While doing so we
also need to add the `selector` field of the Deployment specification.

Based on Helm's recommended practices, I exclude the heritage label from
the selector, but I don't update other deployments with this practice as
it is not something I think will matter.

---

This is meant to fix issues in #1445 about not being able to upgrade to k8s 1.16, but I'm just fixing things I know needs fixing in a k8s 1.16 environment without actually knowing if these were the issues needed fixing.