### PR TITLE
bump prometheus chart to 11

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
    version: 0.20.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
-   version: 9.1.2
+   version: 11.0.2
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
    version: 3.10.1


### PR DESCRIPTION
this appears to eliminate the use of extensions/v1beta1, which is causing deployments to turing to fail (#1485)

unclear why other deployments are not seeing a similar failure, since GKE/OVH are on 1.15 and GESIS is on 1.18 while turing is on 1.16. Maybe it's a change in 1.16 and GESIS doesn't deploy this prometheus chart version?
