### PR TITLE
Update and rename ban_check.md to repo_check.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/repo_check.md
+++ b/.github/ISSUE_TEMPLATE/repo_check.md
@@ -1,6 +1,6 @@
 ---
 name: "\U00002705 Repo Check"
-about: "If you're concerned about banning, we can check your repo"
+about: "If you're concerned if your repository is acceptable for mybinder.org, we can check your repo"
 labels: question
 
 ---


### PR DESCRIPTION
This removes the word "ban_check" from our "repo check" issue template and replaces it with `repo_check`