### PR TITLE
add grafana-export script

### DIFF
--- a/grafana-data/dashboards/3SpLQinmk.json
+++ b/grafana-data/dashboards/3SpLQinmk.json
@@ -1,0 +1,1282 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "#e5ac0e",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "rgba(255, 96, 96, 1)",
+     "limit": 100,
+     "matchAny": true,
+     "name": "Ops log",
+     "showIn": 0,
+     "tags": [
+      "ops-log"
+     ],
+     "type": "tags"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "iteration": 1600760214706,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 17,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "/.*build.*/",
+      "fill": 3,
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(binderhub_build_time_seconds_count[10m]))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "build-watch-requests (10m)",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(increase(binderhub_launch_time_seconds_count[10m]))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Total new launches (10m)",
+      "refId": "B"
+     },
+     {
+      "expr": "sum(kube_pod_status_phase{pod=~\"build-.*\", kubernetes_namespace!=\"jhub-ns\"})",
+      "legendFormat": "Running builds",
+      "refId": "C"
+     },
+     {
+      "expr": "",
+      "refId": "D"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Total launches/builds",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "none",
+      "label": "Launches",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": "Builds",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "-- Mixed --",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 31,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": true,
+    "steppedLine": false,
+    "targets": [
+     {
+      "datasource": "prometheus",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\"})",
+      "legendFormat": "GKE",
+      "refId": "A"
+     },
+     {
+      "datasource": "GESIS",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\", kubernetes_namespace!=\"jhub-ns\"})",
+      "legendFormat": "Gesis",
+      "refId": "B"
+     },
+     {
+      "datasource": "OVH",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\"})",
+      "hide": false,
+      "legendFormat": "OVH",
+      "refId": "C"
+     },
+     {
+      "datasource": "Turing",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\"})",
+      "hide": true,
+      "legendFormat": "Turing",
+      "refId": "D"
+     },
+     {
+      "datasource": "GKE2",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\"})",
+      "legendFormat": "GKE2",
+      "refId": "E"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "User pods running over time",
+    "tooltip": {
+     "shared": true,
+     "sort": 1,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "The number of currently outstanding requests waiting on a launch or build.\n\nThis does correspond to the number of launches, but has little relationship to the number of builds because many requests could be waiting on the same build, and some builds may no longer have anyone waiting for them.",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 7
+    },
+    "id": 34,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "/.*builds.*/",
+      "fill": 3,
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(binderhub_inprogress_builds)",
+      "interval": "",
+      "intervalFactor": 1,
+      "legendFormat": "builds",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(binderhub_inprogress_launches)",
+      "instant": false,
+      "interval": "",
+      "intervalFactor": 1,
+      "legendFormat": "launches",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Requests waiting on launches/builds",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "none",
+      "label": "Launches",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "decimals": 0,
+      "format": "short",
+      "label": "Builds",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 10,
+     "w": 12,
+     "x": 12,
+     "y": 9
+    },
+    "id": 26,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Total Usage",
+      "color": "rgb(124, 124, 124)",
+      "linewidth": 5
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_container_resource_requests_memory_bytes and on (pod) (kube_pod_container_status_ready)) / sum(kube_node_status_allocatable_memory_bytes) ",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Total Usage",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(kube_pod_container_resource_requests_memory_bytes and on (pod) (kube_pod_container_status_ready)) by (node) / sum(kube_node_status_allocatable_memory_bytes) by (node)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": false,
+      "fillColor": "rgba(234, 184, 57, 0.21)",
+      "line": true,
+      "op": "lt",
+      "value": 0.4
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Cluster utilization",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": "1",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 14
+    },
+    "id": 16,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {},
+     {
+      "alias": "Num builds",
+      "yaxis": 2
+     },
+     {
+      "alias": "Total build attempts",
+      "yaxis": 2
+     },
+     {
+      "alias": "New build attempts",
+      "fill": 3,
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_build_time_seconds_count{status=\"success\", kubernetes_namespace!=\"jhub-ns\"}[10m])) / sum(delta(binderhub_build_time_seconds_count{kubernetes_namespace!=\"jhub-ns\"}[10m]))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Build % Success",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(delta(binderhub_launch_time_seconds_count{status=\"success\", kubernetes_namespace!=\"jhub-ns\"}[10m])) / sum(delta(binderhub_launch_time_seconds_count{status!=\"retry\", kubernetes_namespace!=\"jhub-ns\"}[10m]))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Launch % Success",
+      "refId": "C"
+     },
+     {
+      "expr": "sum(delta(binderhub_launch_time_seconds_count{status=\"success\", retries=\"0\", kubernetes_namespace!=\"jhub-ns\"}[10m])) / sum(delta(binderhub_launch_time_seconds_count{status!=\"retry\", kubernetes_namespace!=\"jhub-ns\"}[10m]))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Launch % Success (first try)",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch/Build Success % [10m]",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": "1",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": "20",
+      "min": "0",
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "-- Mixed --",
+    "description": "Cordoned nodes on each cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 8,
+     "w": 12,
+     "x": 12,
+     "y": 19
+    },
+    "id": 33,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "maxPerRow": 2,
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 2,
+    "points": false,
+    "renderer": "flot",
+    "repeat": "cluster",
+    "repeatDirection": "v",
+    "scopedVars": {
+     "cluster": {
+      "selected": true,
+      "text": "GKE2",
+      "value": "GKE2"
+     }
+    },
+    "seriesOverrides": [
+     {}
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "datasource": "$cluster",
+      "expr": "sum(kube_node_spec_unschedulable)",
+      "legendFormat": "GKE",
+      "refId": "A"
+     },
+     {
+      "datasource": "GESIS",
+      "expr": "sum(kube_node_spec_unschedulable)",
+      "legendFormat": "GESIS",
+      "refId": "B"
+     },
+     {
+      "datasource": "OVH",
+      "expr": "sum(kube_node_spec_unschedulable)",
+      "legendFormat": "OVH",
+      "refId": "C"
+     },
+     {
+      "datasource": "Turing",
+      "expr": "sum(kube_node_spec_unschedulable)",
+      "hide": true,
+      "legendFormat": "Turing",
+      "refId": "D"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Cordoned nodes",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {
+     "10th-percentile-failure": "#ef843c",
+     "10th-percentile-success": "#b7dbab",
+     "25th-percentile-failure": "#99440a",
+     "25th-percentile-success": "#7eb26d",
+     "50th-percentile-failure": "#ea6460",
+     "50th-percentile-success": "#7eb26d",
+     "75th-percentile-failure": "#bf1b00",
+     "75th-percentile-success": "#508642",
+     "90th-percentile-failure": "#58140c",
+     "90th-percentile-success": "#3f6833"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 8,
+     "w": 12,
+     "x": 0,
+     "y": 21
+    },
+    "id": 28,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "histogram_quantile(0.1, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "10th-percentile-{{status}}",
+      "refId": "A"
+     },
+     {
+      "expr": "histogram_quantile(0.25, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "25th-percentile-{{status}}",
+      "refId": "B"
+     },
+     {
+      "expr": "histogram_quantile(0.5, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (retries, kubernetes_node, instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "intervalFactor": 2,
+      "legendFormat": "50th-percentile-{{status}} ",
+      "refId": "C"
+     },
+     {
+      "expr": "histogram_quantile(0.75, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "75th-percentile-{{status}}",
+      "refId": "D"
+     },
+     {
+      "expr": "histogram_quantile(0.9, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (instance, kubernetes_node, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 2,
+      "legendFormat": "90th-percentile-{{status}}",
+      "refId": "E"
+     },
+     {
+      "expr": "histogram_quantile(0.99, sum(rate(binderhub_launch_time_seconds_bucket[5m])) without (instance, kubernetes_node, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 2,
+      "legendFormat": "99th-percentile-{{status}}",
+      "refId": "F"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch time percentiles",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "s",
+      "label": null,
+      "logBase": 2,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "cards": {
+     "cardPadding": null,
+     "cardRound": null
+    },
+    "color": {
+     "cardColor": "#b4ff00",
+     "colorScale": "sqrt",
+     "colorScheme": "interpolateSpectral",
+     "exponent": 0.5,
+     "max": null,
+     "min": 0,
+     "mode": "spectrum"
+    },
+    "dataFormat": "timeseries",
+    "datasource": "$cluster",
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 27
+    },
+    "heatmap": {},
+    "hideZeroBuckets": false,
+    "highlightCards": true,
+    "id": 25,
+    "legend": {
+     "show": true
+    },
+    "links": [],
+    "options": {},
+    "reverseYBuckets": false,
+    "targets": [
+     {
+      "expr": "(time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60",
+      "format": "time_series",
+      "interval": "30m",
+      "intervalFactor": 2,
+      "refId": "A"
+     }
+    ],
+    "title": "Distribution of user pod age over time (max 2 hr)",
+    "tooltip": {
+     "show": true,
+     "showHistogram": true
+    },
+    "type": "heatmap",
+    "xAxis": {
+     "show": true
+    },
+    "xBucketNumber": null,
+    "xBucketSize": "30m",
+    "yAxis": {
+     "decimals": null,
+     "format": "m",
+     "logBase": 1,
+     "max": "120",
+     "min": null,
+     "show": true,
+     "splitFactor": null
+    },
+    "yBucketBound": "auto",
+    "yBucketNumber": null,
+    "yBucketSize": 5
+   },
+   {
+    "aliasColors": {
+     "10th-percentile-failure": "#ef843c",
+     "10th-percentile-success": "#b7dbab",
+     "25th-percentile-failure": "#99440a",
+     "25th-percentile-success": "#7eb26d",
+     "50th-percentile-failure": "#ea6460",
+     "50th-percentile-success": "#7eb26d",
+     "75th-percentile-failure": "#bf1b00",
+     "75th-percentile-success": "#508642",
+     "90th-percentile-failure": "#58140c",
+     "90th-percentile-success": "#3f6833"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 29
+    },
+    "id": 27,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": false,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 2,
+    "points": true,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "histogram_quantile(0.1, sum(rate(binderhub_build_time_seconds_bucket[2m])) without (instance, provider, repo)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "10th-percentile-{{status}}",
+      "refId": "A"
+     },
+     {
+      "expr": "histogram_quantile(0.25, sum(rate(binderhub_build_time_seconds_bucket[2m])) without (instance, provider, repo)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "25th-percentile-{{status}}",
+      "refId": "B"
+     },
+     {
+      "expr": "histogram_quantile(0.5, sum(rate(binderhub_build_time_seconds_bucket[2m])) without (instance, provider, repo)) > 0",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "50th-percentile-{{status}}",
+      "refId": "C"
+     },
+     {
+      "expr": "histogram_quantile(0.75, sum(rate(binderhub_build_time_seconds_bucket[2m])) without (instance, provider, repo)) > 0",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 2,
+      "legendFormat": "75th-percentile-{{status}}",
+      "refId": "D"
+     },
+     {
+      "expr": "histogram_quantile(0.9, sum(rate(binderhub_build_time_seconds_bucket[2m])) without (instance, provider, repo)) > 0",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "90th-percentile-{{status}}",
+      "refId": "E"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Build time percentiles",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "s",
+      "label": null,
+      "logBase": 2,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "cards": {
+     "cardPadding": null,
+     "cardRound": null
+    },
+    "color": {
+     "cardColor": "#b4ff00",
+     "colorScale": "sqrt",
+     "colorScheme": "interpolateSpectral",
+     "exponent": 0.5,
+     "mode": "spectrum"
+    },
+    "dataFormat": "timeseries",
+    "datasource": "$cluster",
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 33
+    },
+    "heatmap": {},
+    "hideZeroBuckets": false,
+    "highlightCards": true,
+    "id": 24,
+    "legend": {
+     "show": true
+    },
+    "links": [],
+    "options": {},
+    "reverseYBuckets": false,
+    "targets": [
+     {
+      "expr": "(time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60",
+      "format": "time_series",
+      "interval": "30m",
+      "intervalFactor": 2,
+      "refId": "A"
+     }
+    ],
+    "title": "Distribution of user pod age over time (stale pods)",
+    "tooltip": {
+     "show": true,
+     "showHistogram": true
+    },
+    "type": "heatmap",
+    "xAxis": {
+     "show": true
+    },
+    "xBucketNumber": null,
+    "xBucketSize": "30m",
+    "yAxis": {
+     "decimals": null,
+     "format": "m",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true,
+     "splitFactor": null
+    },
+    "yBucketBound": "auto",
+    "yBucketNumber": null,
+    "yBucketSize": 60
+   },
+   {
+    "cards": {
+     "cardPadding": null,
+     "cardRound": null
+    },
+    "color": {
+     "cardColor": "#b4ff00",
+     "colorScale": "sqrt",
+     "colorScheme": "interpolateSpectral",
+     "exponent": 0.5,
+     "max": null,
+     "min": 0,
+     "mode": "spectrum"
+    },
+    "dataFormat": "timeseries",
+    "datasource": "$cluster",
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 36
+    },
+    "heatmap": {},
+    "hideZeroBuckets": false,
+    "highlightCards": true,
+    "id": 29,
+    "legend": {
+     "show": true
+    },
+    "links": [],
+    "options": {},
+    "reverseYBuckets": false,
+    "targets": [
+     {
+      "expr": "(time() - kube_pod_created{pod=~\"^build-.*\"}) / 60",
+      "format": "time_series",
+      "interval": "30m",
+      "intervalFactor": 2,
+      "refId": "A"
+     }
+    ],
+    "title": "Distribution of build pod age over time",
+    "tooltip": {
+     "show": true,
+     "showHistogram": true
+    },
+    "type": "heatmap",
+    "xAxis": {
+     "show": true
+    },
+    "xBucketNumber": null,
+    "xBucketSize": "10m",
+    "yAxis": {
+     "decimals": null,
+     "format": "m",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true,
+     "splitFactor": null
+    },
+    "yBucketBound": "auto",
+    "yBucketNumber": null,
+    "yBucketSize": 5
+   }
+  ],
+  "refresh": false,
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "tags": [],
+      "text": "prometheus",
+      "value": "prometheus"
+     },
+     "hide": 0,
+     "includeAll": false,
+     "label": "Cluster",
+     "multi": false,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-24h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "1. Overview",
+  "uid": "3SpLQinmk",
+  "version": 53
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:10:10Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "isStarred": true,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "1-overview",
+  "type": "db",
+  "updated": "2020-09-22T07:38:34Z",
+  "updatedBy": "admin",
+  "url": "/d/3SpLQinmk/1-overview",
+  "version": 53
+ }
+}

--- a/grafana-data/dashboards/4QOBFHdiz.json
+++ b/grafana-data/dashboards/4QOBFHdiz.json
@@ -1,0 +1,271 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 11,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 2,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(apiserver_request_count{client=~'.*python$'}[2m])) by (resource, verb)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 1,
+      "legendFormat": "{{verb}} {{resource}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "k8s API calls from JupyterHub / BinderHub [2m]",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "kube_pod_container_status_restarts_total{pod=~\"hub-.*\"}",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{ pod }}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Hub Pod Restart count",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "text": "OVH Prometheus",
+      "value": "OVH Prometheus"
+     },
+     "hide": 0,
+     "label": null,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-6h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Kubernetes API health",
+  "uid": "4QOBFHdiz",
+  "version": 10
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-07-11T21:18:51Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "kubernetes-api-health",
+  "type": "db",
+  "updated": "2019-08-28T19:11:54Z",
+  "updatedBy": "admin",
+  "url": "/d/4QOBFHdiz/kubernetes-api-health",
+  "version": 10
+ }
+}

--- a/grafana-data/dashboards/GYEYQm7ik.json
+++ b/grafana-data/dashboards/GYEYQm7ik.json
@@ -1,0 +1,1591 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "rgba(255, 96, 96, 1)",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1571916579736,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 0,
+     "y": 0
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"hub-.*\"}[2m]))",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "cpu usage",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 1
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "JupyterHub CPU Usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 8,
+     "y": 0
+    },
+    "id": 2,
+    "legend": {
+     "avg": true,
+     "current": true,
+     "max": true,
+     "min": true,
+     "show": false,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"binder-.*\"}[2m])) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 1.5
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "BinderHub CPU Usage (per pod)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 16,
+     "y": 0
+    },
+    "id": 3,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"proxy-.*\"}[2m])) by (container_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{container_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Proxy CPU usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 0,
+     "y": 7
+    },
+    "id": 1,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"hub-.*\"})",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "Memory usage",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 1000000000
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "JupyterHub Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 8,
+     "y": 7
+    },
+    "id": 6,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"binder-.*\"}) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 1500000000
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Binder Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 16,
+     "y": 7
+    },
+    "id": 5,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"proxy-.*\"}) by (container_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{container_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Proxy Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 0,
+     "y": 14
+    },
+    "id": 7,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"prod-dind-.*\"}) by (instance)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{instance}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "DinD builder Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 8,
+     "y": 14
+    },
+    "id": 8,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"[[:alnum:]]+-grafana-.*\"})",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{instance}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Grafana Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 16,
+     "y": 14
+    },
+    "id": 9,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"[[:alnum:]]+-prometheus-server-.*\"}) ",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{instance}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Prometheus Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 0,
+     "y": 21
+    },
+    "id": 10,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"prod-dind-.*\"}[2m])) by (instance)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{instance}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "DinD builders CPU Usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 8,
+     "y": 21
+    },
+    "id": 11,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": false,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"[[:alnum:]]+-grafana-.*\"}[2m]))",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Grafana CPU Usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 8,
+     "x": 16,
+     "y": 21
+    },
+    "id": 12,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"[[:alnum:]]+-prometheus-server-.*\"}[2m]))",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "cpu usage",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Prometheus Server CPU Usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 28
+    },
+    "id": 13,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"[[:alnum:]]+-nginx-ingress-controller-.*\"}[2m])) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "nginx Ingress CPU usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 12,
+     "y": 28
+    },
+    "id": 14,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"[[:alnum:]]+-nginx-ingress-controller-.*\"}) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "nginx Ingress Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 35
+    },
+    "id": 15,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"user-scheduler-.*\"}[2m])) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "user scheduler CPU usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 12,
+     "y": 35
+    },
+    "id": 16,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_rss{pod_name=~\"user-scheduler-.*\"}) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "user scheduler Memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "tags": [],
+      "text": "prometheus",
+      "value": "prometheus"
+     },
+     "hide": 0,
+     "includeAll": false,
+     "label": null,
+     "multi": false,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-2d",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Components Resource Metrics",
+  "uid": "GYEYQm7ik",
+  "version": 12
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:10:20Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "components-resource-metrics",
+  "type": "db",
+  "updated": "2019-10-24T11:34:10Z",
+  "updatedBy": "admin",
+  "url": "/d/GYEYQm7ik/components-resource-metrics",
+  "version": 12
+ }
+}

--- a/grafana-data/dashboards/KPtswm7ik.json
+++ b/grafana-data/dashboards/KPtswm7ik.json
@@ -1,0 +1,389 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "#e5ac0e",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    },
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "limit": 100,
+     "name": "Annotations & Alerts",
+     "showIn": 0,
+     "type": "dashboard"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 7,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "prometheus",
+    "fill": 1,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 0
+    },
+    "id": 3,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "100* (sum(delta(binderhub_launch_time_seconds_count{status=\"success\"}[6h])) / sum(delta(binderhub_launch_time_seconds_count{status!=\"retry\"}[6h])))",
+      "format": "time_series",
+      "interval": "30m",
+      "intervalFactor": 2,
+      "legendFormat": "Launches",
+      "refId": "C"
+     },
+     {
+      "expr": "100 * sum(delta(binderhub_build_time_seconds_count{status=\"success\"}[6h])) / sum(delta(binderhub_build_time_seconds_count[6h]))",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "30m",
+      "intervalFactor": 2,
+      "legendFormat": "Builds",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Success Rates (6h lookback window)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "percent",
+      "label": null,
+      "logBase": 1,
+      "max": "100",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ]
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "prometheus",
+    "fill": 1,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 7
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Builds",
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_launch_time_seconds_count[6h]))",
+      "format": "time_series",
+      "interval": "30m",
+      "intervalFactor": 2,
+      "legendFormat": "Launches",
+      "refId": "C"
+     },
+     {
+      "expr": "sum(delta(binderhub_build_time_seconds_count[6h]))",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "30m",
+      "intervalFactor": 2,
+      "legendFormat": "Builds",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Build/Launch Attempts (6h lookback window)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "none",
+      "label": "Launches",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "decimals": null,
+      "format": "short",
+      "label": "Builds",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     }
+    ]
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "prometheus",
+    "fill": 1,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 14
+    },
+    "id": 5,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Builds",
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_launch_time_seconds_count[24h]))",
+      "format": "time_series",
+      "interval": "24h",
+      "intervalFactor": 2,
+      "legendFormat": "Launches",
+      "refId": "C"
+     },
+     {
+      "expr": "sum(delta(binderhub_build_time_seconds_count[24h]))",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "24h",
+      "intervalFactor": 2,
+      "legendFormat": "Builds",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Build/Launch Attempts (daily)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "none",
+      "label": "Launches",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "decimals": null,
+      "format": "short",
+      "label": "Builds",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     }
+    ]
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": []
+  },
+  "time": {
+   "from": "now-7d",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Service Level Objectives",
+  "uid": "KPtswm7ik",
+  "version": 7
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:11:16Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "service-level-objectives",
+  "type": "db",
+  "updated": "2018-07-12T19:05:27Z",
+  "updatedBy": "admin",
+  "url": "/d/KPtswm7ik/service-level-objectives",
+  "version": 7
+ }
+}

--- a/grafana-data/dashboards/QLzEwmnmz.json
+++ b/grafana-data/dashboards/QLzEwmnmz.json
@@ -1,0 +1,3226 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    }
+   ]
+  },
+  "description": "https://grafana.com/dashboards/3119 - Monitors Kubernetes cluster using Prometheus. Shows overall cluster CPU / Memory / Filesystem usage as well as individual pod, containers, control plane (as deployed by kops) statistics. Uses cAdvisor metrics only.\r\nTweaked from original https://grafana.com/dashboards/315 to add templating for:\r\n- adaptable $interval (instead of hardcoded 1m)\r\n- selectable $datasource (very useful to have a single dashboard tackling several prometheis )",
+  "editable": true,
+  "gnetId": 3119,
+  "graphTooltip": 0,
+  "id": 3,
+  "iteration": 1556696453318,
+  "links": [],
+  "panels": [
+   {
+    "collapsed": false,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 0
+    },
+    "id": 33,
+    "panels": [],
+    "repeat": null,
+    "title": "Network I/O pressure",
+    "type": "row"
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "fill": 1,
+    "grid": {},
+    "gridPos": {
+     "h": 5,
+     "w": 24,
+     "x": 0,
+     "y": 1
+    },
+    "height": "200px",
+    "id": 32,
+    "legend": {
+     "alignAsTable": false,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": false,
+     "sideWidth": 200,
+     "sort": "current",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum (rate (container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\"}[$interval]))",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "Received",
+      "metric": "network",
+      "refId": "A",
+      "step": 10
+     },
+     {
+      "expr": "- sum (rate (container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\"}[$interval]))",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "Sent",
+      "metric": "network",
+      "refId": "B",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Network I/O pressure",
+    "tooltip": {
+     "msResolution": false,
+     "shared": true,
+     "sort": 0,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "Bps",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "Bps",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "collapsed": false,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 6
+    },
+    "id": 34,
+    "panels": [],
+    "repeat": null,
+    "title": "Total usage",
+    "type": "row"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": true,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "editable": true,
+    "error": false,
+    "format": "percent",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": true,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 5,
+     "w": 8,
+     "x": 0,
+     "y": 7
+    },
+    "height": "180px",
+    "id": 4,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (container_memory_working_set_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (machine_memory_bytes{kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "65, 90",
+    "title": "Cluster memory usage",
+    "transparent": false,
+    "type": "singlestat",
+    "valueFontSize": "80%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": true,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "percent",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": true,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 5,
+     "w": 8,
+     "x": 8,
+     "y": 7
+    },
+    "height": "180px",
+    "id": 6,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) / sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "65, 90",
+    "title": "Cluster CPU usage ($interval avg)",
+    "type": "singlestat",
+    "valueFontSize": "80%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": true,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "percent",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": true,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 5,
+     "w": 8,
+     "x": 16,
+     "y": 7
+    },
+    "height": "180px",
+    "id": 7,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/xvda.$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (container_fs_limit_bytes{device=~\"^/dev/xvda.$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "metric": "",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "65, 90",
+    "title": "Cluster filesystem usage",
+    "type": "singlestat",
+    "valueFontSize": "80%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "bytes",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 0,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 9,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "20%",
+    "prefix": "",
+    "prefixFontSize": "20%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (container_memory_working_set_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Used",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "bytes",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 4,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 10,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (machine_memory_bytes{kubernetes_io_hostname=~\"^$Node$\"})",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Total",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "none",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 8,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 11,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": " cores",
+    "postfixFontSize": "30%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[$interval]))",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Used",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "none",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 12,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 12,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": " cores",
+    "postfixFontSize": "30%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"})",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Total",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "bytes",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 16,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 13,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/xvda.$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Used",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "cacheTimeout": null,
+    "colorBackground": false,
+    "colorValue": false,
+    "colors": [
+     "rgba(50, 172, 45, 0.97)",
+     "rgba(237, 129, 40, 0.89)",
+     "rgba(245, 54, 54, 0.9)"
+    ],
+    "datasource": "$datasource",
+    "decimals": 2,
+    "editable": true,
+    "error": false,
+    "format": "bytes",
+    "gauge": {
+     "maxValue": 100,
+     "minValue": 0,
+     "show": false,
+     "thresholdLabels": false,
+     "thresholdMarkers": true
+    },
+    "gridPos": {
+     "h": 3,
+     "w": 4,
+     "x": 20,
+     "y": 12
+    },
+    "height": "1px",
+    "id": 14,
+    "interval": null,
+    "links": [],
+    "mappingType": 1,
+    "mappingTypes": [
+     {
+      "name": "value to text",
+      "value": 1
+     },
+     {
+      "name": "range to text",
+      "value": 2
+     }
+    ],
+    "maxDataPoints": 100,
+    "nullPointMode": "connected",
+    "nullText": null,
+    "postfix": "",
+    "postfixFontSize": "50%",
+    "prefix": "",
+    "prefixFontSize": "50%",
+    "rangeMaps": [
+     {
+      "from": "null",
+      "text": "N/A",
+      "to": "null"
+     }
+    ],
+    "sparkline": {
+     "fillColor": "rgba(31, 118, 189, 0.18)",
+     "full": false,
+     "lineColor": "rgb(31, 120, 193)",
+     "show": false
+    },
+    "tableColumn": "",
+    "targets": [
+     {
+      "expr": "sum (container_fs_limit_bytes{device=~\"^/dev/xvda.$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": "",
+    "title": "Total",
+    "type": "singlestat",
+    "valueFontSize": "50%",
+    "valueMaps": [
+     {
+      "op": "=",
+      "text": "N/A",
+      "value": "null"
+     }
+    ],
+    "valueName": "current"
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 15
+    },
+    "height": "",
+    "id": 47,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "CPU usage per node ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 22
+    },
+    "height": "",
+    "id": 50,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "RAM usage per node",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": "Memory",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "collapsed": false,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 29
+    },
+    "id": 35,
+    "panels": [],
+    "repeat": null,
+    "title": "Pods CPU usage",
+    "type": "row"
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 30
+    },
+    "height": "",
+    "id": 17,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "topk(5, sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"build-.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname))",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Build Pod CPU usage per node ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 9,
+     "w": 24,
+     "x": 0,
+     "y": 37
+    },
+    "height": "",
+    "id": 48,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"build-.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ pod_name }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Build Pod Name ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 46
+    },
+    "height": "",
+    "id": 52,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"jupyter-.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "User Pods CPU usage per node ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 53
+    },
+    "height": "",
+    "id": 53,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"jupyter-.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "User Pods RAM usage per node",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": "Memory",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 60
+    },
+    "height": "",
+    "id": 49,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"prod-dind.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "DIND Pod CPU usage per node ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 67
+    },
+    "height": "",
+    "id": 51,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "sum(container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\", pod_name=~\"prod-dind-.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname)",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ kubernetes_io_hostname }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "DIND Pods RAM usage per node",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": "Memory",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$datasource",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 74
+    },
+    "height": "",
+    "id": 46,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "topk(10, sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod_name))",
+      "format": "time_series",
+      "interval": "10s",
+      "intervalFactor": 1,
+      "legendFormat": "{{ pod_name }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Per Pod CPU usage ($interval avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "transparent": false,
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 81
+    },
+    "id": 36,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 3,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 23
+      },
+      "height": "",
+      "id": 23,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": true,
+       "show": true,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (rate (container_cpu_usage_seconds_total{kubernetes_io_role=\"master\",pod_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "{{ container_name }}",
+        "metric": "container_cpu",
+        "refId": "A",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System services CPU usage ($interval avg)",
+      "tooltip": {
+       "msResolution": true,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "none",
+        "label": "cores",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "System services CPU usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 82
+    },
+    "id": 37,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 3,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 55
+      },
+      "height": "",
+      "id": 24,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "hideEmpty": false,
+       "hideZero": false,
+       "max": false,
+       "min": false,
+       "rightSide": false,
+       "show": true,
+       "sideWidth": null,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container_name, pod_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+        "metric": "container_cpu",
+        "refId": "A",
+        "step": 10
+       },
+       {
+        "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, name, image)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
+        "metric": "container_cpu",
+        "refId": "B",
+        "step": 10
+       },
+       {
+        "expr": "sum (rate (container_cpu_usage_seconds_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, rkt_container_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
+        "metric": "container_cpu",
+        "refId": "C",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Containers CPU usage ($interval avg)",
+      "tooltip": {
+       "msResolution": true,
+       "shared": false,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "none",
+        "label": "cores",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ],
+      "yaxis": {
+       "align": false,
+       "alignLevel": null
+      }
+     }
+    ],
+    "repeat": null,
+    "title": "Containers CPU usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 83
+    },
+    "id": 38,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 3,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 13,
+       "w": 24,
+       "x": 0,
+       "y": 32
+      },
+      "id": 20,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": false,
+       "show": true,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (rate (container_cpu_usage_seconds_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (id)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "{{ id }}",
+        "metric": "container_cpu",
+        "refId": "A",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "All processes CPU usage ($interval avg)",
+      "tooltip": {
+       "msResolution": true,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "none",
+        "label": "cores",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "All processes CPU usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 84
+    },
+    "id": 39,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 71
+      },
+      "id": 25,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": false,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "avg",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (pod_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "{{ pod_name }}",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "A",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pods memory usage",
+      "tooltip": {
+       "msResolution": false,
+       "shared": false,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "bytes",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ],
+      "yaxis": {
+       "align": false,
+       "alignLevel": null
+      }
+     }
+    ],
+    "repeat": null,
+    "title": "Pods memory usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 85
+    },
+    "id": 40,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 41
+      },
+      "id": 26,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": true,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (container_memory_working_set_bytes{kubernetes_io_role=\"master\",pod_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}) by (container_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "{{ container_name }}",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "A",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System services memory usage",
+      "tooltip": {
+       "msResolution": false,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "bytes",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "System services memory usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 86
+    },
+    "id": 41,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 42
+      },
+      "id": 27,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": true,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}) by (container_name, pod_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "A",
+        "step": 10
+       },
+       {
+        "expr": "sum (container_memory_working_set_bytes{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname, name, image)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "B",
+        "step": 10
+       },
+       {
+        "expr": "sum (container_memory_working_set_bytes{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname, rkt_container_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "C",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Containers memory usage",
+      "tooltip": {
+       "msResolution": false,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "bytes",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "Containers memory usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 87
+    },
+    "id": 42,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+       "h": 13,
+       "w": 24,
+       "x": 0,
+       "y": 43
+      },
+      "id": 28,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": false,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+       {
+        "expr": "sum (container_memory_working_set_bytes{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) by (id)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "{{ id }}",
+        "metric": "container_memory_usage:sort_desc",
+        "refId": "A",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "All processes memory usage",
+      "tooltip": {
+       "msResolution": false,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "bytes",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "All processes memory usage",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 88
+    },
+    "id": 43,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 44
+      },
+      "id": 16,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": true,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+       {
+        "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "-> {{ pod_name }}",
+        "metric": "network",
+        "refId": "A",
+        "step": 10
+       },
+       {
+        "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod_name)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "<- {{ pod_name }}",
+        "metric": "network",
+        "refId": "B",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pods network I/O ($interval avg)",
+      "tooltip": {
+       "msResolution": false,
+       "shared": false,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "Bps",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "Pods network I/O",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 89
+    },
+    "id": 44,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+       "h": 7,
+       "w": 24,
+       "x": 0,
+       "y": 45
+      },
+      "id": 30,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": true,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+       {
+        "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container_name, pod_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "-> pod: {{ pod_name }} | {{ container_name }}",
+        "metric": "network",
+        "refId": "B",
+        "step": 10
+       },
+       {
+        "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container_name, pod_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "<- pod: {{ pod_name }} | {{ container_name }}",
+        "metric": "network",
+        "refId": "D",
+        "step": 10
+       },
+       {
+        "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, name, image)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "-> docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
+        "metric": "network",
+        "refId": "A",
+        "step": 10
+       },
+       {
+        "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, name, image)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "<- docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
+        "metric": "network",
+        "refId": "C",
+        "step": 10
+       },
+       {
+        "expr": "sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, rkt_container_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "-> rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
+        "metric": "network",
+        "refId": "E",
+        "step": 10
+       },
+       {
+        "expr": "- sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (kubernetes_io_hostname, rkt_container_name)",
+        "format": "time_series",
+        "hide": false,
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "<- rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
+        "metric": "network",
+        "refId": "F",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Containers network I/O ($interval avg)",
+      "tooltip": {
+       "msResolution": false,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "Bps",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "Containers network I/O",
+    "type": "row"
+   },
+   {
+    "collapsed": true,
+    "gridPos": {
+     "h": 1,
+     "w": 24,
+     "x": 0,
+     "y": 90
+    },
+    "id": 45,
+    "panels": [
+     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+       "h": 13,
+       "w": 24,
+       "x": 0,
+       "y": 46
+      },
+      "id": 29,
+      "legend": {
+       "alignAsTable": true,
+       "avg": true,
+       "current": true,
+       "max": false,
+       "min": false,
+       "rightSide": false,
+       "show": true,
+       "sideWidth": 200,
+       "sort": "current",
+       "sortDesc": true,
+       "total": false,
+       "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+       {
+        "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (id)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "-> {{ id }}",
+        "metric": "network",
+        "refId": "A",
+        "step": 10
+       },
+       {
+        "expr": "- sum (rate (container_network_transmit_bytes_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (id)",
+        "format": "time_series",
+        "interval": "10s",
+        "intervalFactor": 1,
+        "legendFormat": "<- {{ id }}",
+        "metric": "network",
+        "refId": "B",
+        "step": 10
+       }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "All processes network I/O ($interval avg)",
+      "tooltip": {
+       "msResolution": false,
+       "shared": true,
+       "sort": 2,
+       "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+       "buckets": null,
+       "mode": "time",
+       "name": null,
+       "show": true,
+       "values": []
+      },
+      "yaxes": [
+       {
+        "format": "Bps",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+       },
+       {
+        "format": "short",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": false
+       }
+      ]
+     }
+    ],
+    "repeat": null,
+    "title": "All processes network I/O",
+    "type": "row"
+   }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+   "kubernetes"
+  ],
+  "templating": {
+   "list": [
+    {
+     "auto": true,
+     "auto_count": 20,
+     "auto_min": "2m",
+     "current": {
+      "text": "auto",
+      "value": "$__auto_interval_interval"
+     },
+     "hide": 2,
+     "label": null,
+     "name": "interval",
+     "options": [
+      {
+       "selected": true,
+       "text": "auto",
+       "value": "$__auto_interval_interval"
+      },
+      {
+       "selected": false,
+       "text": "1m",
+       "value": "1m"
+      },
+      {
+       "selected": false,
+       "text": "10m",
+       "value": "10m"
+      },
+      {
+       "selected": false,
+       "text": "30m",
+       "value": "30m"
+      },
+      {
+       "selected": false,
+       "text": "1h",
+       "value": "1h"
+      },
+      {
+       "selected": false,
+       "text": "6h",
+       "value": "6h"
+      },
+      {
+       "selected": false,
+       "text": "12h",
+       "value": "12h"
+      },
+      {
+       "selected": false,
+       "text": "1d",
+       "value": "1d"
+      },
+      {
+       "selected": false,
+       "text": "7d",
+       "value": "7d"
+      },
+      {
+       "selected": false,
+       "text": "14d",
+       "value": "14d"
+      },
+      {
+       "selected": false,
+       "text": "30d",
+       "value": "30d"
+      }
+     ],
+     "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+     "refresh": 2,
+     "skipUrlSync": false,
+     "type": "interval"
+    },
+    {
+     "current": {
+      "text": "default",
+      "value": "default"
+     },
+     "hide": 0,
+     "label": null,
+     "name": "datasource",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    },
+    {
+     "allValue": ".*",
+     "current": {
+      "text": "All",
+      "value": "$__all"
+     },
+     "datasource": "$datasource",
+     "hide": 0,
+     "includeAll": true,
+     "label": null,
+     "multi": false,
+     "name": "Node",
+     "options": [],
+     "query": "label_values(kubernetes_io_hostname)",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "sort": 0,
+     "tagValuesQuery": "",
+     "tags": [],
+     "tagsQuery": "",
+     "type": "query",
+     "useTags": false
+    }
+   ]
+  },
+  "time": {
+   "from": "now-3h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "browser",
+  "title": "Kubernetes cluster monitoring (binder-prod)",
+  "uid": "QLzEwmnmz",
+  "version": 18
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:10:31Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "kubernetes-cluster-monitoring-binder-prod",
+  "type": "db",
+  "updated": "2019-05-01T07:58:39Z",
+  "updatedBy": "admin",
+  "url": "/d/QLzEwmnmz/kubernetes-cluster-monitoring-binder-prod",
+  "version": 18
+ }
+}

--- a/grafana-data/dashboards/aptle5FWk.json
+++ b/grafana-data/dashboards/aptle5FWk.json
@@ -1,0 +1,534 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    }
+   ]
+  },
+  "description": "Watch memory usage of pods and nodes",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 14,
+  "iteration": 1566971983052,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "gridPos": {
+     "h": 8,
+     "w": 24,
+     "x": 0,
+     "y": 0
+    },
+    "id": 7,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "node_load5 * on(instance) group_left(nodename) node_uname_info",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{nodename}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "CPU Load5 per node",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 24,
+     "x": 0,
+     "y": 8
+    },
+    "id": 2,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_working_set_bytes{pod_name=~\"jupyter-betatim-2ddsgsdgdsg-2dpx05yc3h\"}) by (pod_name)",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 1,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(container_memory_working_set_bytes{namespace=\"prod\", instance=~\"gke-prod-a-user.*\"}) by (instance)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{instance}} ",
+      "refId": "D"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Memory consumption user nodes",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 24,
+     "x": 0,
+     "y": 17
+    },
+    "id": 8,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "topk(5, sum(container_memory_working_set_bytes{pod_name=~\"jupyter-.*\"}) by (pod_name))",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 1,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Top 5 user pods memory consumption",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "gridPos": {
+     "h": 8,
+     "w": 24,
+     "x": 0,
+     "y": 26
+    },
+    "id": 5,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_container_resource_requests_memory_bytes and on (pod) (kube_pod_container_status_ready)) by (node)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Requested memory",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 24,
+     "x": 0,
+     "y": 34
+    },
+    "id": 3,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_working_set_bytes{namespace=\"prod\", instance=~\"gke-prod-a-core.*\"}) by (instance)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{instance}} ",
+      "refId": "D"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Memory consumption core nodes",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "text": "OVH Prometheus",
+      "value": "OVH Prometheus"
+     },
+     "hide": 0,
+     "label": null,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-6h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Memory usage",
+  "uid": "aptle5FWk",
+  "version": 8
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2019-08-27T19:06:39Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "memory-usage",
+  "type": "db",
+  "updated": "2019-08-28T06:13:53Z",
+  "updatedBy": "admin",
+  "url": "/d/aptle5FWk/memory-usage",
+  "version": 8
+ }
+}

--- a/grafana-data/dashboards/fLoQvRHmk.json
+++ b/grafana-data/dashboards/fLoQvRHmk.json
@@ -1,0 +1,548 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": false,
+     "hide": false,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "limit": 100,
+     "name": "Annotations & Alerts",
+     "showIn": 0,
+     "tags": [],
+     "type": "tags"
+    }
+   ]
+  },
+  "description": "A dashboard to hold plots for status.mybinder.org",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 9,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "prometheus",
+    "description": "The number of outstanding requests waiting on a pending build or launch",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 8,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "/.*build.*/",
+      "fill": 3,
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(binderhub_inprogress_builds)",
+      "legendFormat": "builds",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(binderhub_inprogress_launches)",
+      "legendFormat": "launches",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Requests waiting on launches/builds",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "none",
+      "label": "Launches",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "decimals": 0,
+      "format": "short",
+      "label": "Builds",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "-- Mixed --",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 6,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": true,
+    "steppedLine": false,
+    "targets": [
+     {
+      "datasource": "prometheus",
+      "expr": "sum(kube_pod_status_phase{pod=~\"jupyter-.*\", phase=\"Running\"}) by (phase)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "GKE",
+      "refId": "A"
+     },
+     {
+      "datasource": "GESIS",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\", kubernetes_namespace!=\"jhub-ns\"})",
+      "legendFormat": "Gesis",
+      "refId": "B"
+     },
+     {
+      "datasource": "OVH",
+      "expr": "sum(kube_pod_status_phase{pod=~\"jupyter-.*\", phase=\"Running\"}) by (phase)",
+      "legendFormat": "OVH",
+      "refId": "C"
+     },
+     {
+      "datasource": "Turing",
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", phase=\"Running\"})",
+      "hide": true,
+      "legendFormat": "Turing",
+      "refId": "D"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "User pods running, last hour",
+    "tooltip": {
+     "shared": true,
+     "sort": 2,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": "Total pods",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": null,
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 7
+    },
+    "id": 2,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "100 * (sum(delta(binderhub_launch_time_seconds_count{status=\"success\", kubernetes_namespace!=\"jhub-ns\"}[10m])) / sum(delta(binderhub_launch_time_seconds_count{status!=\"retry\", kubernetes_namespace!=\"jhub-ns\"}[10m])))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Launch success (GKE)",
+      "refId": "A"
+     },
+     {
+      "expr": "",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch success %, last hour",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "percent",
+      "label": null,
+      "logBase": 1,
+      "max": "105",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {
+     "10th-percentile-failure": "#ef843c",
+     "10th-percentile-success": "#b7dbab",
+     "25th-percentile-failure": "#99440a",
+     "25th-percentile-success": "#7eb26d",
+     "50th-percentile-failure": "#ea6460",
+     "50th-percentile-success": "#7eb26d",
+     "75th-percentile-failure": "#bf1b00",
+     "75th-percentile-success": "#508642",
+     "90th-percentile-failure": "#58140c",
+     "90th-percentile-success": "#3f6833"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "prometheus",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 9
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "10th-percentile",
+      "color": "#508642"
+     },
+     {
+      "alias": "25th-percentile",
+      "color": "#9ac48a"
+     },
+     {
+      "alias": "50th-percentile",
+      "color": "#e0f9d7"
+     },
+     {
+      "alias": "75th-percentile",
+      "color": "#f9934e"
+     },
+     {
+      "alias": "90th-percentile",
+      "color": "#bf1b00"
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "histogram_quantile(0.1, sum(rate(binderhub_launch_time_seconds_bucket{status=\"success\"}[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "intervalFactor": 10,
+      "legendFormat": "10th-percentile",
+      "refId": "A"
+     },
+     {
+      "expr": "histogram_quantile(0.25, sum(rate(binderhub_launch_time_seconds_bucket{status=\"success\"}[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 10,
+      "legendFormat": "25th-percentile",
+      "refId": "B"
+     },
+     {
+      "expr": "histogram_quantile(0.5, sum(rate(binderhub_launch_time_seconds_bucket{status=\"success\"}[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 10,
+      "legendFormat": "50th-percentile",
+      "refId": "C"
+     },
+     {
+      "expr": "histogram_quantile(0.75, sum(rate(binderhub_launch_time_seconds_bucket{status=\"success\"}[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 10,
+      "legendFormat": "75th-percentile",
+      "refId": "D"
+     },
+     {
+      "expr": "histogram_quantile(0.9, sum(rate(binderhub_launch_time_seconds_bucket{status=\"success\"}[5m])) without (instance, repo, provider)) > 0",
+      "format": "time_series",
+      "intervalFactor": 10,
+      "legendFormat": "90th-percentile",
+      "refId": "E"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch time percentiles, last hour",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "s",
+      "label": null,
+      "logBase": 10,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": []
+  },
+  "time": {
+   "from": "now-1h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "status",
+  "uid": "fLoQvRHmk",
+  "version": 14
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-06-13T21:41:23Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "status",
+  "type": "db",
+  "updated": "2020-07-15T09:24:03Z",
+  "updatedBy": "admin",
+  "url": "/d/fLoQvRHmk/status",
+  "version": 14
+ }
+}

--- a/grafana-data/dashboards/fZWsQmnmz.json
+++ b/grafana-data/dashboards/fZWsQmnmz.json
@@ -1,0 +1,1478 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "rgba(255, 96, 96, 1)",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 6,
+  "iteration": 1594800981635,
+  "links": [],
+  "panels": [
+   {
+    "columns": [],
+    "datasource": "$cluster",
+    "fontSize": "100%",
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 2,
+    "links": [],
+    "options": {},
+    "pageSize": 50,
+    "scroll": true,
+    "showHeader": true,
+    "sort": {
+     "col": 2,
+     "desc": true
+    },
+    "styles": [
+     {
+      "alias": "Time",
+      "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "pattern": "Time",
+      "type": "hidden"
+     },
+     {
+      "alias": "Launches this hour",
+      "colorMode": null,
+      "colors": [
+       "rgba(245, 54, 54, 0.9)",
+       "rgba(237, 129, 40, 0.89)",
+       "rgba(50, 172, 45, 0.97)"
+      ],
+      "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "decimals": 0,
+      "pattern": "Value",
+      "thresholds": [],
+      "type": "number",
+      "unit": "short"
+     },
+     {
+      "alias": "",
+      "colorMode": null,
+      "colors": [
+       "rgba(245, 54, 54, 0.9)",
+       "rgba(237, 129, 40, 0.89)",
+       "rgba(50, 172, 45, 0.97)"
+      ],
+      "decimals": 2,
+      "pattern": "/.*/",
+      "thresholds": [],
+      "type": "number",
+      "unit": "short"
+     }
+    ],
+    "targets": [
+     {
+      "expr": "topk(10, sum(delta(binderhub_launch_count_total{status=\"success\", kubernetes_namespace!=\"jhub-ns\"}[1h])) by (repo))",
+      "format": "table",
+      "instant": true,
+      "intervalFactor": 2,
+      "refId": "A"
+     }
+    ],
+    "timeFrom": null,
+    "title": "Most Popular Repositories (last hour)",
+    "transform": "table",
+    "type": "table"
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 3,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_status_phase{pod=~\"^jupyter-.*\", kubernetes_namespace!=\"jhub-ns\"}) by (phase)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{phase}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "User pods running over time",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 9
+    },
+    "id": 1,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "topk(5, sum(increase(binderhub_launch_count_total{status=\"success\", repo!~\".*(jupyterlab-demo|ipython-in-depth|binder-examples).*\", kubernetes_namespace!=\"jhub-ns\"}[1h])) by (repo))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{repo}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Top 5 popular repositories (by number of launches in last hour)",
+    "tooltip": {
+     "shared": false,
+     "sort": 2,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 16
+    },
+    "id": 14,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_build_count_total{status=\"success\", repo!~\".*(jupyterlab-demo|ipython-in-depth|binder-examples).*\"}[1h])) by (repo)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{repo}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Successful builds in last hour",
+    "tooltip": {
+     "shared": false,
+     "sort": 2,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 23
+    },
+    "id": 15,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_build_count_total{repo!~\".*(jupyterlab-demo|ipython-in-depth|binder-examples).*\"}[1h])) by (repo)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{repo}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "All build attempts in last hour",
+    "tooltip": {
+     "shared": false,
+     "sort": 2,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 30
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "hideEmpty": true,
+     "hideZero": true,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "/requests/",
+      "fill": 0,
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": true,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_status_phase{pod=~\"build-.*\", kubernetes_namespace!=\"jhub-ns\"}) by (phase)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{phase}}",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(binderhub_inprogress_builds)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Build-watching requests",
+      "refId": "B"
+     },
+     {
+      "expr": "sum(binderhub_inprogress_launches)",
+      "format": "time_series",
+      "hide": true,
+      "intervalFactor": 1,
+      "legendFormat": "Launches in progress",
+      "refId": "C"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Build pods",
+    "tooltip": {
+     "shared": true,
+     "sort": 2,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "none",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "decimals": 0,
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 30
+    },
+    "id": 5,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(\n    kube_pod_status_phase{pod=~\"jupyter-.*\",phase!=\"Running\"}\n    * on (pod) group_left(node)\n    sum(kube_pod_info{pod=~\"jupyter-.*\"}) by (pod, node)\n) by (node, phase)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}} | {{phase}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Non-running pods by node",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {
+     "Pods in pending state": "#e24d42",
+     "Total": "#fce2de"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "Edit the regular expression in \"metrics\" to search for a different pod.",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 39
+    },
+    "id": 6,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Total",
+      "linewidth": 3
+     },
+     {
+      "alias": "Pods in pending state",
+      "linewidth": 3
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "count(kube_pod_info{pod=~\"jupyter-jupyterlab.*\"}) by (node)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     },
+     {
+      "expr": "count(kube_pod_info{pod=~\"jupyter-jupyterlab.*\"})",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Total",
+      "refId": "B"
+     },
+     {
+      "expr": "sum(kube_pod_status_phase{pod=~\"jupyter-jupyterlab.*\",phase=\"Pending\"}) by (phase)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Pods in pending state",
+      "refId": "C"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Pods running by regexp (jupyter-jupyterlab.*)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "decimals": 3,
+    "editable": true,
+    "error": false,
+    "fill": 0,
+    "fillGradient": 0,
+    "grid": {},
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 46
+    },
+    "height": "",
+    "id": 11,
+    "legend": {
+     "alignAsTable": true,
+     "avg": true,
+     "current": true,
+     "max": false,
+     "min": false,
+     "rightSide": false,
+     "show": true,
+     "sort": "avg",
+     "sortDesc": true,
+     "total": false,
+     "values": true
+    },
+    "lines": true,
+    "linewidth": 2,
+    "links": [],
+    "nullPointMode": "connected",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": true,
+    "targets": [
+     {
+      "expr": "topk(5, sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\"}[2m])) by (pod_name))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{ pod_name }}",
+      "metric": "container_cpu",
+      "refId": "A",
+      "step": 10
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": "2h",
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Top 5 Pods CPU usage (2m avg)",
+    "tooltip": {
+     "msResolution": true,
+     "shared": false,
+     "sort": 2,
+     "value_type": "cumulative"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "none",
+      "label": "cores",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": false
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 53
+    },
+    "id": 7,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "delta(binderhub_launch_count_total{status=\"failure\"}[10m]) > 0",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{repo}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch Failing Repositories",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 12,
+     "y": 53
+    },
+    "id": 8,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 3,
+    "points": true,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "delta(binderhub_build_count_total{status=\"failure\"}[10m]) > 0",
+      "format": "time_series",
+      "interval": "1m",
+      "intervalFactor": 2,
+      "legendFormat": "{{repo}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Build Failing Repositories",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 60
+    },
+    "id": 9,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "hideEmpty": false,
+     "hideZero": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Launch attempt",
+      "yaxis": 2
+     },
+     {
+      "alias": "Launch attempts",
+      "yaxis": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(delta(binderhub_launch_count_total{status=\"success\"}[5m])) / sum(delta(binderhub_launch_count_total{status!=\"retry\"}[5m]))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Launch success",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(delta(binderhub_launch_count_total[5m]))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Launch attempts",
+      "refId": "B"
+     },
+     {
+      "expr": "sum(delta(binderhub_launch_count_total{status=\"success\",retries!=\"0\",retries!=\"\"}[5m])) / sum(delta(binderhub_launch_count_total{status!=\"retry\"}[5m]))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Retry rate",
+      "refId": "C"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch success rate [5m]",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": "1",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {
+     ".05": "#3f6833",
+     ".25": "#629e51",
+     ".5": "#fceaca",
+     ".75": "#e24d42",
+     ".95": "#58140c"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 60
+    },
+    "id": 13,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "quantile(.05, (time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": ".05",
+      "refId": "A"
+     },
+     {
+      "expr": "quantile(.25, (time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": ".25",
+      "refId": "D"
+     },
+     {
+      "expr": "quantile(.5, (time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": ".5",
+      "refId": "B"
+     },
+     {
+      "expr": "quantile(.75, (time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": ".75",
+      "refId": "E"
+     },
+     {
+      "expr": "quantile(.95, (time() - kube_pod_created{pod=~\"^jupyter.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": ".95",
+      "refId": "C"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Percentiles of pod age",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": "Minutes",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {
+     ".05": "#3f6833",
+     ".25": "#629e51",
+     ".5": "#fceaca",
+     ".75": "#e24d42",
+     ".95": "#58140c"
+    },
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 69
+    },
+    "id": 16,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "quantile(.95, (time() - kube_pod_created{pod=~\"^build-.*\"}) / 60)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "95 percentile of build pod age",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Percentiles of build pod age",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": "Minutes",
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "tags": [],
+      "text": "prometheus",
+      "value": "prometheus"
+     },
+     "hide": 0,
+     "includeAll": false,
+     "label": null,
+     "multi": false,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-24h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Pod Activity",
+  "uid": "fZWsQmnmz",
+  "version": 44
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:11:05Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "pod-activity",
+  "type": "db",
+  "updated": "2020-07-15T08:17:48Z",
+  "updatedBy": "admin",
+  "url": "/d/fZWsQmnmz/pod-activity",
+  "version": 44
+ }
+}

--- a/grafana-data/dashboards/j6478uAmz.json
+++ b/grafana-data/dashboards/j6478uAmz.json
@@ -1,0 +1,327 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 12,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": null,
+    "fill": 1,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 2,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(container_memory_usage_bytes{pod_name=~'matomo-.*'}) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 1,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Matomo memory usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ]
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": null,
+    "fill": 1,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 3,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(irate(container_cpu_usage_seconds_total{pod_name=~'matomo-.*'}[5m])) by (pod_name)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 1,
+      "legendFormat": "{{pod_name}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Matomo CPU usage",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ]
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": null,
+    "fill": 1,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 0,
+     "y": 9
+    },
+    "id": 6,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(mysql_global_status_threads_connected)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Active MySQL Connections",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ]
+   }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": []
+  },
+  "time": {
+   "from": "now-6h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Matomo",
+  "uid": "j6478uAmz",
+  "version": 5
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-10-01T23:37:32Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "matomo",
+  "type": "db",
+  "updated": "2018-10-02T04:48:24Z",
+  "updatedBy": "admin",
+  "url": "/d/j6478uAmz/matomo",
+  "version": 5
+ }
+}

--- a/grafana-data/dashboards/nDQPwi7mk.json
+++ b/grafana-data/dashboards/nDQPwi7mk.json
@@ -1,0 +1,1463 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "#e5ac0e",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "rgba(255, 96, 96, 1)",
+     "limit": 100,
+     "matchAny": true,
+     "name": "Ops log",
+     "showIn": 0,
+     "tags": [
+      "ops-log"
+     ],
+     "type": "tags"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1594884217119,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 0
+    },
+    "id": 43,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "hideEmpty": true,
+     "hideZero": true,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_status_phase{pod=~\"user-placeholder.*\"}) by (phase)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{ phase }}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Placeholder pods",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 0
+    },
+    "id": 26,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "average",
+      "color": "#cffaff",
+      "fill": 0,
+      "linewidth": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "count(kube_pod_info{pod=~\"jupyter-.*\"}) by (node)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     },
+     {
+      "expr": "avg(count(kube_pod_info{pod=~\"jupyter-.*\"}) by (node))",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "average",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "critical",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 110,
+      "yaxis": "left"
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "User Pods per node",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "Number of nodes in the user pool.",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 6
+    },
+    "id": 40,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_node_info{node!~\".*-core-.*\"}) ",
+      "format": "time_series",
+      "instant": false,
+      "intervalFactor": 1,
+      "legendFormat": "Nodes",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(kube_node_spec_unschedulable)",
+      "legendFormat": "Cordoned",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Nodes in the user pool",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 6
+    },
+    "id": 44,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Total build pods",
+      "color": "#cffaff",
+      "fill": 0,
+      "linewidth": 2,
+      "nullPointMode": "null as zero"
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "count(kube_pod_info{pod=~\"build-.*\"}) by (node)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     },
+     {
+      "expr": "count(kube_pod_info{pod=~\"build-.*\"})",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "Total build pods",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "critical",
+      "fill": true,
+      "line": true,
+      "op": "gt",
+      "value": 110,
+      "yaxis": "left"
+     }
+    ],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Build pods per node",
+    "tooltip": {
+     "shared": false,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 3,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 12
+    },
+    "id": 29,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+     {
+      "alias": "Total",
+      "linewidth": 2
+     }
+    ],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(kubelet_docker_operations{operation_type=\"pull_image\"}[5m]) )",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Total",
+      "refId": "B"
+     },
+     {
+      "expr": "increase(kubelet_docker_operations{operation_type=\"pull_image\"}[5m])",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{kubernetes_io_hostname}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Docker Image Pulls (5m)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "Total amount of disk space available on the node. A reading of 0 would be \"out of disk space\". A sharp increase toward the top of the chart indicates that Kubernetes has cleaned up disk space.",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 12,
+     "y": 12
+    },
+    "id": 8,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "node_filesystem_avail_bytes{mountpoint=\"/etc/hostname\"} * on(instance) group_left(nodename) node_uname_info",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{nodename}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "DiskAvailable on Nodes",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "decbytes",
+      "label": "Available disk space",
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 18
+    },
+    "id": 7,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "node_memory_MemAvailable_bytes * on(instance) group_left(nodename) node_uname_info",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{nodename}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "MemAvailable on Nodes",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "decbytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 12,
+     "y": 18
+    },
+    "id": 28,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "kubelet_docker_operations_latency_microseconds{quantile=\"0.9\", operation_type=\"pull_image\"}",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{kubernetes_io_hostname}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Image pulling latency (90th percentile)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "\u00b5s",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 24
+    },
+    "id": 27,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "rate(kubelet_pod_start_latency_microseconds_sum[2m])",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{kubernetes_io_hostname}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Pod Start Latency",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "\u00b5s",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 25
+    },
+    "id": 36,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "kube_node_spec_unschedulable",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{ node }}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Cordoned Nodes",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 31
+    },
+    "id": 30,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(kube_pod_container_resource_requests_memory_bytes and on (pod) (kube_pod_container_status_ready)) by (node)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Requested memory",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "bytes",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 9,
+     "w": 12,
+     "x": 12,
+     "y": 34
+    },
+    "id": 34,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(binderhub_launch_time_seconds_count{status=\"success\"}[5m])) / sum(increase(binderhub_launch_time_seconds_count{status!=\"retry\"}[5m]))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Success",
+      "refId": "A"
+     },
+     {
+      "expr": "sum(increase(binderhub_launch_time_seconds_count{status=\"success\",retries=\"0\"}[5m])) / sum(increase(binderhub_launch_time_seconds_count{status!=\"retry\"}[5m]))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Success (first try)",
+      "refId": "B"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Launch success %",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": 0,
+      "format": "percentunit",
+      "label": null,
+      "logBase": 1,
+      "max": "1.05",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "description": "CPU 5-minute load average per core on each node (nodes sustained above 1 are overloaded)",
+    "fill": 1,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 12,
+     "x": 0,
+     "y": 38
+    },
+    "id": 38,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "node_load5 / on(kubernetes_node) group_left label_replace(kube_node_status_capacity_cpu_cores, \"kubernetes_node\", \"$1\", \"node\", \"(.*)\")",
+      "format": "time_series",
+      "intervalFactor": 4,
+      "legendFormat": "{{kubernetes_node}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "CPU Load5 per core on each node",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 12,
+     "x": 0,
+     "y": 44
+    },
+    "id": 32,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 3,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "avg((time() - kube_node_created) / 60 / 60 / 24) by (node)",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{node}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Node Age (days)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": false,
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "tags": [],
+      "text": "prometheus",
+      "value": "prometheus"
+     },
+     "hide": 0,
+     "includeAll": false,
+     "label": null,
+     "multi": false,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-24h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Node Activity",
+  "uid": "nDQPwi7mk",
+  "version": 59
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:10:55Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "node-activity",
+  "type": "db",
+  "updated": "2020-07-16T07:23:47Z",
+  "updatedBy": "admin",
+  "url": "/d/nDQPwi7mk/node-activity",
+  "version": 59
+ }
+}

--- a/grafana-data/dashboards/ygtPwi7ik.json
+++ b/grafana-data/dashboards/ygtPwi7ik.json
@@ -1,0 +1,586 @@
+{
+ "dashboard": {
+  "annotations": {
+   "list": [
+    {
+     "builtIn": 1,
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": true,
+     "iconColor": "rgba(0, 211, 255, 1)",
+     "name": "Annotations & Alerts",
+     "type": "dashboard"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "#e5ac0e",
+     "limit": 100,
+     "name": "Deployments",
+     "showIn": 0,
+     "tags": [
+      "deployment-start"
+     ],
+     "type": "tags"
+    },
+    {
+     "datasource": "-- Grafana --",
+     "enable": true,
+     "hide": false,
+     "iconColor": "rgba(255, 96, 96, 1)",
+     "limit": 100,
+     "name": "Ops log",
+     "showIn": 0,
+     "tags": [
+      "operations log"
+     ],
+     "type": "tags"
+    }
+   ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 4,
+  "iteration": 1582441508435,
+  "links": [],
+  "panels": [
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 0
+    },
+    "id": 5,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(nginx_responses_total{server_zone=\"mybinder.org\"}[5m])) by (status_code)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{status_code}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Response codes (mybinder.org)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 6,
+     "w": 24,
+     "x": 0,
+     "y": 7
+    },
+    "id": 4,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(nginx_responses_total{server_zone=\"hub.mybinder.org\"}[5m])) by (status_code)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{status_code}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Response codes (hub.mybinder.org)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 13
+    },
+    "id": 14,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(nginx_upstream_responses_total{upstream=\"prod-proxy-public-80\"}[5m])) by (status_code)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{status_code}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Response codes (CHP)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 0,
+    "fillGradient": 0,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 20
+    },
+    "id": 15,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {
+     "dataLinks": []
+    },
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "sum(increase(nginx_upstream_responses_total{upstream=\"prod-redirector-80\"}[5m])) by (status_code)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "{{status_code}}",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeRegions": [],
+    "timeShift": null,
+    "title": "Response codes (Redirector)",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   },
+   {
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "$cluster",
+    "fill": 1,
+    "gridPos": {
+     "h": 7,
+     "w": 24,
+     "x": 0,
+     "y": 27
+    },
+    "id": 13,
+    "legend": {
+     "avg": false,
+     "current": false,
+     "max": false,
+     "min": false,
+     "show": true,
+     "total": false,
+     "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "options": {},
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [],
+    "spaceLength": 10,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+     {
+      "expr": "min(binderhub_github_rate_limit_remaining) without (instance)",
+      "format": "time_series",
+      "interval": "",
+      "intervalFactor": 2,
+      "legendFormat": "requests-remaining",
+      "refId": "A"
+     }
+    ],
+    "thresholds": [
+     {
+      "colorMode": "warning",
+      "fill": true,
+      "line": false,
+      "op": "lt",
+      "value": 2000
+     }
+    ],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "GitHub requests remaining",
+    "tooltip": {
+     "shared": true,
+     "sort": 0,
+     "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+     "buckets": null,
+     "mode": "time",
+     "name": null,
+     "show": true,
+     "values": []
+    },
+    "yaxes": [
+     {
+      "decimals": null,
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": "5000",
+      "min": "0",
+      "show": true
+     },
+     {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+     }
+    ],
+    "yaxis": {
+     "align": false,
+     "alignLevel": null
+    }
+   }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+   "list": [
+    {
+     "current": {
+      "text": "OVH Prometheus",
+      "value": "OVH Prometheus"
+     },
+     "hide": 0,
+     "includeAll": false,
+     "label": null,
+     "multi": false,
+     "name": "cluster",
+     "options": [],
+     "query": "prometheus",
+     "refresh": 1,
+     "regex": "",
+     "skipUrlSync": false,
+     "type": "datasource"
+    }
+   ]
+  },
+  "time": {
+   "from": "now-12h",
+   "to": "now"
+  },
+  "timepicker": {
+   "refresh_intervals": [
+    "5s",
+    "10s",
+    "30s",
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "1h",
+    "2h",
+    "1d"
+   ],
+   "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+   ]
+  },
+  "timezone": "",
+  "title": "Network Activity",
+  "uid": "ygtPwi7ik",
+  "version": 14
+ },
+ "meta": {
+  "canAdmin": true,
+  "canEdit": true,
+  "canSave": true,
+  "canStar": true,
+  "created": "2018-05-08T14:10:43Z",
+  "createdBy": "admin",
+  "expires": "0001-01-01T00:00:00Z",
+  "folderId": 0,
+  "folderTitle": "General",
+  "folderUrl": "",
+  "hasAcl": false,
+  "isFolder": false,
+  "provisioned": false,
+  "provisionedExternalId": "",
+  "slug": "network-activity",
+  "type": "db",
+  "updated": "2020-02-23T07:05:16Z",
+  "updatedBy": "admin",
+  "url": "/d/ygtPwi7ik/network-activity",
+  "version": 14
+ }
+}

--- a/grafana-data/datasources.json
+++ b/grafana-data/datasources.json
@@ -1,0 +1,94 @@
+[
+ {
+  "access": "proxy",
+  "basicAuth": true,
+  "database": "",
+  "id": 3,
+  "isDefault": false,
+  "jsonData": {
+   "httpMethod": "GET",
+   "keepCookies": []
+  },
+  "name": "GESIS",
+  "orgId": 1,
+  "password": "",
+  "readOnly": false,
+  "type": "prometheus",
+  "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+  "url": "https://notebooks.gesis.org/prometheus",
+  "user": ""
+ },
+ {
+  "access": "proxy",
+  "basicAuth": false,
+  "database": "",
+  "id": 5,
+  "isDefault": false,
+  "jsonData": {
+   "httpMethod": "GET",
+   "keepCookies": []
+  },
+  "name": "GKE2",
+  "orgId": 1,
+  "password": "",
+  "readOnly": false,
+  "type": "prometheus",
+  "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+  "url": "https://prometheus.gke2.mybinder.org",
+  "user": ""
+ },
+ {
+  "access": "proxy",
+  "basicAuth": false,
+  "database": "",
+  "id": 2,
+  "isDefault": false,
+  "jsonData": {
+   "httpMethod": "GET",
+   "keepCookies": []
+  },
+  "name": "OVH",
+  "orgId": 1,
+  "password": "",
+  "readOnly": false,
+  "type": "prometheus",
+  "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+  "url": "https://prometheus-mybinder.mybinder.ovh/",
+  "user": ""
+ },
+ {
+  "access": "direct",
+  "basicAuth": false,
+  "database": "",
+  "id": 1,
+  "isDefault": true,
+  "jsonData": {},
+  "name": "prometheus",
+  "orgId": 1,
+  "password": "",
+  "readOnly": true,
+  "type": "prometheus",
+  "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+  "url": "https://prometheus.mybinder.org",
+  "user": ""
+ },
+ {
+  "access": "proxy",
+  "basicAuth": false,
+  "database": "",
+  "id": 4,
+  "isDefault": false,
+  "jsonData": {
+   "httpMethod": "GET",
+   "keepCookies": []
+  },
+  "name": "Turing",
+  "orgId": 1,
+  "password": "",
+  "readOnly": false,
+  "type": "prometheus",
+  "typeLogoUrl": "public/app/plugins/datasource/prometheus/img/prometheus_logo.svg",
+  "url": "https://prometheus.turing.mybinder.org",
+  "user": ""
+ }
+]

--- a/scripts/grafana-export
+++ b/scripts/grafana-export
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Export grafana data to a folder
+
+Also import data from that folder
+"""
+
+import json
+import logging
+import os
+import pathlib
+
+
+import requests
+
+log = logging.getLogger("grafana-export")
+
+grafana_user = os.environ.get("GRAFANA_USER", "admin")
+grafana_password = os.environ.get("GRAFANA_PASSWORD")
+
+session = requests.Session()
+
+
+def save_dashboard(host, dashboard_result, dashboard_dir):
+    dashboard_dir.mkdir(exist_ok=True)
+    uid = str(dashboard_result["uid"])
+    dest = dashboard_dir.joinpath(f"{uid}.json")
+    log.info(f"Downloading {dashboard_result['title']} to {dest}")
+    r = session.get(host + f"/api/dashboards/uid/{uid}")
+    r.raise_for_status()
+    dashboard = r.json()
+    with dashboard_dir.joinpath(f"{uid}.json").open("w") as f:
+        json.dump(dashboard, f, sort_keys=True, indent=1)
+
+
+def export_grafana(host, data_dir, confirm=True):
+    """export grafana data from host to data_dir"""
+    output_dir = pathlib.Path(data_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dashboard_dir = output_dir.joinpath("dashboards")
+
+    # download dashboards
+    r = requests.get(host + "/api/search?limit=1000")
+    r.raise_for_status()
+    for result in r.json():
+        if result["type"] == "dash-db":
+            save_dashboard(host, result, dashboard_dir)
+
+    # TODO: save folders (we don't have any)
+
+    # data sources
+    datasources_json = output_dir.joinpath("datasources.json")
+    log.info(f"Downloading data sources to {datasources_json}")
+    r = session.get(host + "/api/datasources")
+    r.raise_for_status()
+    datasources = r.json()
+    with datasources_json.open("w") as f:
+        json.dump(datasources, f, sort_keys=True, indent=1)
+
+
+def import_grafana(host, data_dir, confirm=True):
+    """Import grafana data created by export"""
+    data_dir = pathlib.Path(data_dir)
+    if not data_dir.is_dir():
+        raise FileExistsError(f"No such directory: {data_dir}")
+    if confirm:
+        ans = input(f"Import data from {data_dir} to {host}? [y/N]")
+        if not ans.lower().startswith("y"):
+            print("Exiting")
+            return
+    log.info(f"Importing data from {data_dir} to {host}")
+    datasources_json = data_dir.joinpath("datasources.json")
+    log.info(f"Creating data sources from {datasources_json}")
+    with datasources_json.open() as f:
+        datasources = json.load(f)
+
+    r = session.get(host + "/api/datasources")
+    r.raise_for_status()
+    existing = {s["name"]: s for s in r.json()}
+    log.info(f"Already have data sources: {list(existing)}")
+    for source in datasources:
+        if source["name"] in existing:
+            log.info(f"Already have data source {source['name']}")
+            continue
+        log.info(f"Adding data source {source['name']}: {source['url']}")
+        request_data = {}
+        for key in ("name", "url", "access", "type"):
+            request_data[key] = source[key]
+        r = session.post(
+            host + "/api/datasources",
+            data=json.dumps(request_data),
+            headers={"content-type": "application/json"},
+        )
+        r.raise_for_status()
+
+    dashboards_dir = data_dir.joinpath("dashboards")
+    for dashboard_json in dashboards_dir.glob("*.json"):
+        with dashboard_json.open() as f:
+            dashboard = json.load(f)
+
+        # can't preserve integer id on upload,
+        # stable uid is preserved, though
+        dashboard["dashboard"].pop("id")
+        # do not upload metadata
+        meta = dashboard.pop("meta")
+        dashboard["folderId"] = meta["folderId"]
+        dashboard["overwrite"] = True
+        log.info(
+            f"Uploading dashboard {dashboard['dashboard']['uid']}: {dashboard['dashboard']['title']}"
+        )
+        r = session.post(
+            host + "/api/dashboards/db",
+            data=json.dumps(dashboard),
+            headers={"content-type": "application/json"},
+        )
+        r.raise_for_status()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--host",
+        default="https://grafana.mybinder.org",
+        help="The Grafana host to export from.",
+    )
+    parser.add_argument(
+        "-d",
+        "--data-dir",
+        default="./grafana-data",
+        help="Directory in which to store grafana export data",
+    )
+    parser.add_argument(
+        "--import",
+        dest="action",
+        action="store_const",
+        const=import_grafana,
+        default=export_grafana,
+        help="Import grafana data instead of exporting",
+    )
+    parser.add_argument(
+        "-y", "--no-confirm", action="store_true", help="Skip prompts for confirmation"
+    )
+    logging.basicConfig(level=logging.INFO)
+
+    if grafana_password:
+        session.auth = (grafana_user, grafana_password)
+    else:
+        log.warning("Without authentication, data source export will fail")
+    opts = parser.parse_args()
+    opts.action(opts.host, opts.data_dir, confirm=(not opts.no_confirm))


### PR DESCRIPTION
and track an export of our dashboards and data sources

Ran an export on https://grafana.mybinder.org and an import on https://grafana.gke2.mybinder.org

Everything seemed to work except the data source export did not preserve basic-auth credentials, which GESIS uses.

<del>@bitnik Where are the prometheus credentials for GESIS? They should be stored in this repo so that can be accessed by federation maintainers.</del> added in #1632

cf #1596