### PR TITLE
Remove old resource bumps, add new pyhep ones

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,34 +63,20 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1476
-        - pattern: ^ericmjl/bayesian-stats-modelling-tutorial.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1477
-        - pattern: ^hugobowne/deep-learning-from-scratch-pytorch.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1479
-        - pattern: ^xarray-contrib/xarray-tutorial.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1480
-        - pattern: ^carpentries-incubator/introduction-to-conda-for-data-scientists.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1483
-        - pattern: ^dask/dask-tutorial.*
-          config:
-            quota: 300
         # https://github.com/jupyterhub/mybinder.org-deploy/issues/1500
         - pattern: ^ganga-devs/ganga.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1499
-        - pattern: ^jpivarski/2020-07-13-pyhep2020-tutorial.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1506
+        - pattern: ^riga/law_pyhep2020.*
           config:
-            quota: 400
+            quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1512
+        - pattern: ^HDembinski/pyhep-2020-resample.*
+          config:
+            quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1514
+        - pattern: ^stwunsch/pyhep2020-pyroot.*
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
xref: #1506 #1512 #1514

This PR started to see if we can make a trivial edit to get GH Actions to run, then I cleaned out the scipy repos that had gotten resource bumps and added the PyHEP ones for tomorrow.