### PR TITLE
Removing OVH from rotation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -440,11 +440,6 @@ federationRedirect:
       health: https://gke.mybinder.org/health
       versions: https://gke.mybinder.org/versions
       prime: true
-    ovh:
-      url: https://ovh.mybinder.org
-      weight: 19
-      health: https://ovh.mybinder.org/health
-      versions: https://ovh.mybinder.org/versions
     gesis:
       url: https://gesis.mybinder.org
       weight: 15


### PR DESCRIPTION
We can't set the pod capacity to 0 at the moment because the etcd
in the OVH cluster is out of space. Removing it from the federation for
now.

ref #1557 