### PR TITLE
set fetch-depth: 0 on checkout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,8 @@ jobs:
       # Action Repo: https://github.com/actions/checkout
       - name: "Stage 0: Checkout repo"
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Action Repo: https://github.com/actions/setup-python
       - name: "Stage 0: Setup Python 3.6"


### PR DESCRIPTION
I believe the default depth of 1 means tags are unavailable, preventing `git describe` from doing what chartpress expects it to, causing unnecessary rebuilds

We had this set [on travis](https://github.com/jupyterhub/mybinder.org-deploy/blob/847f39b0c097307ea31ad3d59f104ffd0d4a93e5/.travis.yml#L3-L4).
