### PR TITLE
specify grafana storageClassName for all deployments

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -102,7 +102,8 @@ grafana:
           access: direct
           isDefault: true
           editable: false
-
+  persistence:
+    storageClassName: csi-cinder-high-speed
 
 prometheus:
   server:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -91,6 +91,8 @@ grafana:
           access: direct
           isDefault: true
           editable: false
+  persistence:
+    storageClassName: standard
 
 prometheus:
   server:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -76,6 +76,8 @@ grafana:
           access: direct
           isDefault: true
           editable: false
+  persistence:
+    storageClassName: standard
 
 prometheus:
   server:

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -87,7 +87,6 @@ grafana:
       - secretName: turing-grafana-tls-crt
         hosts:
           - grafana.mybinder.turing.ac.uk
-
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -99,6 +98,8 @@ grafana:
           access: direct
           isDefault: true
           editable: false
+  persistence:
+    storageClassName: default
 
 prometheus:
   server:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -382,7 +382,6 @@ grafana:
       kubernetes.io/tls-acme: 'true'
   persistence:
     enabled: true
-    storageClassName: "standard"
     size: 1Gi
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
it's a different value for each. This is why we left it blank!

But without upgrading the grafana chart to fix the empty value for helm 3, it must be specified.