### PR TITLE
Allocate resources for PyHEP 2020 2020-07-16 talks

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,22 +63,26 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1501
-        - pattern: ^CoffeaTeam/coffea-casa-tutorials.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1518
+        - pattern: ^zfit/PyHEP2020.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1523
-        - pattern: ^lukasheinrich/pyhep2020-autodiff-tutorial.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1504
+        - pattern: ^SModelS/pyhep2020.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1510
-        - pattern: ^phinate/neos.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1513
+        - pattern: ^HDembinski/pyhep-2020-iminuit.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1521
-        - pattern: ^henryiii/python-performance-minicourse.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1503
+        - pattern: ^kropiv/MLforNIatPyHEP.*
           config:
-            quota: 300
+            quota: 200
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1507
+        - pattern: ^pyhf/tutorial-PyHEP-2020.*
+          config:
+            quota: 200
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
xref: #1518 #1504 #1513 #1503 #1507

* Resolves #1501
* Resolves #1523
* Resolves #1510 
* Resolves #1521 

This PR allocates 300 (200) pods per "Atlantic" ("Pacific") talk on day 4 of PyHEP 2020 (2020-07-16) (following PR #1515 as a reference). It subsequently deallocates resources from day 3 of PyHEP 2020 and so should not be merged until the night of 2020-07-15 Pacific time or the morning of 2020-07-16 Euorpean time (depending on who is going to review it and is merge shifter).

cc @betatim