### PR TITLE
allow embedding grafana

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -391,6 +391,8 @@ grafana:
       enabled: true
     smtp:
       enabled: true
+    security:
+      allow_embedding: true
 
 prometheus:
   nodeExporter:


### PR DESCRIPTION
[ref](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding)

presumably the default changed during some upgrade.
We use this [on our status page](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_embedding)

noticed on gitter