### PR TITLE
[MRG] Stop automounting the default service account token

### DIFF
--- a/mybinder/templates/federation-redirect/deployment.yaml
+++ b/mybinder/templates/federation-redirect/deployment.yaml
@@ -39,6 +39,7 @@ spec:
       - name: config
         configMap:
           name: federation-redirect
+      automountServiceAccountToken: false
       containers:
       - name: federation-redirect
         image: {{ .Values.federationRedirect.image.name}}:{{ .Values.federationRedirect.image.tag }}


### PR DESCRIPTION
The federation proxy doesn't need access to the Kubernetes API so it
doesn't need to have a token for the default service account either.

The token allows you to access the kubernetes API, but this pod doesn't need this so we remove the token. This reduces the number of things someone who manages to break into this container can do.

A good starting point for reading more https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server