### PR TITLE
log reason for failed health checks

### DIFF
--- a/images/analytics-publisher/Dockerfile
+++ b/images/analytics-publisher/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7-stretch
+FROM python:3.8-slim-buster
 
 WORKDIR /srv
 
-ADD . .
+COPY . .
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 

--- a/images/federation-redirect/Dockerfile
+++ b/images/federation-redirect/Dockerfile
@@ -1,9 +1,26 @@
-FROM python:3.7-stretch
+ARG DIST=buster
+# build in non-slim image, which has compilation dependencies
+FROM python:3.8-$DIST as builder
+
+# RUN apt-get -y update
+
+COPY requirements.txt requirements.txt
+
+RUN python3 -m pip wheel -r requirements.txt -w /wheelhouse
+
+FROM python:3.8-slim-$DIST
+
+# pycurl requires libcurl
+RUN apt-get -y update \
+ && apt-get -y install --no-install-recommends \
+        libcurl4 \
+ && apt-get clean \
+ && rm -rvf /var/lib/apt/lists/*
+
+COPY --from=builder /wheelhouse /wheelhouse
+RUN python3 -m pip install /wheelhouse/*.whl
 
 WORKDIR /srv
-
-ADD . .
-
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+COPY app.py /srv/app.py
 
 CMD ["python3", "/srv/app.py"]

--- a/images/federation-redirect/requirements.txt
+++ b/images/federation-redirect/requirements.txt
@@ -1,2 +1,2 @@
 tornado==6.0.2
-pycurl==7.43.0.3
+pycurl==7.43.0.6


### PR DESCRIPTION
- log reason on each failure, rather than only logging reason when a member is removed from the federation
- don't retry successful checks with unhealthy status (identified with FailedCheck exception class)
- use `python:3.8-slim-buster` as base image for both images in this repo, reducing image sizes from 890-950MB to 120-150MB.