### PR TITLE
repo2docker bump: jupyter/repo2docker:0.11.0-159.g35e6e7e

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -67,7 +67,7 @@ binderhub:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:0.11.0-143.g8fe5916
+      build_image: jupyter/repo2docker:0.11.0-159.g35e6e7e
       per_repo_quota: 100
       per_repo_quota_higher: 200
       build_memory_limit: "2G"


### PR DESCRIPTION
This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/8fe5916...35e6e7e

- Closes https://github.com/jupyterhub/mybinder.org-deploy/issues/1607 (hopefully)