### PR TITLE
Revert "Bump chartpress to 1.0.*"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytest-timeout
 pytest-xdist
 requests
 kubernetes
-chartpress==1.0.*
+chartpress<1.0.0


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1722

With chartpress==1.0.*, we see the SemVer error when building the chart. Reverting back to 0.7 for the time being.