### PR TITLE
deploy cert-manager in its own chart

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -240,19 +240,6 @@ def deploy(release):
             '--watch', d
         ])
 
-    remove_certmanager()
-
-def remove_certmanager():
-    """Remove certmanager"""
-    version = os.environ["CERT_MANAGER_VERSION"]
-
-    manifest_url = f"https://github.com/jetstack/cert-manager/releases/download/{version}/cert-manager.yaml"
-    print(BOLD + GREEN + f"Deleting cert-manager {version}" + NC, flush=True)
-
-    subprocess.check_call(
-        ["kubectl", "delete", "-f", manifest_url]
-    )
-
 
 def setup_certmanager():
     """Install cert-manager separately
@@ -260,20 +247,6 @@ def setup_certmanager():
     cert-manager docs and CRD assumptions say that cert-manager must never be a sub-chart,
     always installed on its own in a cert-manager namespace
     """
-    # FIXME: remove after deployment is fixed
-    # this patch helps avoid hangs while deleting things that aren't used anymore
-    # due to webhook being undeployed
-    subprocess.call([
-        "kubectl",
-        "patch",
-        "crd",
-        "challenges.acme.cert-manager.io",
-        "-p",
-        '{"metadata":{"finalizers": []}}',
-        "--type=merge",
-    ])
-    return
-
 
     # TODO: cert-manager chart >= 0.15
     # has `installCRDs` option, which should eliminate the separate CRD step

--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -1,4 +1,3 @@
-{{- if false }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -29,4 +28,3 @@ spec:
     - http01:
         ingress:
           class: nginx
-{{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -448,8 +448,3 @@ federationRedirect:
       weight: 1
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
-
-cert-manager:
-  ingressShim:
-    defaultIssuerName: letsencrypt-prod
-    defaultIssuerKind: ClusterIssuer


### PR DESCRIPTION
This should hopefully finish the transition of cert-manager to its own helm release

I've already deployed this manually to staging via `deploy.py --local` and it has successfully issued the cert I started the request for in #1590 so hopefully this will work in prod as well