### PR TITLE
specify kube version in kubeval

### DIFF
--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -53,6 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         release: ["staging", "prod", "ovh", "turing"]
+        kube_version: ["1.15", "1.18"]
 
     steps:
       - name: Checkout repo
@@ -113,6 +114,6 @@ jobs:
           yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
 
       # Use --ignore-missing-schemas to avoid failure of CRDs
-      - name: Validate k8s resources for ${{ matrix.release}}
+      - name: Validate k8s resources for ${{ matrix.release }} kube-${{ matrix.kube_version }}
         run: |
-          kubeval --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+          kubeval --kubernetes-version ${{ matrix.kube_version }} --strict --ignore-missing-schemas -d helm-${{ matrix.release }}

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -29,31 +29,46 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install yamllint
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on everything but secrets
-        run: |
-          yamllint -d scripts/yamllint-no-secrets.yaml --no-warnings .
-
       - name: Unlock git-crypt secrets
         if: github.event.pull_request.head.repo.fork == false
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on secrets
-        if: github.event.pull_request.head.repo.fork == false
+      # pick yamllint config based on whether we have access to secrets or not
+      - name: Select yamllint config
         run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "false" ]]; then
+            echo "linting secrets"
+            export YAMLLINT_CONFIG=scripts/yamllint-config.yaml
+          else
+            echo "not linting secrets"
+            export YAMLLINT_CONFIG=scripts/yamllint-no-secrets.yaml
+          fi
+          # persist env for the next step
+          echo "::set-env name=YAMLLINT_CONFIG::$YAMLLINT_CONFIG"
+
+      # We use --no-warnings in this step to reduce output to critical errors
+      - name: Run yamllint
+        run: |
+          yamllint -d ${YAMLLINT_CONFIG} --no-warnings .
 
   lint-helm:
-    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        release: ["staging", "prod", "ovh", "turing"]
-        kube_version: ["1.15", "1.18"]
+        include:
+        - release: staging
+          kube_version: "1.15"
+        - release: prod
+          kube_version: "1.15"
+        - release: prod
+          kube_version: "1.18"
+        - release: ovh
+          kube_version: "1.15"
+        - release: turing
+          kube_version: "1.16"
 
     steps:
       - name: Checkout repo
@@ -76,18 +91,14 @@ jobs:
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
-      - name: Install helm kubeval plugin
-        run: |
-          helm plugin install https://github.com/instrumenta/helm-kubeval
-
-      - name: Install local charts
-        working-directory: mybinder
+      - name: Setup helm
         run: |
           helm init --client-only
-          helm dep up
+          helm dep up mybinder
           helm plugin install https://github.com/instrumenta/helm-kubeval
 
       - name: Unlock git-crypt secrets
+        if: github.event.pull_request.head.repo.fork == false
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
@@ -96,13 +107,23 @@ jobs:
         run: |
           chartpress
 
+      - name: Select secret config
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "false" ]]; then
+            export SECRET_CONFIG="-f secrets/config/common.yaml -f config/${{ matrix.release }}.yaml"
+          else
+            export SECRET_CONFIG="-f config/test-secrets.yaml"
+          fi
+          echo "linting with secret config ${SECRET_CONFIG}"
+          # persist env for the next step
+          echo "::set-env name=SECRET_CONFIG::$SECRET_CONFIG"
+
       - name: Run helm kubeval for ${{ matrix.release }} with kube-${{ matrix.kube_version }}
         run: |
           helm kubeval \
           --kubernetes-version ${{ matrix.kube_version }} \
           --strict \
           --ignore-missing-schemas \
-          -f secrets/config/common.yaml \
           -f config/${{ matrix.release }}.yaml \
-          -f secrets/config/${{ matrix.release }}.yaml
+          ${SECRET_CONFIG} \
           mybinder

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -59,16 +59,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        # versions must be available
+        # at https://github.com/instrumenta/kubernetes-json-schema
+        # in the form v${version}-standalone-strict
+        # this does *not* include all kubernetes versions!
         - release: staging
-          kube_version: "1.15"
+          kube_version: "1.15.7"
         - release: prod
-          kube_version: "1.15"
+          kube_version: "1.15.7"
         - release: prod
-          kube_version: "1.18"
+          kube_version: "1.18.1"
         - release: ovh
-          kube_version: "1.15"
+          kube_version: "1.15.7"
         - release: turing
-          kube_version: "1.16"
+          kube_version: "1.16.4"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -10,7 +10,7 @@ env:
   HELM_VERSION: "v2.16.10"
 
 jobs:
-  yamllint-raw:
+  lint-config:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,9 +30,9 @@ jobs:
           python -m pip install yamllint
 
       # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on config/
+      - name: Run yamllint on everything but secrets
         run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings config/
+          yamllint -d scripts/yamllint-no-secrets.yaml --no-warnings .
 
       - name: Unlock git-crypt secrets
         if: github.event.pull_request.head.repo.fork == false
@@ -41,10 +41,10 @@ jobs:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on secrets/config
+      - name: Run yamllint on secrets
         if: github.event.pull_request.head.repo.fork == false
         run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
+          yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/
 
   lint-helm:
     if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           yamllint -d scripts/yamllint-config.yaml --no-warnings secrets/config/
 
-  yamllint-templates:
+  lint-helm:
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     strategy:
@@ -69,23 +69,23 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install yamllint chartpress
-
-      - name: Install kubeval
-        run: |
-          curl -L https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
-          sudo mv ${HOME}/kubeval /usr/local/bin
+          python -m pip install chartpress
 
       - name: Install helm
         run: |
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
+      - name: Install helm kubeval plugin
+        run: |
+          helm plugin install https://github.com/instrumenta/helm-kubeval
+
       - name: Install local charts
         working-directory: mybinder
         run: |
           helm init --client-only
           helm dep up
+          helm plugin install https://github.com/instrumenta/helm-kubeval
 
       - name: Unlock git-crypt secrets
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
@@ -96,24 +96,13 @@ jobs:
         run: |
           chartpress
 
-      - name: Make output directory for helm template
+      - name: Run helm kubeval for ${{ matrix.release }} with kube-${{ matrix.kube_version }}
         run: |
-          mkdir helm-${{ matrix.release }}
-
-      - name: Run helm template for ${{ matrix.release }}
-        run: |
-          helm template mybinder \
+          helm kubeval \
+          --kubernetes-version ${{ matrix.kube_version }} \
+          --strict \
+          --ignore-missing-schemas \
           -f secrets/config/common.yaml \
           -f config/${{ matrix.release }}.yaml \
-          -f secrets/config/${{ matrix.release }}.yaml \
-          --output-dir helm-${{ matrix.release }}
-
-      # We use --no-warnings in this step to reduce output to critical errors
-      - name: Run yamllint on ${{ matrix.release }} chart
-        run: |
-          yamllint -d scripts/yamllint-config.yaml --no-warnings helm-${{ matrix.release }}
-
-      # Use --ignore-missing-schemas to avoid failure of CRDs
-      - name: Validate k8s resources for ${{ matrix.release }} kube-${{ matrix.kube_version }}
-        run: |
-          kubeval --kubernetes-version ${{ matrix.kube_version }} --strict --ignore-missing-schemas -d helm-${{ matrix.release }}
+          -f secrets/config/${{ matrix.release }}.yaml
+          mybinder

--- a/config/test-secrets.yaml
+++ b/config/test-secrets.yaml
@@ -1,0 +1,23 @@
+# minimal content for fields required in secret config
+# for use when linting/testing PRs prior to merge
+binderhub:
+  networkPolicy:
+    egress:
+      bannedIps:
+        - "1.1.1.1/32"
+    ingress:
+      bannedIps:
+        - "1.1.1.1/32"
+  jupyterhub:
+    hub:
+      services:
+        binder:
+          apiToken: "abc123"
+    proxy:
+      secretToken: "abc123"
+matomo:
+  db:
+    serviceAccountKey: "abc123"
+
+analyticsPublisher:
+  serviceAccountKey: "abc123"

--- a/scripts/yamllint-config.yaml
+++ b/scripts/yamllint-config.yaml
@@ -8,6 +8,7 @@ extends: relaxed
 # the JupyterHub helm chart too
 ignore: |
   **/jupyterhub/**
+  mybinder/templates
 
 # Ignore common but non-critical errors
 rules:

--- a/scripts/yamllint-no-secrets.yaml
+++ b/scripts/yamllint-no-secrets.yaml
@@ -1,0 +1,5 @@
+extends: scripts/yamllint-config.yaml
+
+ignore: |
+  secrets/**
+  mybinder/templates


### PR DESCRIPTION
- lints all our yaml, not just config
- use helm-kubeval plugin as mentioned in #1601, skipping what should be a redundant yamllint on helm templates
- run helm-kubeval with the bare minimum secret config (in config/test-secrets.yaml) when secrets are not available, giving us a better chance of catching helm template issues prior to merge

closes #1601