### PR TITLE
Revert "binderhub: 0.2.0-n277.h3187c31...0.2.0-n293.h7e04ad4"

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
    version: 3.10.1
    repository: https://charts.helm.sh/stable
  - name: binderhub
-   version: 0.2.0-n293.h7e04ad4
+   version: 0.2.0-n277.h3187c31
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1686

causing things to get stuck, especially health checks