### PR TITLE
[MRG] Change federation redirector to use weighted rendezvous

### DIFF
--- a/images/federation-redirect/README.rst
+++ b/images/federation-redirect/README.rst
@@ -24,3 +24,12 @@ health they are automatically added back to the list of viable targets.
 The redirect response contains a short lived cookie that is used to remember
 the choice of target. This means that subsequent visits from the same user
 agent will be directed to the same target.
+
+
+-------------
+Running tests
+-------------
+
+To run the automated tests for the redirector change to this directory in
+your terminal and run ``pytest``. This should find the tests in
+``test_rendezvous.py``.

--- a/images/federation-redirect/test_rendezvous.py
+++ b/images/federation-redirect/test_rendezvous.py
@@ -1,0 +1,33 @@
+from collections import Counter
+
+from app import rendezvous_rank
+
+
+def test_50_50_split():
+    # check that two buckets with equal weight get used roughly the
+    # same number of times
+    result = Counter(
+        [rendezvous_rank([("a", 1.0), ("b", 1.0)], "key-%i" % i)[0] for i in range(100)]
+    )
+    # as there is no randomness involved the result should always be the same
+    assert result["a"] == 52
+    assert result["b"] == 48
+
+
+def test_80_20_split():
+    # check that two buckets with a 80-20 weighting work
+    result = Counter(
+        [rendezvous_rank([("a", 0.8), ("b", 0.2)], "key-%i" % i)[0] for i in range(100)]
+    )
+    # as there is no randomness involved the result should always be the same
+    assert result["a"] == 75
+    assert result["b"] == 25
+
+
+def test_100_0_split():
+    # check that a bucket with zero weight never gets selected
+    # the weight of bucket "a" doesn't matter
+    result = Counter(
+        [rendezvous_rank([("a", 0.8), ("b", 0.)], "key-%i" % i)[0] for i in range(100)]
+    )
+    assert Counter({"a": 100}) == result


### PR DESCRIPTION
This adds the ability to weight clusters in addition to limiting them by
quota.
 This is nice to spread the "random repos" across clusters.

I checked that it works with things like:
```
In [57]: Counter([rendezvous_rank([('a', 1.), ('b', 1.)], "key-%i" % i)[0] for i in range(100)])
Out[57]: Counter({'a': 48, 'b': 52})

In [60]: Counter([rendezvous_rank([('a', .2), ('b', .8)], "key-%i" % i)[0] for i in range(100)])
Out[60]: Counter({'a': 82, 'b': 18})
```
so I think it works.

If we want to start using weights we need to update the comments/docs that were added in #1639 