### PR TITLE
bump helm to latest 2.x patch release (2.16.10)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ on:
 # Global environment variables
 env:
   GCLOUD_SDK_VERION: "290.0.1"
-  HELM_VERSION: "v2.16.3"
+  HELM_VERSION: "v2.16.10"
   KUBECTL_VERSION: "v1.18.0"
   CERT_MANAGER_VERSION: "v0.15.2"
   GIT_COMMITTER_EMAIL: ci-user@github.local

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -7,7 +7,7 @@ on:
       - "**/*.yml"
 
 env:
-  HELM_VERSION: "v2.16.3"
+  HELM_VERSION: "v2.16.10"
 
 jobs:
   yamllint-raw:


### PR DESCRIPTION
minor version is unchanged, so this shouldn't be disruptive