### PR TITLE
bump repo2docker

### DIFF
--- a/config/prod-gke2.yaml
+++ b/config/prod-gke2.yaml
@@ -9,7 +9,7 @@ binderhub:
   config:
     BinderHub:
       # TODO: start small! remove limit  when we seem stable
-      pod_quota: 100
+      pod_quota: 300
       build_node_selector: *userNodeSelector
       hub_url: https://hub.gke2.mybinder.org
       badge_base_url: https://mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -76,7 +76,7 @@ binderhub:
         - ^https%3A%2F%2Fbitbucket.org%2Fnikiubel%2Fnikiubel.bitbucket.io.git/.*
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:0.11.0-159.g35e6e7e
+      build_image: jupyter/repo2docker:0.11.0-165.gbc9b1ae
       per_repo_quota: 100
       per_repo_quota_higher: 200
       build_memory_limit: "3G"


### PR DESCRIPTION
This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyter/repo2docker/compare/35e6e7e...bc9b1ae

Deploys switch to mamba: https://github.com/jupyterhub/repo2docker/pull/962