### PR TITLE
Revert "binderhub: 0.2.0-n277.h3187c31...0.2.0-n287.h068b631"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
    version: 3.10.1
    repository: https://charts.helm.sh/stable
  - name: binderhub
-   version: 0.2.0-n287.h068b631
+   version: 0.2.0-n277.h3187c31
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1684

@arnim observed a disruption following my merge of the PR above.

```shell
# this works reliably - hub pod
curl -v https://hub.gke.mybinder.org/hub/health

# the responses are intermittently very slow (0-10 seconds?) - binder pod
curl -v https://gke.mybinder.org/health
```

The hub pod has loads of 503 errors to the /metrics endpoint of user pods. Not sure if it had that before.

```
[I 2020-10-30 23:08:34.078 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Flux-org-lux-binder-r48kmn7c%2Fmetrics (@10.0.4.9) 1.68ms
[I 2020-10-30 23:08:35.502 JupyterHub log:174] 200 GET /hub/api/users/ladominguez-jupyter-seismology-vn0wgusl (binder@10.0.3.120) 11.71ms
[I 2020-10-30 23:08:36.352 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fbinder-examples-demo-julia-jn33vy05%2Fmetrics (@10.0.4.9) 2.29ms
[I 2020-10-30 23:08:36.953 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fsisaza-informatica-iefp7lin%2Fmetrics (@10.0.4.9) 2.18ms
[I 2020-10-30 23:08:37.099 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fkjwinston52-jupyter-notebooks-qnkhyi2v%2Fmetrics (@10.0.4.9) 2.25ms
[I 2020-10-30 23:08:37.402 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fulugris-bike-jdquqst8%2Fmetrics (@10.0.4.9) 1.68ms
[I 2020-10-30 23:08:37.548 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fsisaza-informatica-lheyeotp%2Fmetrics (@10.0.4.9) 1.91ms
[I 2020-10-30 23:08:38.121 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fmids-info-w18-drills-scyolpfp%2Fmetrics (@10.0.4.9) 1.44ms
[I 2020-10-30 23:08:38.229 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Flux-org-lux-binder-r48kmn7c%2Fmetrics (@10.0.4.9) 1.73ms
[I 2020-10-30 23:08:38.264 JupyterHub log:174] 200 GET /hub/api/users/ladominguez-jupyter-seismology-vn0wgusl (binder@10.0.3.120) 12.13ms
[W 2020-10-30 23:08:38.602 JupyterHub _version:34] Single-user server has no version header, which means it is likely < 0.8. Expected 1.1.0
[I 2020-10-30 23:08:38.603 JupyterHub base:855] User ladominguez-jupyter-seismology-vn0wgusl took 7.580 seconds to start
[I 2020-10-30 23:08:38.603 JupyterHub proxy:262] Adding user ladominguez-jupyter-seismology-vn0wgusl to proxy /user/ladominguez-jupyter-seismology-vn0wgusl/ => http://10.0.27.38:8888
[I 2020-10-30 23:08:38.720 JupyterHub log:174] 200 GET /hub/health (@10.128.0.17) 1.35ms
[I 2020-10-30 23:08:38.801 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fbokeh-bokeh-notebooks-kz6irp57%2Fmetrics (@10.0.4.9) 1.97ms
[I 2020-10-30 23:08:38.891 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fbinder-examples-demo-julia-ojmcra31%2Fmetrics (@10.0.4.9) 1.70ms
[I 2020-10-30 23:08:41.359 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fbinder-examples-demo-julia-jn33vy05%2Fmetrics (@10.0.4.9) 1.62ms
[I 2020-10-30 23:08:41.955 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fsisaza-informatica-iefp7lin%2Fmetrics (@10.0.4.9) 1.55ms
[I 2020-10-30 23:08:42.089 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fkjwinston52-jupyter-notebooks-qnkhyi2v%2Fmetrics (@10.0.4.9) 1.85ms
[I 2020-10-30 23:08:42.125 JupyterHub log:174] 200 GET /hub/api/users/ladominguez-jupyter-seismology-vn0wgusl (binder@10.0.3.120) 14.30ms
[I 2020-10-30 23:08:42.416 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fulugris-bike-jdquqst8%2Fmetrics (@10.0.4.9) 1.64ms
[I 2020-10-30 23:08:42.554 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fsisaza-informatica-lheyeotp%2Fmetrics (@10.0.4.9) 1.78ms
[I 2020-10-30 23:08:43.122 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fmids-info-w18-drills-scyolpfp%2Fmetrics (@10.0.4.9) 2.03ms
[I 2020-10-30 23:08:43.801 JupyterHub log:174] 200 GET /hub/error/503?url=%2Fuser%2Fbokeh-bokeh-notebooks-kz6irp57%2Fmetrics (@10.0.4.9) 1.64ms
```