### PR TITLE
Remove Turing from federation and CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -161,9 +161,9 @@ jobs:
           - federation_member: prod
             binder_url: https://gke.mybinder.org
             hub_url: https://hub.gke.mybinder.org
-          - federation_member: turing
-            binder_url: https://turing.mybinder.org
-            hub_url: https://hub.mybinder.turing.ac.uk
+          # - federation_member: turing
+          #   binder_url: https://turing.mybinder.org
+          #   hub_url: https://hub.mybinder.turing.ac.uk
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -7,7 +7,7 @@ letsencrypt:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 80
+      pod_quota: 0
       hub_url: https://hub.mybinder.turing.ac.uk
       badge_base_url: https://mybinder.org
       sticky_builds: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -490,6 +490,6 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
-      weight: 1
+      weight: 0
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions


### PR DESCRIPTION
This PR removes the Turing cluster from the federation while I upgrade it from helm v2 to v3. It also removes it from the CI matrix to avoid clashing with some concurrent debugging.