### PR TITLE
Increase build memory limit on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -11,7 +11,7 @@ binderhub:
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binder-staging/r2d-72d7634-
       sticky_builds: true
-      build_memory_limit: "1G"
+      build_memory_limit: "2G"
 
   dind:
     resources:
@@ -20,7 +20,7 @@ binderhub:
         memory: 1Gi
       limits:
         cpu: "1"
-        memory: 2Gi
+        memory: 2.5Gi
 
   ingress:
     hosts:


### PR DESCRIPTION
A test build of binder-examples/conda failed because conda got killed
while trying to solve the environment.

```
Step 40/51 : USER ${NB_USER}
 ---> Running in 9aaa62f46745
Removing intermediate container 9aaa62f46745
 ---> 263449ac4f83
Step 41/51 : RUN conda env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && conda clean --all -f -y && conda list -p ${NB_PYTHON_PREFIX}
 ---> Running in c0e47a19c0c6
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... Killed
Removing intermediate container c0e47a19c0c6
The command '/bin/sh -c conda env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && conda clean --all -f -y && conda list -p ${NB_PYTHON_PREFIX}' returned a non-zero code: 137
```

Let's see if this fixes https://staging.mybinder.org/v2/gh/binder-examples/conda/master