### PR TITLE
reduce memory request on GKE to 450M

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -48,7 +48,7 @@ binderhub:
     singleuser:
       nodeSelector: *userNodeSelector
       memory:
-        guarantee: 550M
+        guarantee: 450M
         limit: 2G
       cpu:
         guarantee: 0.01


### PR DESCRIPTION
we have had low memory usage and load hasn't been too high for a while, so I think we can try bumping it up again.

should fit ~20% more users on a node on average, from 60-70 to 75-90.

let's keep an eye on [load](https://grafana.mybinder.org/d/nDQPwi7mk/node-activity?orgId=1&from=now-24h&to=now&fullscreen&panelId=38) and responsiveness.

basically reverts #908