### PR TITLE
update terraform layout for 0.13

### DIFF
--- a/terraform/modules/mybinder/resource.tf
+++ b/terraform/modules/mybinder/resource.tf
@@ -1,14 +1,3 @@
-provider "google" {
-  version = "~> 3.39"
-  project = "binderhub-288415"
-  region  = "us-central1"
-  zone    = "us-central1-a"
-}
-
-provider "random" {
-  version = "~> 2.3"
-}
-
 data "google_client_config" "provider" {}
 
 locals {

--- a/terraform/modules/mybinder/versions.tf
+++ b/terraform/modules/mybinder/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.44"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0.0"
+    }
+  }
+  required_version = "~> 0.13"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -6,7 +6,6 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.39"
   project = "binderhub-288415"
   region  = "us-central1"
   zone    = "us-central1-a"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,7 +6,6 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.39"
   project = "binderhub-288415"
   region  = "us-central1"
   zone    = "us-central1-a"


### PR DESCRIPTION
Following [terraform docs](https://www.terraform.io/upgrade-guides/0-13.html#before-you-upgrade)

There was a small snag for prod, since we updated to 0.13 and then deleted a resource, which confuses things. But it wasn't too hard to work around it (I had to re-add the to-be-removed resource, upgrade, then remove it again, which wasn't a big deal since it was just an IAM role).

- separate versions.tf file for provider sources and versions
- remove redundant version specifications prod/staging
- require 0.13

no change to what's deployed

The changes in #1671 have been deployed to prod and staging