### PR TITLE
consolidate resource allocations to values.yaml

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -13,14 +13,6 @@ binderhub:
 
   replicas: 1
 
-  resources:
-    requests:
-      cpu: "0.25"
-      memory: 1Gi
-    limits:
-      cpu: "2"
-      memory: 1Gi
-
   extraVolumes:
     - name: secrets
       secret:
@@ -49,45 +41,17 @@ binderhub:
           - binder.mybinder.ovh
 
   jupyterhub:
-    hub:
-      resources:
-        requests:
-          cpu: "0.25"
-          memory: 1Gi
-        limits:
-          cpu: "2"
-          memory: 1Gi
     singleuser:
       imagePullSecret:
         enabled: true
         registry: dlqpwel7.gra5.container-registry.ovh.net
         username: cLxohgOONW
         email:
-      memory:
-        guarantee: 550M
-        limit: 2G
-      cpu:
-        guarantee: 0.01
-        limit: 1
+
     proxy:
       https:
         type: offload
-      chp:
-        resources:
-          requests:
-            memory: 320Mi
-            cpu: "0.1"
-          limits:
-            memory: 320Mi
-            cpu: "0.5"
-      nginx:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: "0.25"
-          limits:
-            memory: 512Mi
-            cpu: 1
+
 
     ingress:
       annotations:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -32,51 +32,14 @@ binderhub:
     hosts:
       - gke.mybinder.org
 
-  resources:
-    requests:
-      cpu: "0.25"
-      memory: 1Gi
-    limits:
-      cpu: "2"
-      memory: 1Gi
-
   jupyterhub:
     singleuser:
       nodeSelector: *userNodeSelector
-      memory:
-        guarantee: 450M
-        limit: 2G
-      cpu:
-        guarantee: 0.01
-        limit: 1
     hub:
       nodeSelector: *coreNodeSelector
-      resources:
-        requests:
-          cpu: "0.25"
-          memory: 1Gi
-        limits:
-          cpu: "2"
-          memory: 1Gi
 
     proxy:
       nodeSelector: *coreNodeSelector
-      chp:
-        resources:
-          requests:
-            memory: 320Mi
-            cpu: "0.1"
-          limits:
-            memory: 320Mi
-            cpu: "0.5"
-      nginx:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: "0.25"
-          limits:
-            memory: 512Mi
-            cpu: 1
     ingress:
       hosts:
         - hub.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -9,6 +9,10 @@ binderhub:
       sticky_builds: true
       build_memory_limit: "2G"
 
+  resources:
+    requests:
+      memory: 512Mi
+
   dind:
     resources:
       requests:
@@ -25,6 +29,11 @@ binderhub:
       - cert-manager-test.staging.mybinder.org
 
   jupyterhub:
+    hub:
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: null
     singleuser:
       memory:
         guarantee: 256M

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -17,14 +17,6 @@ binderhub:
 
   replicas: 1
 
-  resources:
-    requests:
-      cpu: "0.25"
-      memory: 1Gi
-    limits:
-      cpu: "2"
-      memory: 1Gi
-
   ingress:
     enabled: true
     hosts:
@@ -54,39 +46,6 @@ binderhub:
       value: /event-secret/service-account.json
 
   jupyterhub:
-    hub:
-      resources:
-        requests:
-          cpu: "0.25"
-          memory: 1Gi
-        limits:
-          cpu: "2"
-          memory: 1Gi
-    singleuser:
-      memory:
-        guarantee: 550M
-        limit: 2G
-      cpu:
-        guarantee: 0.01
-        limit: 1
-    proxy:
-      chp:
-        resources:
-          requests:
-            memory: 320Mi
-            cpu: "0.1"
-          limits:
-            memory: 320Mi
-            cpu: "0.5"
-      nginx:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: "0.25"
-          limits:
-            memory: 512Mi
-            cpu: 1
-
     ingress:
       enabled: true
       annotations:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -29,6 +29,15 @@ binderhub:
   pdb:
     minAvailable: 1
 
+  resources:
+    requests:
+      cpu: "0.25"
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+
+
   networkPolicy:
     enabled: true
     egress:
@@ -178,6 +187,13 @@ binderhub:
     hub:
       networkPolicy:
         enabled: true
+      resources:
+        requests:
+          cpu: "0.25"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 1Gi
       pdb:
         minAvailable: 0
       extraConfig:
@@ -197,6 +213,13 @@ binderhub:
       service:
         type: ClusterIP
       chp:
+        resources:
+          requests:
+            memory: 320Mi
+            cpu: "0.1"
+          limits:
+            memory: 320Mi
+            cpu: "0.5"
         cmd:
           - configurable-http-proxy
           - --ip=0.0.0.0
@@ -206,6 +229,14 @@ binderhub:
           - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
           - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
           - --log-level=error
+      nginx:
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: "0.25"
+          limits:
+            memory: 512Mi
+            cpu: 1
     ingress:
       enabled: true
       annotations:
@@ -225,6 +256,12 @@ binderhub:
       networkPolicy:
         enabled: true
         egress: []
+      memory:
+        guarantee: 450M
+        limit: 2G
+      cpu:
+        guarantee: 0.01
+        limit: 1
       storage:
         extraVolumes:
           - name: etc-jupyter
@@ -280,19 +317,19 @@ ingress-nginx:
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                - ingress
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - controller
-            topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - ingress
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - controller
+              topologyKey: kubernetes.io/hostname
     replicaCount: 3
     scope:
       enabled: true


### PR DESCRIPTION
we had duplicate but equivalent resource allocations on all deployments

it's fine for these to diverge based on deployments, but gke-prod gets by far the most attention and is often the only one updated

almost all values are initialized by copy/paste from prod and are still the same other than singleuser guarantees

a step toward #1575

Passing the changes through [helm diff](https://github.com/databus23/helm-diff) [1], shows the following resulting changes:

<details>

```
staging
Switched to context "staging".
staging, binder, Deployment (apps) has changed:
  # Source: mybinder/charts/binderhub/templates/deployment.yaml
--
--
          resources:
+             limits:
+               cpu: "2"
+               memory: 1Gi
              requests:
--
--
              requests:
-               cpu: 0.2
+               cpu: "0.25"
                memory: 512Mi
--
--
            timeoutSeconds: 10
staging, hub, Deployment (apps) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/hub/deployment.yaml
--
--
          # This lets us autorestart when the secret changes!
-         checksum/config-map: e49a3ffa2e4eca709db1553d25e79291dd43f61ce371c9bf08031c144626ac29
+         checksum/config-map: db53c3f1aa43a0e844904568e6fb73e689083928842c0b8d495e33f1a2e2962c
          checksum/secret: 72393350b09b5e0626b0a09b50d7a5b871404dd1457f561d26575fc5db227b47
--
--
            resources:
+             limits:
+               cpu: "2"
+               memory: 1Gi
              requests:
--
--
                port: hub
staging, hub-config, ConfigMap (v1) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/hub/configmap.yaml
--
--
        resources:
+         limits:
+           cpu: "2"
+           memory: 1Gi
          requests:
--
--
              setattr(cparent, name, data)
staging, proxy, Deployment (apps) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/proxy/deployment.yaml
--
--
            resources:
+             limits:
+               cpu: "0.5"
+               memory: 320Mi
              requests:
--
--
              requests:
-               cpu: 200m
-               memory: 512Mi
+               cpu: "0.1"
+               memory: 320Mi
            securityContext:
prod
Switched to context "prod".
no changes
ovh
Switched to context "ovh".
ovh, hub, Deployment (apps) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/hub/deployment.yaml
--
--
          # This lets us autorestart when the secret changes!
-         checksum/config-map: ce7745b68e78b9de074dfb7bdf69f9d88ec19984dc3561284e648bbe575b65e7
+         checksum/config-map: 5b55f70db5e2fa7f2ae2dcce1e5a00319a7bb8472ae717b0f9f045125c658292
          checksum/secret: b9afb1b98e5d925129274caaf4f1975a5c0af341be6ceb112a1adb2fb947a4ac
--
--
                port: hub
ovh, hub-config, ConfigMap (v1) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/hub/configmap.yaml
--
--
        memory:
-         guarantee: 550M
+         guarantee: 450M
          limit: 2G
--
--
              setattr(cparent, name, data)
ovh, user-placeholder, StatefulSet (apps) has changed:
  # Source: mybinder/charts/binderhub/charts/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
--
--
                cpu: 0.01
-               memory: 550M
+               memory: 450M
              limits:
```

</details>

Highlights:

- no changes at all to prod
- reduce singleuser memory requests on ovh to match prod
- apply some limits where there were none to staging, and small changes to requests

I specifically left dind resources out of this, since they are quite sensitive to node flavor, unlike most of the rest.


[1] which I scripted [here](https://gist.github.com/83c9c87b070ba8dac5c1572ec96bb2dd) for myself, but it assumes you have kubectx setup exactly like I do with a kubernetes context for each deployment