### PR TITLE
Remove Turing from the Federation

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -10,7 +10,7 @@ letsencrypt:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 80
+      pod_quota: 0
       hub_url: https://hub.mybinder.turing.ac.uk
       badge_base_url: https://mybinder.org
       sticky_builds: true


### PR DESCRIPTION
Setting Turing's pod quota to zero til I figure out why the h*ll the chart won't upgrade