### PR TITLE
test cert-manager update by requiring a new host on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -22,6 +22,7 @@ binderhub:
     hosts:
       - gke.staging.mybinder.org
       - gke2.staging.mybinder.org
+      - cert-manager-test.staging.mybinder.org
 
   jupyterhub:
     singleuser:


### PR DESCRIPTION
We can't know 100% that the cert-manager update worked until it issues a new cert (#1589).
This adds an endpoint to request a new cert, in the hopes of verifying that cert-manager is working. It's not *exactly* the same as verifying renewal in #1589, but should at least kick the tires.