### PR TITLE
add health checks to deployment tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,12 @@ def pytest_addoption(parser):
         help="Fully qualified URL to the hub installation"
     )
 
+
 @pytest.fixture
 def binder_url(request):
-    return request.config.getoption('--binder-url')
+    return request.config.getoption("--binder-url").rstrip("/")
+
 
 @pytest.fixture
 def hub_url(request):
-    return request.config.getoption('--hub-url')
+    return request.config.getoption("--hub-url").rstrip("/")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,9 @@
-import requests
+"""Basic HTTP tests to make sure things are running"""
+import pprint
+
 import pytest
+import requests
+
 
 def test_binder_up(binder_url):
     """
@@ -18,6 +22,20 @@ def test_hub_up(hub_url):
     # 403 is expected since we are using nullauthenticator
     # FIXME: Have a dedicated health check endpoint for the hub
     assert resp.status_code == 403
+
+
+def test_hub_health(hub_url):
+    """check JupyterHubHub health endpoint"""
+    resp = requests.get(hub_url + "/hub/health")
+    print(resp.text)
+    assert resp.status_code == 200
+
+
+def test_binder_health(binder_url):
+    """check BinderHub health endpoint"""
+    resp = requests.get(binder_url + "/health")
+    pprint.pprint(resp.json())
+    assert resp.status_code == 200
 
 
 # the proxy-patches pod can take up to 30 seconds


### PR DESCRIPTION
Do not consider a deployment failing health checks to be a success

I believe this would have caught the recent deployment failures and prevented them from deploying across the whole federation. My suspicion is that staging would still have succeeded while prod would have failed, since it appears to be a performance issue, but we would at least have been notified of the problem
