### PR TITLE
Limit all jovian.ml for the moment

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -61,6 +61,9 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
+        - pattern: ^jupyter-api-2dgit.*
+          config:
+            quota: 20
 
     GitRepoProvider:
       banned_specs:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -61,13 +61,11 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
-        - pattern: ^jupyter-api-2dgit.*
-          config:
-            quota: 20
 
     GitRepoProvider:
       banned_specs:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
+        - ^https%3A%2F%2Fjovian.ml%2Fapi%2Fgit%2F.*
     BinderHub:
       use_registry: true
       build_image: jupyter/repo2docker:0.11.0-141.gf0c6f65


### PR DESCRIPTION
There is no one repo that uses a lot of resources so instead this regex
tries to match every jovian.ml repository and applies a lower limit to
it.

It seems as if almost every launch from jovian.ml comes from a different repository/URL.

It would be better if we could apply a limit to the sum of all repos that match a pattern.

Does someone know who we can contact from the website to let them know before we do this or find a compromise that works for everyone?