### PR TITLE
bump nginx-ingress chart to 1.40.3

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
  - name: nginx-ingress
-   version: 0.20.0
+   version: 1.40.3
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
    version: 11.0.2


### PR DESCRIPTION
following #1493, nginx-ingress also uses Deployment removed from extensions/v1beta1

this might get turing back (#1485)