### PR TITLE
bump nginx-ingress, cert-manager

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -223,9 +223,3 @@ gcsProxy:
     - name: mybinder-staging-events-archive
       host: archive-analytics-staging-mybinder.mybinder.ovh
 
-
-cert-manager:
-  ingressShim:
-    defaultIssuerName: "letsencrypt-prod"
-    defaultIssuerKind: "ClusterIssuer"
-    defaultACMEChallengeType: "http01"

--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -225,8 +225,6 @@ gcsProxy:
 
 
 cert-manager:
-  webhook:
-    enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "ClusterIssuer"

--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -154,7 +154,7 @@ prometheus:
           secretName: tls-crt
 
 
-nginx-ingress:
+ingress-nginx:
   controller:
     hostNetwork: true
     replicaCount: 1

--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -1,9 +1,5 @@
 projectName: ovh
 
-tags:
-  kubelego: false
-  certmanager: true
-
 binderhub:
   config:
     BinderHub:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -144,7 +144,7 @@ prometheus:
             - prometheus.mybinder.org
           secretName: kubelego-tls-prometheus
 
-nginx-ingress:
+ingress-nginx:
   controller:
     service:
       loadBalancerIP: 35.202.202.188

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,9 +1,5 @@
 projectName: binder-prod
 
-tags:
-  kubelego: false
-  certmanager: true
-
 userNodeSelector: &userNodeSelector
   mybinder.org/pool-type: users
 coreNodeSelector: &coreNodeSelector
@@ -124,9 +120,6 @@ grafana:
           access: direct
           isDefault: true
           editable: false
-
-kube-lego:
-  nodeSelector: *coreNodeSelector
 
 prometheus:
   server:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -220,8 +220,6 @@ gcsProxy:
       host: archive.analytics.mybinder.org
 
 cert-manager:
-  webhook:
-    enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "ClusterIssuer"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -219,11 +219,5 @@ gcsProxy:
     - name: mybinder-events-archive
       host: archive.analytics.mybinder.org
 
-cert-manager:
-  ingressShim:
-    defaultIssuerName: "letsencrypt-prod"
-    defaultIssuerKind: "ClusterIssuer"
-    defaultACMEChallengeType: "http01"
-
 federationRedirect:
   enabled: true

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -72,7 +72,7 @@ prometheus:
             - prometheus.staging.mybinder.org
           secretName: kubelego-tls-prometheus
 
-nginx-ingress:
+ingress-nginx:
   controller:
     service:
       loadBalancerIP: 104.197.11.66

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -122,12 +122,6 @@ gcsProxy:
     - name: mybinder-staging-events-archive
       host: archive.analytics.staging.mybinder.org
 
-cert-manager:
-  ingressShim:
-    defaultIssuerName: "letsencrypt-prod"
-    defaultIssuerKind: "ClusterIssuer"
-    defaultACMEChallengeType: "http01"
-
 federationRedirect:
   host: staging.mybinder.org
   enabled: true

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,9 +1,5 @@
 projectName: binder-staging
 
-tags:
-  kubelego: false
-  certmanager: true
-
 binderhub:
   config:
     BinderHub:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -123,8 +123,6 @@ gcsProxy:
       host: archive.analytics.staging.mybinder.org
 
 cert-manager:
-  webhook:
-    enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "ClusterIssuer"

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -205,9 +205,3 @@ gcsProxy:
   buckets:
     - name: mybinder-staging-events-archive
       host: archive-analytics-staging-mybinder.turing.10.0.0.1.xip.io
-
-cert-manager:
-  ingressShim:
-    defaultIssuerName: "letsencrypt-prod"
-    defaultIssuerKind: "ClusterIssuer"
-    defaultACMEChallengeType: "http01"

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -1,6 +1,5 @@
 projectName: turing
 
-tags:
 
 letsencrypt:
   contactEmail: drsarahlgibson@gmail.com

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -1,8 +1,6 @@
 projectName: turing
 
 tags:
-  kubelego: false
-  certmanager: true
 
 letsencrypt:
   contactEmail: drsarahlgibson@gmail.com

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -158,12 +158,10 @@ prometheus:
           secretName: turing-prometheus-tls-crt
 
 
-nginx-ingress:
+ingress-nginx:
   controller:
     service:
       loadBalancerIP: 51.105.120.231
-    config:
-      proxy-body-size: 64m
 
 
 static:

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -207,8 +207,6 @@ gcsProxy:
       host: archive-analytics-staging-mybinder.turing.10.0.0.1.xip.io
 
 cert-manager:
-  webhook:
-    enabled: false
   ingressShim:
     defaultIssuerName: "letsencrypt-prod"
     defaultIssuerKind: "ClusterIssuer"

--- a/deploy.py
+++ b/deploy.py
@@ -205,6 +205,8 @@ def deploy(release):
             "secrets/ban.py",
         ])
 
+    setup_certmanager()
+
     print(BOLD + GREEN + f"Starting helm upgrade for {release}" + NC, flush=True)
     helm = [
         'helm', 'upgrade', '--install',
@@ -326,8 +328,6 @@ def main():
             setup_auth_turing(args.cluster)
         else:
             setup_auth_gcloud(args.release, args.cluster)
-
-        setup_certmanager()
         setup_helm(args.release)
 
     deploy(args.release)

--- a/deploy.py
+++ b/deploy.py
@@ -239,10 +239,39 @@ def deploy(release):
         ])
 
 
-def main():
-    # Get current working directory
-    cwd = os.getcwd()
+def setup_certmanager():
+    """Install cert-manager CRDs"""
 
+    # TODO: cert-manager chart >= 0.15
+    # has `installCRDs` option, which should elimnate this step
+    # however, upgrade notes say this *must not* be used
+    # when upgrading, only for fresh deployments,
+    # and requires helm >=3.3.1 and kubernetes >=1.16.14
+
+    requirements_yaml = os.path.join(ABSOLUTE_HERE, "mybinder", "requirements.yaml")
+    with open(requirements_yaml, "r") as f:
+        requirements = yaml.safe_load(f)
+
+    for dep in requirements["dependencies"]:
+        if dep["name"] == "cert-manager":
+            cert_manager = dep
+            break
+    else:
+        raise ValueError(f"cert-manager dependency not found in {requirements_yaml}")
+    version = cert_manager["version"]
+    manifest_url = f"https://github.com/jetstack/cert-manager/releases/download/{version}/cert-manager.yaml"
+    print(BOLD + GREEN + f"Applying cert-manager {version} CRDs" + NC, flush=True)
+
+    subprocess.check_call([
+        'kubectl',
+        'apply',
+        '--validate=false',
+        '-f',
+        manifest_url,
+    ])
+
+
+def main():
     # parse command line args
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
@@ -298,6 +327,7 @@ def main():
         else:
             setup_auth_gcloud(args.release, args.cluster)
 
+        setup_certmanager()
         setup_helm(args.release)
 
     deploy(args.release)

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
- - name: nginx-ingress
-   version: 1.41.3
-   repository: https://kubernetes-charts.storage.googleapis.com
+ - name: ingress-nginx
+   version: 2.13.0
+   repository: https://kubernetes.github.io/ingress-nginx
  - name: prometheus
    version: 11.0.2
    repository: https://kubernetes-charts.storage.googleapis.com

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -8,18 +8,11 @@ dependencies:
  - name: grafana
    version: 3.10.1
    repository: https://kubernetes-charts.storage.googleapis.com
- - name: kube-lego
-   version: 0.4.2
-   repository: https://kubernetes-charts.storage.googleapis.com
-   tags:
-     - kubelego
  - name: cert-manager
    # note: due to https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16
-   # we should not upgrade to v0.16 until we are on kubernetes >= 1.16.14
+   # we should not upgrade to v0.16 until we are on kubernetes >= 1.16.14 everywhere
    version: v0.15.2
    repository: https://charts.jetstack.io
-   tags:
-     - certmanager
  - name: binderhub
    version: 0.2.0-n215.h9447e17
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
  - name: nginx-ingress
-   version: 0.20.0
+   version: 1.41.3
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: prometheus
    version: 11.0.2
@@ -14,7 +14,9 @@ dependencies:
    tags:
      - kubelego
  - name: cert-manager
-   version: v0.12.0
+   # note: due to https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16
+   # we should not upgrade to v0.16 until we are on kubernetes >= 1.16.14
+   version: v0.15.2
    repository: https://charts.jetstack.io
    tags:
      - certmanager

--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.tags.certmanager }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -29,4 +28,3 @@ spec:
     - http01:
         ingress:
           class: nginx
-{{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,6 +1,4 @@
-tags:
-  kubelego: true
-  certmanager: false
+tags: {}
 
 etcJupyter:
   jupyter_notebook_config.json:
@@ -335,15 +333,6 @@ static:
       kubernetes.io/tls-acme: 'true'
     tls:
       secretName: kubelego-tls-static
-
-kube-lego:
-  config:
-    LEGO_EMAIL: yuvipanda@gmail.com
-    LEGO_URL: https://acme-v01.api.letsencrypt.org/directory
-  rbac:
-    create: true
-  image:
-    tag: 0.1.7
 
 grafana:
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -256,16 +256,14 @@ binderhub:
               add:
                 - NET_ADMIN
 
-nginx-ingress:
+ingress-nginx:
   rbac:
     create: true
   defaultBackend:
+    enabled: true
     minAvailable: 0
-  statsExporter:
-    service:
-      annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '10254'
+  admissionWebhooks:
+    enabled: false
   controller:
     resources:
       requests:
@@ -286,11 +284,11 @@ nginx-ingress:
           podAffinityTerm:
             labelSelector:
               matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
-                - nginx-ingress
-              - key: component
+                - ingress
+              - key: app.kubernetes.io/component
                 operator: In
                 values:
                 - controller

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -462,8 +462,7 @@ federationRedirect:
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
 
-certmanager:
+cert-manager:
   ingressShim:
-    defaultIssuerName: letsencrypt-production
+    defaultIssuerName: letsencrypt-prod
     defaultIssuerKind: ClusterIssuer
-    defaultIssuerGroup: cert-manager.io


### PR DESCRIPTION
Planning to do this Thursday, since it is likely to require manual intervention, as these are pretty long upgrades, which we should probably try to avoid.

In the meantime, I'm looking at upgrade docs of both to see if I can be well prepared for what comes.

Notes:

- upgrading cert-manager from 0.12 to 0.15 instead of 0.16, due to note [here](https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16/) suggesting that 0.16 requires kubernetes 1.16.14, while our GKE clusters are still on 1.15
- [ ] [0.14 upgrade docs](https://cert-manager.io/docs/installation/upgrading/upgrading-0.13-0.14/) suggest manually deleting all cert-manager deployments prior to upgrade
- [x] same doc notes that the webhook is now required, so our `webhook.enabled = false` config should be removed
- [x] looks like `ingressShim.defaultACMEChallengeType` doesn't exist anymore

nginx:

- [x] upgrading from 0.14 to 2.13
- [x] updating repo from deprecated `stable/nginx-ingress` to dedicated 
- [x] update config key to `ingress-nginx`
- [x] lots of config changes for the ingress
- [x] might need to add annotations for ingress controller to be used?
- [x] metrics config appears to have changed a lot
- [x] defaultBackend must be enabled explicitly

closes #1498 