### PR TITLE
2020-08-28 bump resources for pycon-jp

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -63,6 +63,11 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
+        # https://github.com/jupyterhub/mybinder.org-deploy/issues/1560
+        # Remove 2020-08-31
+        - pattern: ^hannari-python/tutorial.*
+          config:
+            quota: 300
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
Event starts 2020-08-30 01:00Z, so we should merge this bump on the 28th (Friday)

ref: #1560