### PR TITLE
Revert "bump nginx-ingress chart to 1.40.3"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
  - name: nginx-ingress
-   version: 1.40.3
+   version: 0.20.0
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
    version: 11.0.2


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1494

nginx-ingress bump isn't happy! Roll it back while we figure out what needs to be done