### PR TITLE
Allocate resources for PyHEP 2020 2020-07-15 talks

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,20 +63,20 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1500
-        - pattern: ^ganga-devs/ganga.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1501
+        - pattern: ^CoffeaTeam/coffea-casa-tutorials.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1506
-        - pattern: ^riga/law_pyhep2020.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1523
+        - pattern: ^lukasheinrich/pyhep2020-autodiff-tutorial.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1512
-        - pattern: ^HDembinski/pyhep-2020-resample.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1510
+        - pattern: ^phinate/neos.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1514
-        - pattern: ^stwunsch/pyhep2020-pyroot.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1521
+        - pattern: ^henryiii/python-performance-minicourse.*
           config:
             quota: 300
 


### PR DESCRIPTION
xref: #1501 #1523 #1510 #1521

* Resolves #1500 
* Resolves #1506 
* Resolves #1512 
* Resolves #1514

This PR allocates 300 pods per talk on [day 3 of PyHEP 2020 (2020-07-15)](https://indico.cern.ch/event/882824/timetable/#day-2020-07-15) (following PR #1515 as a reference). It subsequently deallocates resources from day 2 of PyHEP 2020 and so should not be merged until the night of 2020-07-14 Pacific time or the morning of 2020-07-15 Euorpean time (depending on who is going to review it and is merge shifter). 

cc @betatim 