### PR TITLE
update ingress apiVersion

### DIFF
--- a/config/ovh/ovh_mybinder_org_ingress.yaml
+++ b/config/ovh/ovh_mybinder_org_ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ovh-mybinder-org

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 description: A meta-chart for the binderhub deployment on mybinder.org
 name: mybinder
 version: 0.1.0
+kubeVersion: ">= 1.15.0"

--- a/mybinder/templates/federation-redirect/ingress.yaml
+++ b/mybinder/templates/federation-redirect/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.federationRedirect.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: federation-redirect

--- a/mybinder/templates/gcs-proxy/ingress.yaml
+++ b/mybinder/templates/gcs-proxy/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gcsProxy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: gcs-proxy

--- a/mybinder/templates/matomo/ingress.yaml
+++ b/mybinder/templates/matomo/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.matomo.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: matomo

--- a/mybinder/templates/redirector/ingress.yaml
+++ b/mybinder/templates/redirector/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: redirector

--- a/mybinder/templates/static/ingress.yaml
+++ b/mybinder/templates/static/ingress.yaml
@@ -5,7 +5,7 @@
 #
 # This is a separate path-whitelisted ingress rather than just
 # a domain alias to prevent possible reflection attacks.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: static


### PR DESCRIPTION
extensions/v1beta1 is removed in 1.16. The newer networking.k8s.io/v1beta1 is available from 1.14.

All our clusters are on at least 1.15, so we should be set. Put this in `kubeVersion` in the Chart.yaml to be safe.


this should help with #1485