### PR TITLE
Migrate helm repo 'stable' to https://charts.helm.sh/stable

### DIFF
--- a/docs/source/getting_started/production_environment.md
+++ b/docs/source/getting_started/production_environment.md
@@ -112,7 +112,7 @@ create a file called `requirements.yaml` and put the following in it:
 dependencies:
 - name: prometheus
   version: 4.6.16
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
 ```
 
 This also allows us to pin a *version* of Prometheus, which improves

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -4,10 +4,10 @@ dependencies:
    repository: https://kubernetes.github.io/ingress-nginx
  - name: prometheus
    version: 11.0.2
-   repository: https://kubernetes-charts.storage.googleapis.com
+   repository: https://charts.helm.sh/stable
  - name: grafana
    version: 3.10.1
-   repository: https://kubernetes-charts.storage.googleapis.com
+   repository: https://charts.helm.sh/stable
  - name: binderhub
    version: 0.2.0-n244.hd6d3e22
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is an update as noted by using Helm v3.4.0 that warned that using the old reference instead of the new will stop working in ~ two weeks (13 november).
