### PR TITLE
helm doesn't evaluate kubernetesVersion prereleases correctly

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A meta-chart for the binderhub deployment on mybinder.org
 name: mybinder
 version: 0.1.0
-kubeVersion: ">= 1.15.0"
+kubeVersion: ">= 1.15.0-0"


### PR DESCRIPTION
Workaround found [here](https://github.com/helm/helm/issues/6190#issuecomment-519712714)