### PR TITLE
remove heritage from matchLabels for gcs-proxy

### DIFF
--- a/mybinder/templates/gcs-proxy/pdb.yaml
+++ b/mybinder/templates/gcs-proxy/pdb.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
       app: gcs-proxy
       component: nginx
 {{- end }}

--- a/mybinder/templates/gcs-proxy/service.yaml
+++ b/mybinder/templates/gcs-proxy/service.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: gcs-proxy
     component: nginx
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   ports:
@@ -15,6 +14,5 @@ spec:
   selector:
     app: gcs-proxy
     component: nginx
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
I think this is causing current lack of availability for archive.analytics