### PR TITLE
Add issue template to check a repo is liable for banning

### DIFF
--- a/.github/ISSUE_TEMPLATE/ban_check.md
+++ b/.github/ISSUE_TEMPLATE/ban_check.md
@@ -1,0 +1,19 @@
+---
+name: "U+2705 Repo Check"
+about: "If you're concerned about banning, we can check your repo"
+labels: question
+
+---
+
+<!--
+🌟🌟🌟🌟🌟
+Use this form to check if a repository may be liable for banning.
+
+👉 Please answer all these questions.
+
+🌟🌟🌟🌟🌟
+-->
+
+### A link to the repository
+
+### Why are you concerned this repository maybe liable for banning? (For example, does it make a lot of API calls, create a lot of IO traffic?)

--- a/.github/ISSUE_TEMPLATE/ban_check.md
+++ b/.github/ISSUE_TEMPLATE/ban_check.md
@@ -16,4 +16,6 @@ Use this form to check if a repository may be liable for banning.
 
 ### A link to the repository
 
-### Why are you concerned this repository maybe liable for banning? (For example, does it make a lot of API calls, create a lot of IO traffic?)
+### Why are you concerned this repository maybe liable for banning?
+
+For example: it will have lots of users, it makes a lot of API calls, creates a lot of network traffic?


### PR DESCRIPTION
We often get questions in Gitter along the lines of "I have a repository that I'm worried might be banned by mybinder.org because it does _something_". I thought it might be a nice idea to have an issue template for these sorts of questions. It currently asked for a link to the repo and why they're concerned they might be banned if they run it. A member of the team can then check it out and advise the repo owner.

Are there any other questions we'd like the form to ask?

Please also see https://github.com/jupyterhub/binder/pull/210