### PR TITLE
set OVH nodeSelector for nginx-ingress

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -162,6 +162,9 @@ nginx-ingress:
   controller:
     hostNetwork: true
     replicaCount: 1
+    # OVH host-networking requires ingress controller on node-1
+    nodeSelector:
+      kubernetes.io/hostname: node-1
   scope:
     enabled: false
 


### PR DESCRIPTION
OVH cluster uses host-networking, which means ingress must stay on node-1 for DNS to resolve