### PR TITLE
[WIP] Edit lint-validate workflow so secrets aren't linted in PRs from forks

### DIFF
--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -13,7 +13,7 @@ jobs:
   test-repo:
     runs-on: ubuntu-16.04
     steps:
-      - run: echo ${{ github.base_ref }}
+      - run: echo ${{ github.head_ref }}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,9 +1,10 @@
 name: Lint and Validate helm chart
 
-# This trigger only runs when PRs are 'opened', 'synchronized' or 'reopened'
-# It runs in the context of the base repository so allows easier sharing of secrets
-# Docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
-on: [pull_request_target]
+on:
+  push:
+    paths:
+      - "**/*.yaml"
+      - "**/*.yml"
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,8 +12,9 @@ env:
 jobs:
   test-repo:
     runs-on: ubuntu-16.04
-    run: echo ${{ github.repository }}
-    
+    steps:
+      - run: echo ${{ github.repository }}
+
   # yamllint-raw:
   #   runs-on: ubuntu-16.04
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,10 +1,9 @@
 name: Lint and Validate helm chart
 
-on:
-  pull_request:
-    paths:
-      - "**/*.yaml"
-      - "**/*.yml"
+# This trigger only runs when PRs are 'opened', 'synchronized' or 'reopened'
+# It runs in the context of the base repository so allows easier sharing of secrets
+# Docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+on: [pull_request_target]
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,109 +10,109 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  # yamllint-raw:
-  #   runs-on: ubuntu-16.04
+  yamllint-raw:
+    runs-on: ubuntu-16.04
 
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: 3.7
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install yamllint
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
 
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on config/
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on config/
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
 
-  #     - name: Unlock git-crypt secrets
-  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-  #       env:
-  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Unlock git-crypt secrets
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on secrets/config
-  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on secrets/config
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
-  # yamllint-templates:
-  #   if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       release: ["staging", "prod", "ovh", "turing"]
+  yamllint-templates:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["staging", "prod", "ovh", "turing"]
 
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: 3.7
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install yamllint chartpress
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint chartpress
 
-  #     - name: Install kubeval
-  #       run: |
-  #         curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-  #         sudo mv ${HOME}/kubeval /usr/local/bin
+      - name: Install kubeval
+        run: |
+          curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          sudo mv ${HOME}/kubeval /usr/local/bin
 
-  #     - name: Install helm
-  #       run: |
-  #         curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-  #         sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
+      - name: Install helm
+        run: |
+          curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
-  #     - name: Install local charts
-  #       working-directory: mybinder
-  #       run: |
-  #         helm init --client-only
-  #         helm dep up
+      - name: Install local charts
+        working-directory: mybinder
+        run: |
+          helm init --client-only
+          helm dep up
 
-  #     - name: Unlock git-crypt secrets
-  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-  #       env:
-  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Unlock git-crypt secrets
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-  #     - name: Run chartpress
-  #       run: |
-  #         chartpress
+      - name: Run chartpress
+        run: |
+          chartpress
 
-  #     - name: Make output directory for helm template
-  #       run: |
-  #         mkdir helm-${{ matrix.release }}
+      - name: Make output directory for helm template
+        run: |
+          mkdir helm-${{ matrix.release }}
 
-  #     - name: Run helm template for ${{ matrix.release }}
-  #       run: |
-  #         helm template mybinder \
-  #         -f secrets/config/common.yaml \
-  #         -f config/${{ matrix.release }}.yaml \
-  #         -f secrets/config/${{ matrix.release }}.yaml \
-  #         --output-dir helm-${{ matrix.release }}
+      - name: Run helm template for ${{ matrix.release }}
+        run: |
+          helm template mybinder \
+          -f secrets/config/common.yaml \
+          -f config/${{ matrix.release }}.yaml \
+          -f secrets/config/${{ matrix.release }}.yaml \
+          --output-dir helm-${{ matrix.release }}
 
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on ${{ matrix.release }} chart
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on ${{ matrix.release }} chart
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
-  #     # Use --ignore-missing-schemas to avoid failure of CRDs
-  #     - name: Validate k8s resources for ${{ matrix.release}}
-  #       run: |
-  #         kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+      # Use --ignore-missing-schemas to avoid failure of CRDs
+      - name: Validate k8s resources for ${{ matrix.release}}
+        run: |
+          kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,6 +10,11 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
+  test-repo:
+    runs-on: ubuntu-16.04
+    steps:
+      - run: echo ${{ github.repository }}
+
   # yamllint-raw:
   #   runs-on: ubuntu-16.04
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -29,18 +29,25 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install yamllint
 
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on config/
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+
       - name: Unlock git-crypt secrets
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on config/ and secrets/config
+      - name: Run yamllint on secrets/config
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
           yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
   yamllint-templates:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -13,7 +13,7 @@ jobs:
   test-repo:
     runs-on: ubuntu-16.04
     steps:
-      - run: echo ${{ github.repository }}
+      - run: echo ${{ github.base_ref }}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,109 +10,109 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  yamllint-raw:
-    runs-on: ubuntu-16.04
+  # yamllint-raw:
+  #   runs-on: ubuntu-16.04
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.7
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install yamllint
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install yamllint
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on config/
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on config/
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings config/
 
-      - name: Unlock git-crypt secrets
-        if: github.repository == 'jupyterhub/mybinder.org-deploy'
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+  #     - name: Unlock git-crypt secrets
+  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+  #       env:
+  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on secrets/config
-        if: github.repository == 'jupyterhub/mybinder.org-deploy'
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on secrets/config
+  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
-  yamllint-templates:
-    if: github.repository == 'jupyterhub/mybinder.org-deploy'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ["staging", "prod", "ovh", "turing"]
+  # yamllint-templates:
+  #   if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       release: ["staging", "prod", "ovh", "turing"]
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.7
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install yamllint chartpress
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install yamllint chartpress
 
-      - name: Install kubeval
-        run: |
-          curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-          sudo mv ${HOME}/kubeval /usr/local/bin
+  #     - name: Install kubeval
+  #       run: |
+  #         curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  #         sudo mv ${HOME}/kubeval /usr/local/bin
 
-      - name: Install helm
-        run: |
-          curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-          sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
+  #     - name: Install helm
+  #       run: |
+  #         curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  #         sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
-      - name: Install local charts
-        working-directory: mybinder
-        run: |
-          helm init --client-only
-          helm dep up
+  #     - name: Install local charts
+  #       working-directory: mybinder
+  #       run: |
+  #         helm init --client-only
+  #         helm dep up
 
-      - name: Unlock git-crypt secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+  #     - name: Unlock git-crypt secrets
+  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+  #       env:
+  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      - name: Run chartpress
-        run: |
-          chartpress
+  #     - name: Run chartpress
+  #       run: |
+  #         chartpress
 
-      - name: Make output directory for helm template
-        run: |
-          mkdir helm-${{ matrix.release }}
+  #     - name: Make output directory for helm template
+  #       run: |
+  #         mkdir helm-${{ matrix.release }}
 
-      - name: Run helm template for ${{ matrix.release }}
-        run: |
-          helm template mybinder \
-          -f secrets/config/common.yaml \
-          -f config/${{ matrix.release }}.yaml \
-          -f secrets/config/${{ matrix.release }}.yaml \
-          --output-dir helm-${{ matrix.release }}
+  #     - name: Run helm template for ${{ matrix.release }}
+  #       run: |
+  #         helm template mybinder \
+  #         -f secrets/config/common.yaml \
+  #         -f config/${{ matrix.release }}.yaml \
+  #         -f secrets/config/${{ matrix.release }}.yaml \
+  #         --output-dir helm-${{ matrix.release }}
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on ${{ matrix.release }} chart
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on ${{ matrix.release }} chart
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
-      # Use --ignore-missing-schemas to avoid failure of CRDs
-      - name: Validate k8s resources for ${{ matrix.release}}
-        run: |
-          kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+  #     # Use --ignore-missing-schemas to avoid failure of CRDs
+  #     - name: Validate k8s resources for ${{ matrix.release}}
+  #       run: |
+  #         kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,11 +10,6 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  test-repo:
-    runs-on: ubuntu-16.04
-    steps:
-      - run: echo ${{ github.head_ref }}
-
   # yamllint-raw:
   #   runs-on: ubuntu-16.04
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,6 +10,10 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
+  test-repo:
+    runs-on: ubuntu-16.04
+    run: echo ${{ github.repository }}
+    
   # yamllint-raw:
   #   runs-on: ubuntu-16.04
 


### PR DESCRIPTION
We had problems that the linting GitHub Action fails on PRs from forks since they can't access the secrets. This PR edits the workflow file to only run jobs that require secrets in PRs that come from within the origin repo.