### PR TITLE
Upgrade staging to use Helm v3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,6 @@ on:
 # Global environment variables
 env:
   GCLOUD_SDK_VERION: "290.0.1"
-  HELM_VERSION: "v2.16.10"
   KUBECTL_VERSION: "v1.18.0"
   CERT_MANAGER_VERSION: "v0.15.2"
   GIT_COMMITTER_EMAIL: ci-user@github.local
@@ -37,6 +36,9 @@ jobs:
       ((github.event_name == 'push') &&
       (github.ref == 'refs/heads/master'))
     runs-on: ubuntu-18.04
+    # Set helm version for this job
+    env:
+      HELM_VERSION: "v3.3.4"
     strategy:
       fail-fast: false  # Do not cancel all jobs if one fails
       matrix:
@@ -148,6 +150,9 @@ jobs:
     # Only run job if the event is a push to master
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-18.04
+    # Set helm version for this job
+    env:
+      HELM_VERSION: "v2.16.10"
     # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
     strategy:
       fail-fast: false  # Do not cancel all jobs if one fails

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: "Stage 1: Install helm"
         run: |
-          curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          curl -L https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
       # Action Repo: https://github.com/sliteteam/github-action-git-crypt-unlock

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,7 +107,7 @@ jobs:
       - name: "Stage 2: Setup helm"
         working-directory: mybinder
         run: |
-          helm init --client-only
+          helm repo add stable https://charts.helm.sh/stable
           helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
           helm repo add jetstack https://charts.jetstack.io
           helm repo update

--- a/deploy.py
+++ b/deploy.py
@@ -135,7 +135,7 @@ def setup_helm(release):
     # Only compare helm versions for release not running helm3
     if release == "staging":
         helm_version_major = HELM_VERSION.split(".")[0]
-        
+
         if helm_version_major == "v3":
             print(BOLD + GREEN + "You are running helm3!" + NC, flush=True)
         else:
@@ -272,7 +272,6 @@ def deploy(release, name=None):
         name,
         name,
         "mybinder",
-        "--force",
         "--cleanup-on-fail",
         "-f",
         os.path.join("config", release + ".yaml"),
@@ -281,6 +280,11 @@ def deploy(release, name=None):
         "-f",
         os.path.join("secrets", "config", release + ".yaml"),
     ]
+
+    if release == "staging":
+        helm.extend(["--create-namespace"])
+    else:
+        helm.extend(["--force"])
 
     subprocess.check_call(helm)
     print(BOLD + GREEN + f"SUCCESS: Helm upgrade for {release} completed" + NC, flush=True)

--- a/deploy.py
+++ b/deploy.py
@@ -132,27 +132,65 @@ def setup_auth_gcloud(release, cluster=None):
 
 def setup_helm(release):
     """ensure helm is up to date"""
-    # First check the helm client and server versions
-    client_helm_cmd = ["helm", "version", "-c", "--short"]
-    client_version = (
-        subprocess.check_output(client_helm_cmd)
-        .decode("utf-8")
-        .split(":")[1]
-        .split("+")[0]
-        .strip()
-    )
-
-    server_helm_cmd = ["helm", "version", "-s", "--short"]
-    try:
-        server_version = (
-            subprocess.check_output(server_helm_cmd)
+    # Only compare helm versions for release not running helm3
+    if release == "staging":
+        helm_version_major = HELM_VERSION.split(".")[0]
+        
+        if helm_version_major == "v3":
+            print(BOLD + GREEN + "You are running helm3!" + NC, flush=True)
+        else:
+            raise Exception(
+                f"Upgrading {release} requires helm3 to be installed. Please check your installation."
+            )
+    else:
+        # First check the helm client and server versions
+        client_helm_cmd = ["helm", "version", "-c", "--short"]
+        client_version = (
+            subprocess.check_output(client_helm_cmd)
             .decode("utf-8")
             .split(":")[1]
             .split("+")[0]
             .strip()
         )
-    except subprocess.CalledProcessError:
-        server_version = None
+
+        server_helm_cmd = ["helm", "version", "-s", "--short"]
+        try:
+            server_version = (
+                subprocess.check_output(server_helm_cmd)
+                .decode("utf-8")
+                .split(":")[1]
+                .split("+")[0]
+                .strip()
+            )
+        except subprocess.CalledProcessError:
+            server_version = None
+
+        print(BOLD + GREEN +
+            f"Client version: {client_version}, Server version: {server_version}" +
+            NC,
+            flush=True
+        )
+
+        # Now check if the version of helm matches that which CI is expecting
+        if client_version != HELM_VERSION:
+            # The local helm version is not what was expected - user needs to change the installation
+            raise Exception(
+                f"You are not running helm {HELM_VERSION} which is the version our continuous deployment system uses.\n" +
+                "Please change your installation and try again.\n"
+            )
+        elif (client_version == HELM_VERSION) and (client_version != server_version):
+            # The correct local version of helm is installed, but the server side
+            # has previously accidentally been upgraded. Perform a force-upgrade
+            # to bring the server side back to matching version
+            print(f"Upgrading helm from {server_version} to {HELM_VERSION}")
+            subprocess.check_call(['helm', 'init', '--upgrade', '--force-upgrade'])
+        elif (client_version == HELM_VERSION) and (client_version == server_version):
+            # All is good! Perform normal helm init command.
+            # We use the --client-only flag so that the Tiller installation is not affected.
+            subprocess.check_call(['helm', 'init', '--client-only'])
+        else:
+            # This is a catch-all exception. Hopefully this doesn't execute!
+            raise Exception("Please check your helm installation.")
 
     # TODO: fresh cluster needs these run once:
     # not yet automated, not needed once we move to helm 3
@@ -160,33 +198,6 @@ def setup_helm(release):
     # kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
     # helm init --service-account tiller --history-max 100 --wait
     # kubectl patch deployment tiller-deploy --namespace=kube-system --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
-
-    print(BOLD + GREEN +
-        f"Client version: {client_version}, Server version: {server_version}" +
-        NC,
-        flush=True
-    )
-
-    # Now check if the version of helm matches that which CI is expecting
-    if client_version != HELM_VERSION:
-        # The local helm version is not what was expected - user needs to change the installation
-        raise Exception(
-            f"You are not running helm {HELM_VERSION} which is the version our continuous deployment system uses.\n" +
-            "Please change your installation and try again.\n"
-        )
-    elif (client_version == HELM_VERSION) and (client_version != server_version):
-        # The correct local version of helm is installed, but the server side
-        # has previously accidentally been upgraded. Perform a force-upgrade
-        # to bring the server side back to matching version
-        print(f"Upgrading helm from {server_version} to {HELM_VERSION}")
-        subprocess.check_call(['helm', 'init', '--upgrade', '--force-upgrade'])
-    elif (client_version == HELM_VERSION) and (client_version == server_version):
-        # All is good! Perform normal helm init command.
-        # We use the --client-only flag so that the Tiller installation is not affected.
-        subprocess.check_call(['helm', 'init', '--client-only'])
-    else:
-        # This is a catch-all exception. Hopefully this doesn't execute!
-        raise Exception("Please check your helm installation.")
 
     deployment = json.loads(subprocess.check_output([
         'kubectl',

--- a/deploy.py
+++ b/deploy.py
@@ -133,8 +133,18 @@ def setup_auth_gcloud(release, cluster=None):
 def setup_helm(release):
     """ensure helm is up to date"""
     # Only compare helm versions for release not running helm3
+    # First check the helm client and server versions
+    client_helm_cmd = ["helm", "version", "-c", "--short"]
+    client_version = (
+        subprocess.check_output(client_helm_cmd)
+        .decode("utf-8")
+        .split(":")[1]
+        .split("+")[0]
+        .strip()
+    )
+
     if release == "staging":
-        helm_version_major = HELM_VERSION.split(".")[0]
+        helm_version_major = client_version.split(".")[0]
 
         if helm_version_major == "v3":
             print(BOLD + GREEN + "You are running helm3!" + NC, flush=True)
@@ -143,16 +153,6 @@ def setup_helm(release):
                 f"Upgrading {release} requires helm3 to be installed. Please check your installation."
             )
     else:
-        # First check the helm client and server versions
-        client_helm_cmd = ["helm", "version", "-c", "--short"]
-        client_version = (
-            subprocess.check_output(client_helm_cmd)
-            .decode("utf-8")
-            .split(":")[1]
-            .split("+")[0]
-            .strip()
-        )
-
         server_helm_cmd = ["helm", "version", "-s", "--short"]
         try:
             server_version = (


### PR DESCRIPTION
I have migrated the deployments on staging to Helm v3 from v2. This PR updates the cd.yml workflow to provide job-specific env vars to define the Helm version. Currently, only staging is running Helm3 while the rest of the federation is still on v2.