### PR TITLE
Change OVH's version of Helm in CI matrix job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -169,7 +169,7 @@ jobs:
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh
-            helm_version: "v2.16.10"
+            helm_version: "v3.3.4"
 
     steps:
       - name: "Stage 0: Checkout repo"


### PR DESCRIPTION
This PR is bumping the version of helm used during OVH's upgrade to helm 3