### PR TITLE
remove quota from prod-gke2

### DIFF
--- a/config/prod-gke2.yaml
+++ b/config/prod-gke2.yaml
@@ -8,8 +8,6 @@ coreNodeSelector: &coreNodeSelector
 binderhub:
   config:
     BinderHub:
-      # TODO: start small! remove limit  when we seem stable
-      pod_quota: 300
       build_node_selector: *userNodeSelector
       hub_url: https://hub.gke2.mybinder.org
       badge_base_url: https://mybinder.org


### PR DESCRIPTION
seems to be handling similar traffic to prod now, rely on federation priority from now on