### PR TITLE
Fix getting v2 helm major identifier

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -144,7 +144,7 @@ def get_helm_major_version():
     helm_version_major = client_version.split(".")[0]
 
     if "Client:" in helm_version_major:
-        helm_version_major = helm_version_major.split(":").split("+").strip()
+        helm_version_major = helm_version_major.split(":")[-1].strip()
 
     return helm_version_major
 


### PR DESCRIPTION
This is a small fix when getting the major version identifier of helm for clusters running v2