### PR TITLE
remove cert-manager from chart

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ env:
   GCLOUD_SDK_VERION: "290.0.1"
   HELM_VERSION: "v2.16.3"
   KUBECTL_VERSION: "v1.18.0"
+  CERT_MANAGER_VERSION: "v0.15.2"
   GIT_COMMITTER_EMAIL: ci-user@github.local
   GIT_COMMITTER_NAME: CI User
   GIT_AUTHOR_EMAIL: ci-user@github.local

--- a/config/cert-manager.yaml
+++ b/config/cert-manager.yaml
@@ -1,0 +1,4 @@
+ingressShim:
+  # our default ClusterIssuer is in mybinder/templates/cluster-issuer.yaml
+  defaultIssuerName: letsencrypt-prod
+  defaultIssuerKind: ClusterIssuer

--- a/deploy.py
+++ b/deploy.py
@@ -263,7 +263,7 @@ def setup_certmanager():
     # FIXME: remove after deployment is fixed
     # this patch helps avoid hangs while deleting things that aren't used anymore
     # due to webhook being undeployed
-    subprocess.check_call([
+    subprocess.call([
         "kubectl",
         "patch",
         "crd",

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -8,11 +8,6 @@ dependencies:
  - name: grafana
    version: 3.10.1
    repository: https://kubernetes-charts.storage.googleapis.com
- - name: cert-manager
-   # note: due to https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16
-   # we should not upgrade to v0.16 until we are on kubernetes >= 1.16.14 everywhere
-   version: v0.15.2
-   repository: https://charts.jetstack.io
  - name: binderhub
    version: 0.2.0-n215.h9447e17
    repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -1,3 +1,4 @@
+{{- if false }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -28,3 +29,4 @@ spec:
     - http01:
         ingress:
           class: nginx
+{{- end }}


### PR DESCRIPTION
cert-manager must be deployed in its own chart, but before that can work it must be completely removed. We cannot switch over in one step.