### PR TITLE
Increase limits for PyHEP conference day 1

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -83,6 +83,14 @@ binderhub:
         - pattern: ^dask/dask-tutorial.*
           config:
             quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1500
+        - pattern: ^ganga-devs/ganga.*
+          config:
+            quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1499
+        - pattern: ^jpivarski/2020-07-13-pyhep2020-tutorial.*
+          config:
+            quota: 400
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
xref #1499 and #1500 for details

Dealing with the repos for the first day of the conference only. The limit is increased to 300 ("ganga tutorial") and 400 ("awkward array tutorial"). These are both below the requested number off ~600. Let's discuss tomorrow (Monday) morning if we want to increase the limit even further. For a live stream with about 600-700 viewers in the stream 200 was a good limit that corresponded to basically the number of concurrent instances for that repo.

It would be good to gain some experience with what the scale factor is between registered number of people and concurrent binder pods.

Another thing to ponder is that currently all of mybinder.org peaks at around 700-800 concurrent pods. Nearly doubling this will certainly lead to "interesting" things happening.