### PR TITLE
Fix issue template ban_check icon

### DIFF
--- a/.github/ISSUE_TEMPLATE/ban_check.md
+++ b/.github/ISSUE_TEMPLATE/ban_check.md
@@ -1,5 +1,5 @@
 ---
-name: "U+2705 Repo Check"
+name: "\U00002705 Repo Check"
 about: "If you're concerned about banning, we can check your repo"
 labels: question
 


### PR DESCRIPTION
The icon on the repo check issue template is incorrect:
![image](https://user-images.githubusercontent.com/1644105/92976640-e3067b00-f482-11ea-919b-fa5a54b76b1b.png)
