### PR TITLE
Reflect new project name in SRE docs

### DIFF
--- a/docs/source/components/cloud.md
+++ b/docs/source/components/cloud.md
@@ -35,12 +35,12 @@ can be used to provide the same service.
 
 ## Projects
 
-We have two major [projects](https://cloud.google.com/storage/docs/projects)
-that run on Google Cloud.
+We have a [project](https://cloud.google.com/storage/docs/projects)
+that runs on Google Cloud: `binderhub`. It contains the following two clusters:
 
-1. `binder-prod`, runs production - `mybinder.org` and all resources
+1. `prod`, runs production - `mybinder.org` and all resources
    needed for it.
-2. `binder-staging` runs staging - `staging.mybinder.org` and all resources
+2. `staging` runs staging - `staging.mybinder.org` and all resources
    needed for it.
 
 We try to make staging and prod be as similar as possible. Staging should
@@ -56,7 +56,7 @@ as Open Source, and does not have much in the way of proprietary enhancements.
 
 ### Cluster
 
-In production, the cluster is called `prod-a`. In staging, it is called `staging`.
+In production, the cluster is called `prod`. In staging, it is called `staging`.
 
 ### Node Pools
 
@@ -68,7 +68,7 @@ current NodePool.
 
 ### Machine sizes
 
-The `prod-a` cluster currently uses `n1-highmem-32` machines. These have
+The `prod` cluster currently uses `n1-highmem-32` machines. These have
 32 CPU cores and 208 GB of Memory. We use the `highmem` machines (with more Memory per CPU)
 as opposed to `standard` machines for the following reasons:
 
@@ -89,7 +89,7 @@ down.
 
 ### Boot disk sizes
 
-In `prod-a`, we use 1000 GB SSD disks as boot disks. On Google Cloud, the size of
+In `prod`, we use 1000 GB SSD disks as boot disks. On Google Cloud, the size of
 the disk [controls the performance](https://cloud.google.com/compute/docs/disks/performance) - larger the disk, the faster it is. Our disks need to be fast since we
 are doing a lot of I/O operations during docker build / push / pull / run, so we
 use SSDs.

--- a/docs/source/getting_started/getting_started.md
+++ b/docs/source/getting_started/getting_started.md
@@ -5,7 +5,7 @@ maintain the BinderHub deployment at `mybinder.org`.
 
 ## Make sure you have access on the Google Cloud project
 
-Go to `console.cloud.google.com` and see if you have `binder-prod` listed
+Go to `console.cloud.google.com` and see if you have `binderhub` listed
 in your projects. If not, message one of the Binder devs on the [Gitter Channel](https://gitter.im/jupyterhub/binder)
 to get access.
 
@@ -20,7 +20,7 @@ out the [Zero to JupyterHub Google SDK section](https://zero-to-jupyterhub.readt
 When you run `gcloud init` for the first time, it'll ask you to authenticate
 and to choose a project / default region. You should authenticate with
 the email that's been given privileges to work on `mybinder.org`, choose
-the project `binder-prod`, and use the region `us-central1-a`.
+the project `binderhub`, and use the region `us-central1`.
 
 We recommend enabling [`kubectl` autocompletion](https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion)
 as well.
@@ -31,7 +31,7 @@ Once you have `kubectl` installed, you can connect it with `mybinder.org`.
 To do so, run the following command:
 
 ```
-gcloud container clusters get-credentials prod-a --zone us-central1-a --project binder-prod
+gcloud container clusters get-credentials prod --zone us-central1 --project binderhub
 ```
 
 This will open a log-in page in your browser. If you've got access, you'll
@@ -52,7 +52,7 @@ Now that you're connected to prod it's time to connect to staging. To do so,
 pull the staging credentials on to your local machine:
 
 ```
-gcloud container clusters get-credentials staging --zone us-central1-a --project binder-staging
+gcloud container clusters get-credentials staging --zone us-central1-a --project binderhub
 ```
 
 You can now switch between the `prod` and `staging` deployments by changing your

--- a/docs/source/operation_guide/command_snippets.md
+++ b/docs/source/operation_guide/command_snippets.md
@@ -36,8 +36,8 @@ It should take a couple of minutes.
 To upgrade the master version with `gcloud`:
 
 ```bash
-gcloud --project=binderhub container clusters upgrade staging --master --zone=us-central1-a
-gcloud --project=binderhub container clusters upgrade prod --master --zone=us-central1
+gcloud --project=binderhub-288415 container clusters upgrade staging --master --zone=us-central1-a
+gcloud --project=binderhub-288415 container clusters upgrade prod --master --zone=us-central1
 ```
 
 Now we can start the process of upgrading node versions, which takes more time.
@@ -65,7 +65,7 @@ old_pool=default-pool
 new_pool=pool-$(date +"%Y%m%d")
 
 
-gcloud --project=binderhub container node-pools create $new_pool \
+gcloud --project=binderhub-288415 container node-pools create $new_pool \
     --cluster=staging \
     --disk-size=500 \
     --machine-type=n1-standard-4 \
@@ -99,7 +99,7 @@ kubectl drain --force --delete-local-data --ignore-daemonsets --grace-period=0 $
 and then the node pool can be deleted:
 
 ```bash
-gcloud --project=binderhub container node-pools delete $old_pool --cluster=staging --zone=us-central1-a
+gcloud --project=binderhub-288415 container node-pools delete $old_pool --cluster=staging --zone=us-central1-a
 ```
 
 #### Upgrading prod
@@ -130,7 +130,7 @@ First we'll create variables that point to our old and new node pools to make it
 ```bash
 # old_user_pool is the name of the existing user pool, to be deleted
 # we can automatically assign this to a variable like so
-old_user_pool=$(gcloud container node-pools list --cluster prod --project=binderhub --format json | jq -r '.[].name' | grep '^user')
+old_user_pool=$(gcloud container node-pools list --cluster prod --project=binderhub-288415 --format json | jq -r '.[].name' | grep '^user')
 # new_user_pool can be anything, as long as it isn't the same as old_user_pool
 # we recommend appending with the date
 new_user_pool=user-$(date +"%Y%m%d")
@@ -138,14 +138,14 @@ new_user_pool=user-$(date +"%Y%m%d")
 
 > Note: You can see a list of the node pools by running:
 ```bash
-gcloud container node-pools list --cluster prod --project=binderhub --zone=us-central1
+gcloud container node-pools list --cluster prod --project=binderhub-288415 --zone=us-central1
 ```
 
 Then we can create the new user pool:
 
 ```bash
 # create the new user pool
-gcloud beta --project=binderhub container node-pools create $new_user_pool \
+gcloud beta --project=binderhub-288415 container node-pools create $new_user_pool \
     --cluster=prod \
     --zone=us-central1 \
     --disk-type=pd-ssd \
@@ -164,11 +164,11 @@ and/or create the new core pool:
 
 ```bash
 # the name of the old 'core' pool
-old_core_pool=$(gcloud container node-pools list --cluster prod --project=binderhub --format json | jq -r '.[].name' | grep '^core')
+old_core_pool=$(gcloud container node-pools list --cluster prod --project=binderhub-288415 --format json | jq -r '.[].name' | grep '^core')
 # the name of the new 'core' pool
 new_core_pool=core-$(date +"%Y%m%d")
 
-gcloud beta --project=binderhub container node-pools create $new_core_pool \
+gcloud beta --project=binderhub-288415 container node-pools create $new_core_pool \
     --cluster=prod \
     --zone=us-central1 \
     --disk-type=pd-ssd \
@@ -225,9 +225,9 @@ After draining the nodes, the old pool can be deleted.
 ```bash
 kubectl drain --force --delete-local-data --ignore-daemonsets --grace-period=0 $node
 
-gcloud --project=binderhub container node-pools delete $old_user_pool --cluster=prod --zone=us-central1
+gcloud --project=binderhub-288415 container node-pools delete $old_user_pool --cluster=prod --zone=us-central1
 
-gcloud --project=binderhub container node-pools delete $old_core_pool --cluster=prod --zone=us-central1
+gcloud --project=binderhub-288415 container node-pools delete $old_core_pool --cluster=prod --zone=us-central1
 ```
 
 ## Pod management

--- a/docs/source/operation_guide/command_snippets.md
+++ b/docs/source/operation_guide/command_snippets.md
@@ -36,8 +36,8 @@ It should take a couple of minutes.
 To upgrade the master version with `gcloud`:
 
 ```bash
-gcloud --project=binder-staging container clusters upgrade staging --master --zone=us-central1-a
-gcloud --project=binder-prod container clusters upgrade prod-a --master --zone=us-central1-a
+gcloud --project=binderhub container clusters upgrade staging --master --zone=us-central1-a
+gcloud --project=binderhub container clusters upgrade prod --master --zone=us-central1
 ```
 
 Now we can start the process of upgrading node versions, which takes more time.
@@ -65,7 +65,7 @@ old_pool=default-pool
 new_pool=pool-$(date +"%Y%m%d")
 
 
-gcloud --project=binder-staging container node-pools create $new_pool \
+gcloud --project=binderhub container node-pools create $new_pool \
     --cluster=staging \
     --disk-size=500 \
     --machine-type=n1-standard-4 \
@@ -74,7 +74,7 @@ gcloud --project=binder-staging container node-pools create $new_pool \
     --zone=us-central1-a
 ```
 
-> Note: To see a list of the node pools, run `gcloud container node-pools list --cluster staging --project=binder-staging`.
+> Note: To see a list of the node pools, run `gcloud container node-pools list --cluster staging --project=binderhub`.
 
 After the pool is created, cordon the previous nodes:
 
@@ -99,7 +99,7 @@ kubectl drain --force --delete-local-data --ignore-daemonsets --grace-period=0 $
 and then the node pool can be deleted:
 
 ```bash
-gcloud --project=binder-staging container node-pools delete $old_pool --cluster=staging --zone=us-central1-a
+gcloud --project=binderhub container node-pools delete $old_pool --cluster=staging --zone=us-central1-a
 ```
 
 #### Upgrading prod
@@ -130,7 +130,7 @@ First we'll create variables that point to our old and new node pools to make it
 ```bash
 # old_user_pool is the name of the existing user pool, to be deleted
 # we can automatically assign this to a variable like so
-old_user_pool=$(gcloud container node-pools list --cluster prod-a --project=binder-prod --format json | jq -r '.[].name' | grep '^user')
+old_user_pool=$(gcloud container node-pools list --cluster prod --project=binderhub --format json | jq -r '.[].name' | grep '^user')
 # new_user_pool can be anything, as long as it isn't the same as old_user_pool
 # we recommend appending with the date
 new_user_pool=user-$(date +"%Y%m%d")
@@ -138,16 +138,16 @@ new_user_pool=user-$(date +"%Y%m%d")
 
 > Note: You can see a list of the node pools by running:
 ```bash
-gcloud container node-pools list --cluster prod-a --project=binder-prod --zone=us-central1-a
+gcloud container node-pools list --cluster prod --project=binderhub --zone=us-central1
 ```
 
 Then we can create the new user pool:
 
 ```bash
 # create the new user pool
-gcloud beta --project=binder-prod container node-pools create $new_user_pool \
-    --cluster=prod-a \
-    --zone=us-central1-a \
+gcloud beta --project=binderhub container node-pools create $new_user_pool \
+    --cluster=prod \
+    --zone=us-central1 \
     --disk-type=pd-ssd \
     --disk-size=1000 \
     --machine-type=n1-highmem-8 \
@@ -164,13 +164,13 @@ and/or create the new core pool:
 
 ```bash
 # the name of the old 'core' pool
-old_core_pool=$(gcloud container node-pools list --cluster prod-a --project=binder-prod --format json | jq -r '.[].name' | grep '^core')
+old_core_pool=$(gcloud container node-pools list --cluster prod --project=binderhub --format json | jq -r '.[].name' | grep '^core')
 # the name of the new 'core' pool
 new_core_pool=core-$(date +"%Y%m%d")
 
-gcloud beta --project=binder-prod container node-pools create $new_core_pool \
-    --cluster=prod-a \
-    --zone=us-central1-a \
+gcloud beta --project=binderhub container node-pools create $new_core_pool \
+    --cluster=prod \
+    --zone=us-central1 \
     --disk-type=pd-ssd \
     --disk-size=250 \
     --machine-type=n1-highmem-4 \
@@ -225,9 +225,9 @@ After draining the nodes, the old pool can be deleted.
 ```bash
 kubectl drain --force --delete-local-data --ignore-daemonsets --grace-period=0 $node
 
-gcloud --project=binder-prod container node-pools delete $old_user_pool --cluster=prod-a --zone=us-central1-a
+gcloud --project=binderhub container node-pools delete $old_user_pool --cluster=prod --zone=us-central1
 
-gcloud --project=binder-prod container node-pools delete $old_core_pool --cluster=prod-a --zone=us-central1-a
+gcloud --project=binderhub container node-pools delete $old_core_pool --cluster=prod --zone=us-central1
 ```
 
 ## Pod management
@@ -302,7 +302,7 @@ To pre-emptively bump the cluster size beyond current occupancy, follow these st
   * Under "Node Pools" find the "minimum size" field and update it.
 
 * Use the `gcloud` command line tool to explicitly resize the cluster.
-  * `gcloud container clusters resize prod-a --size <NEW-SIZE>`
+  * `gcloud container clusters resize prod --size <NEW-SIZE>`
 
 Manually resizing a cluster with autoscaling on doesn't always work because the autoscaler
 can automatically reduce the cluster size after asking for more nodes that

--- a/images/analytics-publisher/README.rst
+++ b/images/analytics-publisher/README.rst
@@ -26,7 +26,7 @@ You can test events archiver locally with:
    python3 images/analytics-publisher/archiver.py \
            --debug \
            --dry-run \
-           binder-prod binderhub-events-text  \
+           binderhub binderhub-events-text  \
            mybinder-events-raw-export mybinder-events-archive
 
 The ``--debug`` and ``--dry-run`` options tell the script to print output


### PR DESCRIPTION
When we migrated Google projects, we now only have one, called
"binderhub", as opposed to two. The production cluster also has a
different name and is in a different zone to staging.

This PR attempts to update the SRE docs to catch changes in our
workflow to the references project ID and cluster name/zone.

I may not have caught all places where changes are pertinent, please feel free to add to this PR if you spot anything!