### PR TITLE
apply memory limit to builds

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -27,7 +27,7 @@ binderhub:
     resources:
       requests:
         cpu: "2"
-        memory: 8Gi
+        memory: 1Gi
       limits:
         cpu: "5"
         memory: 12Gi

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -11,6 +11,16 @@ binderhub:
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
       sticky_builds: true
+      build_memory_limit: 1Gi
+
+  dind:
+    resources:
+      requests:
+        cpu: "0"
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
 
   ingress:
     hosts:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -72,6 +72,8 @@ binderhub:
       build_image: jupyter/repo2docker:0.11.0-132.g5179447
       per_repo_quota: 100
       per_repo_quota_higher: 200
+      build_memory_limit: "2Gi"
+      build_memory_request: "1Gi"
 
       banner_message: |
         <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a>, <a href="https://www.ovh.com/">OVH</a>, <a href="https://notebooks.gesis.org">GESIS Notebooks</a> and the <a href="https://turing.ac.uk">Turing Institute</a> for supporting us! 🎉</div>
@@ -148,6 +150,13 @@ binderhub:
 
   dind:
     enabled: true
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 1Gi
+      limits:
+        cpu: "4"
+        memory: 4Gi
 
   imageCleaner:
     enabled: true


### PR DESCRIPTION
- request 1G per build for scheduling purposes
- apply 2G limit on builds
- reduce dind pod memory request to account for builds now requesting resources while they are running

The result (for GKE prod) will be:

- less memory reserved while fewer than 7 builds are running on a node
- no change when 7 builds are running, other than per-build memory limit of 2G
- more memory reserved while more than 7 builds are running, increasing likelihood of builds triggering scale-up

closes #1529

requires https://github.com/jupyterhub/binderhub/pull/1144 for the build_memory_request to have its desired effect. We can either wait for that, or merge, in which case `build_memory_limit` would be used for the request as well, meaning builds would request 2G instead of 1G until the separate config option lands