### PR TITLE
Add OVH back to rotation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -445,6 +445,11 @@ federationRedirect:
       weight: 15
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
+    ovh:
+      url: https://ovh.mybinder.org
+      weight: 19
+      health: https://ovh.mybinder.org/health
+      versions: https://ovh.mybinder.org/versions
     turing:
       turing:
       url: https://turing.mybinder.org


### PR DESCRIPTION
We had to remove OVH from this list (unlike usually) because we couldn't
update the pod capacity on OVH when etcd had run out of storage.