### PR TITLE
finish moving old prod to gke1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,8 +157,8 @@ jobs:
       matrix:
         include:
           - federation_member: prod
-            binder_url: https://gke.mybinder.org
-            hub_url: https://hub.gke.mybinder.org
+            binder_url: https://gke1.mybinder.org
+            hub_url: https://hub.gke1.mybinder.org
             cluster_name: prod-a
           - federation_member: prod-gke2
             binder_url: https://gke2.mybinder.org

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -9,7 +9,7 @@ binderhub:
   config:
     BinderHub:
       build_node_selector: *userNodeSelector
-      hub_url: https://hub.gke.mybinder.org
+      hub_url: https://hub.gke1.mybinder.org
       badge_base_url: https://mybinder.org
       image_prefix: gcr.io/binder-prod/r2d-f18835fd-
       google_analytics_code: "UA-101904940-1"

--- a/docs/source/operation_guide/federation.rst
+++ b/docs/source/operation_guide/federation.rst
@@ -12,7 +12,7 @@ the BinderHub federation, who is in it, how to join it, etc, see
 ==========================  ========  ===============  ==============  =============== =====
   URL                       Response  Docker registry  JupyterHub API  User/Build Pods Quota
 ==========================  ========  ===============  ==============  =============== =====
-gke.mybinder.org
+gke1.mybinder.org
 gke2.mybinder.org
 ovh.mybinder.org
 gesis.mybinder.org
@@ -23,7 +23,7 @@ turing.mybinder.org
 
    <script>
    var fedUrls = [
-       "https://gke.mybinder.org",
+       "https://gke1.mybinder.org",
        "https://gke2.mybinder.org",
        "https://ovh.mybinder.org",
        "https://gesis.mybinder.org",

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -467,10 +467,10 @@ federationRedirect:
   load_balancer: "rendezvous"
   hosts:
     gke:
-      url: https://gke.mybinder.org
+      url: https://gke1.mybinder.org
       weight: 65
-      health: https://gke.mybinder.org/health
-      versions: https://gke.mybinder.org/versions
+      health: https://gke1.mybinder.org/health
+      versions: https://gke1.mybinder.org/versions
       prime: true
     gke2:
       url: https://gke2.mybinder.org


### PR DESCRIPTION
instead of gke.mybinder.org

in preparation for gke2 taking over top-level mybinder.org and gke.mybinder.org

DNS has been updated so that *.gke1.mybinder.org will keep pointing to the old cluster. gke.mybinder.org will follow mybinder.org.