### PR TITLE
Allocate resources for PyHEP 2020 2020-07-17 talks

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,24 +63,28 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1518
-        - pattern: ^zfit/PyHEP2020.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1522
+        - pattern: ^henryiii/bh-talk-pyhep-2020.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1504
-        - pattern: ^SModelS/pyhep2020.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1519
+        - pattern: ^martinschwinzerl/pyhep2020-cxx-bindings.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1513
-        - pattern: ^HDembinski/pyhep-2020-iminuit.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1520
+        - pattern: ^aoeftiger/pyhep2020.*
           config:
             quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1503
-        - pattern: ^kropiv/MLforNIatPyHEP.*
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1517
+        - pattern: ^andrzejnovak/2020-07-17-pyhep2020-mplhep.*
           config:
-            quota: 200
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1507
-        - pattern: ^pyhf/tutorial-PyHEP-2020.*
+            quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1502
+        - pattern: ^matt-komm/pyhep20_tfpipeline.*
+          config:
+            quota: 300
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1505
+        - pattern: ^prasanthcakewalk/ThickBrick-Tutorial-PyHEP-2020.*
           config:
             quota: 200
         # https://github.com/jupyterhub/mybinder.org-deploy/issues/1538


### PR DESCRIPTION
xref: #1522, #1519, #1520, #1517, #1502, #1505

* Resolves #1518
* Resolves #1504 
* Resolves #1513 
* Resolves #1503
* Resolves #1507

This PR allocates 300 (200) pods per "Atlantic" ("Pacific") talk on day 5 of PyHEP 2020 (2020-07-17). It subsequently deallocates resources from day 4 of PyHEP 2020 and so should not be merged until the night of 2020-07-16 Pacific time or the morning of 2020-07-17 Euorpean time (depending on who is going to review it and is merge shifter).