### PR TITLE
increase placeholders to 75 on GKE prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -92,7 +92,7 @@ binderhub:
             - hub.gke.mybinder.org
     scheduling:
       userPlaceholder:
-        replicas: 25
+        replicas: 75
       userScheduler:
         nodeSelector: *coreNodeSelector
 


### PR DESCRIPTION
this reserves ~three quarters of a node as always idle, so we have more runway for scale-up events

increasing the number of placeholder pods increases the size of a spike in launch traffic we can handle by starting a node scale-up event earlier,
making it more likely that the node is ready when 'real' user pods start being assigned to it

75 is a lot! We should only have it this high during SciPy or similar events, and bring it back down to ~25 when it's over