### PR TITLE
Disable z2jh singleuser network policy

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -70,6 +70,10 @@ binderhub:
         enabled: true
         replicas: 5
 
+    singleuser:
+      networkPolicy:
+        enabled: false
+
   imageCleaner:
     # Use 40GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 40e9


### PR DESCRIPTION
related: #1468

cc: @manics @consideRatio

We've identified a conflict between the singleuser and binder-users network policies which is causing the DNS problem we see on the Turing cluster. This PR is suggesting that we disable the restrictive z2jh singleuser policy set in the binderhub helm chart for the time being for the Turing cluster **only**.

This means that singleuser pods will only have a single policy applied to them (binder-users) instead of two (binder-users and singleuser).

Further investigation needs to go into **why** this is happening? The network controller? The Turing cluster runs Azure's CNI, maybe this will be fixed by switching to calico/kubenet/something else? But that would require a complete redeployment of the infrastructure. That is to say, I don't think the CNI can be switched out in place. Docs: https://docs.microsoft.com/en-us/azure/aks/use-network-policies