### PR TITLE
ci: use non-deprecated repo for setup-gcloud action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,9 +73,9 @@ jobs:
           pip install --upgrade setuptools pip
           pip install --upgrade -r requirements.txt
 
-      # Action Repo: https://github.com/GoogleCloudPlatform/github-actions/tree/master/setup-gcloud
+      # Action Repo: https://github.com/google-github-actions/setup-gcloud
       - name: "Stage 1: Install gcloud SDK"
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCLOUD_SDK_VERION }}
 
@@ -198,7 +198,7 @@ jobs:
       # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
       - name: "Stage 1: Install gcloud SDK"
         if: matrix.federation_member == 'prod'
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCLOUD_SDK_VERION }}
 


### PR DESCRIPTION
I noticed warnings about setup-gcloud action being deprecated, and that they recommend a new version. This PR does that.

![image](https://user-images.githubusercontent.com/3837114/101071279-a6877e80-359c-11eb-8eed-7094409d8457.png)
