### PR TITLE
Bump chartpress to 1.0.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytest-timeout
 pytest-xdist
 requests
 kubernetes
-chartpress<1.0.0
+chartpress==1.0.*


### PR DESCRIPTION
This bump is not needed for anything specific, it's just maintenance. Since I know its a safe version upgrade I figure it makes sense for me to suggest it so others don't have to read the changelog etc.