### PR TITLE
Increase limit on OVH to 60

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -7,7 +7,7 @@ tags:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 55
+      pod_quota: 60
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       sticky_builds: true


### PR DESCRIPTION
Follow up #1552

This is probably the upper end of what fits on the cluster with only three nodes