### PR TITLE
repo2docker uses a different format for specifying memory limits

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -11,7 +11,7 @@ binderhub:
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
       sticky_builds: true
-      build_memory_limit: 1Gi
+      build_memory_limit: "1G"
 
   dind:
     resources:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -77,8 +77,8 @@ binderhub:
       build_image: jupyter/repo2docker:0.11.0-132.g5179447
       per_repo_quota: 100
       per_repo_quota_higher: 200
-      build_memory_limit: "2Gi"
-      build_memory_request: "1Gi"
+      build_memory_limit: "2G"
+      build_memory_request: "1G"
 
       banner_message: |
         <div style="text-align: center;">Thanks to <a href="https://cloud.google.com/">Google Cloud</a>, <a href="https://www.ovh.com/">OVH</a>, <a href="https://notebooks.gesis.org">GESIS Notebooks</a> and the <a href="https://turing.ac.uk">Turing Institute</a> for supporting us! 🎉</div>


### PR DESCRIPTION
Follow up to #1576. Docker uses 1G and not 1Gi to specify a 1 gigabyte memory limit. So this PR changes those config strings that end up getting passed on to docker via repo2docker.