### PR TITLE
[MRG] Edit linting workflow so secrets aren't required when PR comes from fork

### DIFF
--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,10 +1,6 @@
 name: Lint and Validate helm chart
 
-on:
-  push:
-    paths:
-      - "**/*.yaml"
-      - "**/*.yml"
+on: [push]
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,16 +10,6 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  set-env-var:
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Set fork status as an environment variable
-        run: |
-          STATUS="$( echo ${PAYLOAD} | jq .pull_request.head.repo.fork )"
-          echo "::set-env name=fork::${STATUS}"
-        env:
-          PAYLOAD: ${{ toJSON(github.event) }}
-
   yamllint-raw:
     needs: set-env-var
     runs-on: ubuntu-16.04
@@ -46,19 +36,19 @@ jobs:
           yamllint -d scripts/yamllint-config.yaml --no-warnings config/
 
       - name: Unlock git-crypt secrets
-        if: env.fork == 'false'
+        if: github.event.pull_request.head.repo.fork == 'false'
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       # We use --no-warnings in this step to reduce output to critical errors
       - name: Run yamllint on secrets/config
-        if: env.fork == 'false'
+        if: github.event.pull_request.head.repo.fork == 'false'
         run: |
           yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
   yamllint-templates:
-    needs: set-env-var
+    if: github.event.pull_request.head.repo.fork == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -67,60 +57,50 @@ jobs:
 
     steps:
       - name: Checkout repo
-        if: env.fork == 'false'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.7
-        if: env.fork == 'false'
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
 
       - name: Install dependencies
-        if: env.fork == 'false'
         run: |
           python -m pip install --upgrade pip
           python -m pip install yamllint chartpress
 
       - name: Install kubeval
-        if: env.fork == 'false'
         run: |
           curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/kubeval /usr/local/bin
 
       - name: Install helm
-        if: env.fork == 'false'
         run: |
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
       - name: Install local charts
-        if: env.fork == 'false'
         working-directory: mybinder
         run: |
           helm init --client-only
           helm dep up
 
       - name: Unlock git-crypt secrets
-        if: env.fork == 'false'
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: Run chartpress
-        if: env.fork == 'false'
         run: |
           chartpress
 
       - name: Make output directory for helm template
-        if: env.fork == 'false'
         run: |
           mkdir helm-${{ matrix.release }}
 
       - name: Run helm template for ${{ matrix.release }}
-        if: env.fork == 'false'
         run: |
           helm template mybinder \
           -f secrets/config/common.yaml \
@@ -130,12 +110,10 @@ jobs:
 
       # We use --no-warnings in this step to reduce output to critical errors
       - name: Run yamllint on ${{ matrix.release }} chart
-        if: env.fork == 'false'
         run: |
           yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
       # Use --ignore-missing-schemas to avoid failure of CRDs
       - name: Validate k8s resources for ${{ matrix.release}}
-        if: env.fork == 'false'
         run: |
           kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -55,7 +55,6 @@ jobs:
 
   yamllint-templates:
     needs: set-env-var
-    if: env.fork == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -64,50 +63,60 @@ jobs:
 
     steps:
       - name: Checkout repo
+        if: env.fork == 'false'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.7
+        if: env.fork == 'false'
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
 
       - name: Install dependencies
+        if: env.fork == 'false'
         run: |
           python -m pip install --upgrade pip
           python -m pip install yamllint chartpress
 
       - name: Install kubeval
+        if: env.fork == 'false'
         run: |
           curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/kubeval /usr/local/bin
 
       - name: Install helm
+        if: env.fork == 'false'
         run: |
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
       - name: Install local charts
+        if: env.fork == 'false'
         working-directory: mybinder
         run: |
           helm init --client-only
           helm dep up
 
       - name: Unlock git-crypt secrets
+        if: env.fork == 'false'
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: Run chartpress
+        if: env.fork == 'false'
         run: |
           chartpress
 
       - name: Make output directory for helm template
+        if: env.fork == 'false'
         run: |
           mkdir helm-${{ matrix.release }}
 
       - name: Run helm template for ${{ matrix.release }}
+        if: env.fork == 'false'
         run: |
           helm template mybinder \
           -f secrets/config/common.yaml \
@@ -117,10 +126,12 @@ jobs:
 
       # We use --no-warnings in this step to reduce output to critical errors
       - name: Run yamllint on ${{ matrix.release }} chart
+        if: env.fork == 'false'
         run: |
           yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
       # Use --ignore-missing-schemas to avoid failure of CRDs
       - name: Validate k8s resources for ${{ matrix.release}}
+        if: env.fork == 'false'
         run: |
           kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,10 +12,9 @@ jobs:
      - run: echo ${{ github.repository_owner}}
 
      - name: see payload
-      run: |
-        echo "$PAYLOAD"
-      env:
-        PAYLOAD: ${{ toJSON(github.event) }}
+       run: echo "${PAYLOAD}"
+       env:
+         PAYLOAD: ${{ toJSON(github.event) }}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,6 +1,10 @@
 name: Lint and Validate helm chart
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - "**/*.yaml"
+      - "**/*.yml"
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
      - run: echo ${{ github.repository_owner}}
 
+     - name: see payload
+      run: |
+        echo "$PAYLOAD"
+      env:
+        PAYLOAD: ${{ toJSON(github.event) }}
+
   # yamllint-raw:
   #   runs-on: ubuntu-16.04
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,7 +12,7 @@ jobs:
       - run: echo ${{ github.repository_owner}}
 
       - name: see payload
-        run: echo "${PAYLOAD}" | jq pull_request.head.repo.fork
+        run: echo "${PAYLOAD}" | jq .pull_request.head.repo.fork
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -53,73 +53,74 @@ jobs:
         run: |
           yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
-  # yamllint-templates:
-  #   if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       release: ["staging", "prod", "ovh", "turing"]
+  yamllint-templates:
+    needs: set-env-var
+    if: env.fork == 'false'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["staging", "prod", "ovh", "turing"]
 
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: 3.7
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install yamllint chartpress
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint chartpress
 
-  #     - name: Install kubeval
-  #       run: |
-  #         curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-  #         sudo mv ${HOME}/kubeval /usr/local/bin
+      - name: Install kubeval
+        run: |
+          curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          sudo mv ${HOME}/kubeval /usr/local/bin
 
-  #     - name: Install helm
-  #       run: |
-  #         curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-  #         sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
+      - name: Install helm
+        run: |
+          curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
-  #     - name: Install local charts
-  #       working-directory: mybinder
-  #       run: |
-  #         helm init --client-only
-  #         helm dep up
+      - name: Install local charts
+        working-directory: mybinder
+        run: |
+          helm init --client-only
+          helm dep up
 
-  #     - name: Unlock git-crypt secrets
-  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-  #       env:
-  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Unlock git-crypt secrets
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-  #     - name: Run chartpress
-  #       run: |
-  #         chartpress
+      - name: Run chartpress
+        run: |
+          chartpress
 
-  #     - name: Make output directory for helm template
-  #       run: |
-  #         mkdir helm-${{ matrix.release }}
+      - name: Make output directory for helm template
+        run: |
+          mkdir helm-${{ matrix.release }}
 
-  #     - name: Run helm template for ${{ matrix.release }}
-  #       run: |
-  #         helm template mybinder \
-  #         -f secrets/config/common.yaml \
-  #         -f config/${{ matrix.release }}.yaml \
-  #         -f secrets/config/${{ matrix.release }}.yaml \
-  #         --output-dir helm-${{ matrix.release }}
+      - name: Run helm template for ${{ matrix.release }}
+        run: |
+          helm template mybinder \
+          -f secrets/config/common.yaml \
+          -f config/${{ matrix.release }}.yaml \
+          -f secrets/config/${{ matrix.release }}.yaml \
+          --output-dir helm-${{ matrix.release }}
 
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on ${{ matrix.release }} chart
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on ${{ matrix.release }} chart
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
-  #     # Use --ignore-missing-schemas to avoid failure of CRDs
-  #     - name: Validate k8s resources for ${{ matrix.release}}
-  #       run: |
-  #         kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+      # Use --ignore-missing-schemas to avoid failure of CRDs
+      - name: Validate k8s resources for ${{ matrix.release}}
+        run: |
+          kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,15 +12,9 @@ jobs:
       - run: echo ${{ github.repository_owner}}
 
       - name: see payload
-        run: echo "${PAYLOAD}" | jq .pull_request.head.repo.fork
+        run: echo "::set-env name=FORK::$($PAYLOAD | jq .pull_request.head.repo.fork")
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
-
-      - name: store payload
-        uses: actions/upload-artifact@v2
-        with:
-          name: payload.json
-          path: ${{ github.event_path }}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-16.04
     steps:
-     - run: echo ${{ github.respository_owner}}
+     - run: echo ${{ github.repository_owner}}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Set fork status as an environment variable
         run: |
-          STATUS="$( ${PAYLOAD} | jq .pull_request.head.repo.fork )"
+          STATUS="$( echo ${PAYLOAD} | jq .pull_request.head.repo.fork )"
           echo "::set-env name=fork::${STATUS}"
         env:
           PAYLOAD: ${{ toJSON(github.event) }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -9,12 +9,18 @@ jobs:
   test:
     runs-on: ubuntu-16.04
     steps:
-     - run: echo ${{ github.repository_owner}}
+      - run: echo ${{ github.repository_owner}}
 
-     - name: see payload
-       run: echo "${PAYLOAD}" | jq .head.fork
-       env:
-         PAYLOAD: ${{ toJSON(github.event) }}
+      - name: see payload
+        run: echo "${PAYLOAD}" | jq .head.fork
+        env:
+          PAYLOAD: ${{ toJSON(github.event) }}
+
+      - name: store payload
+        uses: actions/upload-artifact@v2
+        with:
+          name: payload.json
+          path: ${{ github.event_path }}
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   yamllint-raw:
-    needs: set-env-var
     runs-on: ubuntu-16.04
 
     steps:

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,7 +12,7 @@ jobs:
      - run: echo ${{ github.repository_owner}}
 
      - name: see payload
-       run: echo "${PAYLOAD}"
+       run: echo "${PAYLOAD}" | jq .head.fork
        env:
          PAYLOAD: ${{ toJSON(github.event) }}
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,11 +10,13 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Set fork status as an environment variable
-        run: echo "::set-env name=fork::$($PAYLOAD | jq .pull_request.head.repo.fork)"
+        run: |
+          STATUS="$( ${PAYLOAD} | jq .pull_request.head.repo.fork )"
+          echo "::set-env name=fork::${STATUS}"
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 
-      - name: Test fork env variables
+      - name: Test fork env variable
         run: |
           echo "${fork}"
           echo ${{ env.fork }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,6 +1,6 @@
 name: Lint and Validate helm chart
 
-on: [push]
+on: [pull_request_target]
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,7 +12,7 @@ jobs:
       - run: echo ${{ github.repository_owner}}
 
       - name: see payload
-        run: echo "::set-env name=FORK::$($PAYLOAD | jq .pull_request.head.repo.fork")
+        run: echo "::set-env name=FORK::$($PAYLOAD | jq .pull_request.head.repo.fork)"
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -12,7 +12,7 @@ jobs:
       - run: echo ${{ github.repository_owner}}
 
       - name: see payload
-        run: echo "${PAYLOAD}" | jq .head.fork
+        run: echo "${PAYLOAD}" | jq pull_request.head.repo.fork
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,114 +1,119 @@
 name: Lint and Validate helm chart
 
-on: [push]
+on: [pull_request]
 
 env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  yamllint-raw:
+  test:
     runs-on: ubuntu-16.04
-
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+     - run: echo ${{ github.respository_owner}}
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
+  # yamllint-raw:
+  #   runs-on: ubuntu-16.04
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install yamllint
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on config/
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.7
 
-      - name: Unlock git-crypt secrets
-        if: github.repository == 'jupyterhub/mybinder.org-deploy'
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install yamllint
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on secrets/config
-        if: github.repository == 'jupyterhub/mybinder.org-deploy'
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on config/
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings config/
 
-  yamllint-templates:
-    if: github.repository == 'jupyterhub/mybinder.org-deploy'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ["staging", "prod", "ovh", "turing"]
+  #     - name: Unlock git-crypt secrets
+  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+  #       env:
+  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on secrets/config
+  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
+  # yamllint-templates:
+  #   if: github.repository == 'jupyterhub/mybinder.org-deploy'
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       release: ["staging", "prod", "ovh", "turing"]
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install yamllint chartpress
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Install kubeval
-        run: |
-          curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-          sudo mv ${HOME}/kubeval /usr/local/bin
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.7
 
-      - name: Install helm
-        run: |
-          curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-          sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install yamllint chartpress
 
-      - name: Install local charts
-        working-directory: mybinder
-        run: |
-          helm init --client-only
-          helm dep up
+  #     - name: Install kubeval
+  #       run: |
+  #         curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  #         sudo mv ${HOME}/kubeval /usr/local/bin
 
-      - name: Unlock git-crypt secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+  #     - name: Install helm
+  #       run: |
+  #         curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+  #         sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
-      - name: Run chartpress
-        run: |
-          chartpress
+  #     - name: Install local charts
+  #       working-directory: mybinder
+  #       run: |
+  #         helm init --client-only
+  #         helm dep up
 
-      - name: Make output directory for helm template
-        run: |
-          mkdir helm-${{ matrix.release }}
+  #     - name: Unlock git-crypt secrets
+  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+  #       env:
+  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      - name: Run helm template for ${{ matrix.release }}
-        run: |
-          helm template mybinder \
-          -f secrets/config/common.yaml \
-          -f config/${{ matrix.release }}.yaml \
-          -f secrets/config/${{ matrix.release }}.yaml \
-          --output-dir helm-${{ matrix.release }}
+  #     - name: Run chartpress
+  #       run: |
+  #         chartpress
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on ${{ matrix.release }} chart
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
+  #     - name: Make output directory for helm template
+  #       run: |
+  #         mkdir helm-${{ matrix.release }}
 
-      # Use --ignore-missing-schemas to avoid failure of CRDs
-      - name: Validate k8s resources for ${{ matrix.release}}
-        run: |
-          kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+  #     - name: Run helm template for ${{ matrix.release }}
+  #       run: |
+  #         helm template mybinder \
+  #         -f secrets/config/common.yaml \
+  #         -f config/${{ matrix.release }}.yaml \
+  #         -f secrets/config/${{ matrix.release }}.yaml \
+  #         --output-dir helm-${{ matrix.release }}
+
+  #     # We use --no-warnings in this step to reduce output to critical errors
+  #     - name: Run yamllint on ${{ matrix.release }} chart
+  #       run: |
+  #         yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
+
+  #     # Use --ignore-missing-schemas to avoid failure of CRDs
+  #     - name: Validate k8s resources for ${{ matrix.release}}
+  #       run: |
+  #         kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,7 +1,7 @@
 name: Lint and Validate helm chart
 
 on:
-  pull_request:
+  push:
     paths:
       - "**/*.yaml"
       - "**/*.yml"
@@ -29,18 +29,25 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install yamllint
 
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on config/
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+
       - name: Unlock git-crypt secrets
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on config/ and secrets/config
+      - name: Run yamllint on secrets/config
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
           yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
   yamllint-templates:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -1,6 +1,6 @@
 name: Lint and Validate helm chart
 
-on: [pull_request_target]
+on: [push]
 
 env:
   HELM_VERSION: "v2.16.3"

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,15 +10,17 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Set fork status as an environment variable
-        run: echo "::set-env name=FORK::$($PAYLOAD | jq .pull_request.head.repo.fork)"
+        run: echo "::set-env name=fork::$($PAYLOAD | jq .pull_request.head.repo.fork)"
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 
       - name: Test fork env variables
-        run: echo ${{ env.FORK }}
+        run: |
+          echo "${fork}"
+          echo ${{ env.fork }}
 
       - name: run if true
-        if: env.FORK == 'true'
+        if: env.fork == 'true'
         run: echo "fork is true!"
 
   # yamllint-raw:

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -6,7 +6,7 @@ env:
   HELM_VERSION: "v2.16.3"
 
 jobs:
-  test:
+  set-env-var:
     runs-on: ubuntu-16.04
     steps:
       - name: Set fork status as an environment variable
@@ -16,50 +16,42 @@ jobs:
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
 
-      - name: Test fork env variable
+  yamllint-raw:
+    needs: set-env-var
+    runs-on: ubuntu-16.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
         run: |
-          echo "${fork}"
-          echo ${{ env.fork }}
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
 
-      - name: run if true
-        if: env.fork == 'true'
-        run: echo "fork is true!"
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on config/
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
 
-  # yamllint-raw:
-  #   runs-on: ubuntu-16.04
+      - name: Unlock git-crypt secrets
+        if: env.fork == 'false'
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: 3.7
-
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install yamllint
-
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on config/
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings config/
-
-  #     - name: Unlock git-crypt secrets
-  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-  #       env:
-  #         GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-
-  #     # We use --no-warnings in this step to reduce output to critical errors
-  #     - name: Run yamllint on secrets/config
-  #       if: github.repository == 'jupyterhub/mybinder.org-deploy'
-  #       run: |
-  #         yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint on secrets/config
+        if: env.fork == 'false'
+        run: |
+          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
   # yamllint-templates:
   #   if: github.repository == 'jupyterhub/mybinder.org-deploy'

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -9,12 +9,17 @@ jobs:
   test:
     runs-on: ubuntu-16.04
     steps:
-      - run: echo ${{ github.repository_owner}}
-
-      - name: see payload
+      - name: Set fork status as an environment variable
         run: echo "::set-env name=FORK::$($PAYLOAD | jq .pull_request.head.repo.fork)"
         env:
           PAYLOAD: ${{ toJSON(github.event) }}
+
+      - name: Test fork env variables
+        run: echo ${{ env.FORK }}
+
+      - name: run if true
+        if: env.FORK == 'true'
+        run: echo "fork is true!"
 
   # yamllint-raw:
   #   runs-on: ubuntu-16.04


### PR DESCRIPTION
We had failure issues on PRs that come from forks because they can't access the repo's secrets. I'm trying to reconfigure the lint-validate.yml workflow file so that the steps that require secrets are only run when the source branch of a PR is owned by the host repository.

I've opened this PR from my fork to test this.