### PR TITLE
pause deployments to turing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,9 +138,9 @@ jobs:
             binder_url: https://gke.mybinder.org
             hub_url: https://hub.gke.mybinder.org
             cluster_name: prod-a
-          - federation_member: turing
-            binder_url: https://turing.mybinder.org
-            hub_url: https://hub.mybinder.turing.ac.uk
+          # - federation_member: turing
+          #   binder_url: https://turing.mybinder.org
+          #   hub_url: https://hub.mybinder.turing.ac.uk
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh


### PR DESCRIPTION
while turing is not yet accepting new deployments

This should get our Actions status passing.

We should re-add turing when we fix the nginx-ingress chart update.