### PR TITLE
Deallocate resources used for PyHEP 2020

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,30 +63,6 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1522
-        - pattern: ^henryiii/bh-talk-pyhep-2020.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1519
-        - pattern: ^martinschwinzerl/pyhep2020-cxx-bindings.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1520
-        - pattern: ^aoeftiger/pyhep2020.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1517
-        - pattern: ^andrzejnovak/2020-07-17-pyhep2020-mplhep.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1502
-        - pattern: ^matt-komm/pyhep20_tfpipeline.*
-          config:
-            quota: 300
-        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1505
-        - pattern: ^prasanthcakewalk/ThickBrick-Tutorial-PyHEP-2020.*
-          config:
-            quota: 200
         # https://github.com/jupyterhub/mybinder.org-deploy/issues/1538
         - pattern: ^Microsoft/QuantumKatas.*
           config:


### PR DESCRIPTION
[PyHEP 2020](https://indico.cern.ch/event/882824/) is over, so all BinderHub allocations for it should be removed. So long and thanks for all the ~fish~ BinderHub. :wink: 

- Resolves #1522
- Resolves #1519
- Resolves #1520
- Resolves #1517
- Resolves #1502
- Resolves #1505

This PR deallocates resources from day 5 of PyHEP 2020 (2020-07-17) and so should not be merged until the night of 2020-07-17 Pacific time or the morning of 2020-07-18 Euorpean time (depending on who is going to review it and is merge shifter).