### PR TITLE
Disable OVH while we figure out DockerHub rate limit

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -488,7 +488,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 1
+      weight: 0
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
After setting up a secret for pulling images we are still getting "pull rate limit" errors. Not quite sure why, but for the moment manually disabling OVH at the redirector level as users can't launch instances and the automated health check doesn't catch this.