### PR TITLE
Update CI to install helm3 for Turing cluster

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -213,8 +213,15 @@ jobs:
           version: ${{ env.KUBECTL_VERSION }}
 
       - name: "Stage 1: Install helm ${{ env.HELM_VERSION }}"
+        if: matrix.helm_version == env.HELM_VERSION
         run: |
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
+          sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
+
+      - name: "Stage 1: Install helm ${{ matrix.helm_version }}"
+        if: matrix.helm_version != env.HELM_VERSION
+        run: |
+          curl -L https://get.helm.sh/helm-${{ matrix.helm_version }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
 
       - name: "Stage 2: Unlock git-crypt secrets"
@@ -222,10 +229,21 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      - name: "Stage 2: Setup helm"
+      - name: "Stage 2: Setup helm ${{ env.HELM_VERSION }}"
+        if: matrix.helm_version == env.HELM_VERSION
         working-directory: mybinder
         run: |
           helm init --client-only
+          helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm dep up
+
+      - name: "Stage 2: Setup helm ${{ matrix.helm_version }}"
+        if: matrix.helm_version != env.HELM_VERSION
+        working-directory: mybinder
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
           helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
           helm repo add jetstack https://charts.jetstack.io
           helm repo update

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           version: ${{ env.KUBECTL_VERSION }}
 
-      - name: "Stage 1: Install helm"
+      - name: "Stage 1: Install helm ${{ env.HELM_VERSION }}"
         run: |
           curl -L https://get.helm.sh/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm
@@ -209,7 +209,7 @@ jobs:
         with:
           version: ${{ env.KUBECTL_VERSION }}
 
-      - name: "Stage 1: Install helm"
+      - name: "Stage 1: Install helm ${{ env.HELM_VERSION }}"
         run: |
           curl -L https://storage.googleapis.com/kubernetes-helm/helm-${{ env.HELM_VERSION }}-linux-amd64.tar.gz | tar --directory ${HOME} --extract --gzip --file -
           sudo mv ${HOME}/linux-amd64/helm /usr/local/bin/helm

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -161,12 +161,15 @@ jobs:
           - federation_member: prod
             binder_url: https://gke.mybinder.org
             hub_url: https://hub.gke.mybinder.org
-          # - federation_member: turing
-          #   binder_url: https://turing.mybinder.org
-          #   hub_url: https://hub.mybinder.turing.ac.uk
+            helm_version: "v2.16.10"
+          - federation_member: turing
+            binder_url: https://turing.mybinder.org
+            hub_url: https://hub.mybinder.turing.ac.uk
+            helm_version: "v3.3.4"
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh
+            helm_version: "v2.16.10"
 
     steps:
       - name: "Stage 0: Checkout repo"


### PR DESCRIPTION
This PR reintroduces the Turing cluster into CI (but not the federation or redirector) and handles installing helm v2 or v3 depending on the cluster matrix values.