### PR TITLE
Remove resources for dawn-ico/dusk-dawn-notebook

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -73,9 +73,6 @@ binderhub:
         - pattern: ^michaelJwilson/DESI-HighSchool.*
           config:
             quota: 200
-        - pattern: ^dawn-ico/dusk-dawn-notebook.*
-          config:
-            quota: 128
 
     GitRepoProvider:
       banned_specs:


### PR DESCRIPTION
The ESiWACE2 DSL workshop has concluded now. I don't know if you want to keep this entry for the future. I think for maintainability, it's easier to keep the increased resources _clean_. From our side, we would need such an increase probably at maximum once per year. And I think this time we didn't even come close to hitting the 100 concurrent users. :sweat_smile: 

Based on preliminary discussions and feedback, we can say that climate and meteorological scientists really enjoyed working with the jupyter labs and notebooks. Additionally, mybinder was great since it was so convenient for participants to get access to the exercise tools (instead of having to setup complicated dependencies themselves). We were very happy to be able to use mybinder :smile: (feel free to contact me if you want a proper _reference_)

Related #1701 