### PR TITLE
[MRG] Expose nodeSelector config

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -183,6 +183,7 @@ matomo:
       memory: 1Gi
 
 analyticsPublisher:
+  nodeSelector: *coreNodeSelector
   project: binderhub-288415
   destinationBucket: binder-events-archive
   events:
@@ -191,6 +192,7 @@ analyticsPublisher:
     sourceBucket: binder-billing-archive
 
 gcsProxy:
+  nodeSelector: *coreNodeSelector
   buckets:
     - name: binder-events-archive
       host: archive.analytics.mybinder.org
@@ -198,4 +200,5 @@ gcsProxy:
       host: archive.analytics.gke2.mybinder.org
 
 federationRedirect:
+  nodeSelector: *coreNodeSelector
   enabled: true

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -183,7 +183,6 @@ matomo:
       memory: 1Gi
 
 analyticsPublisher:
-  nodeSelector: *coreNodeSelector
   project: binderhub-288415
   destinationBucket: binder-events-archive
   events:
@@ -192,7 +191,6 @@ analyticsPublisher:
     sourceBucket: binder-billing-archive
 
 gcsProxy:
-  nodeSelector: *coreNodeSelector
   buckets:
     - name: binder-events-archive
       host: archive.analytics.mybinder.org
@@ -200,5 +198,4 @@ gcsProxy:
       host: archive.analytics.gke2.mybinder.org
 
 federationRedirect:
-  nodeSelector: *coreNodeSelector
   enabled: true

--- a/mybinder/templates/analytics-publisher/deployment.yaml
+++ b/mybinder/templates/analytics-publisher/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/analytics-publisher/configmap.yaml") . | sha256sum }}
     spec:
+      nodeSelector: {{ .Values.analyticsPublisher.nodeSelector | toJson }}
       volumes:
       - name: secrets
         secret:

--- a/mybinder/templates/federation-redirect/deployment.yaml
+++ b/mybinder/templates/federation-redirect/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/federation-redirect/configmap.yaml") . | sha256sum }}
     spec:
+      nodeSelector: {{ .Values.federationRedirect.nodeSelector | toJson }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/mybinder/templates/matomo/mysqld-exporter/deployment.yaml
+++ b/mybinder/templates/matomo/mysqld-exporter/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         component: mysqld-exporter
     spec:
       automountServiceAccountToken: false
+      nodeSelector: {{ .Values.matomo.nodeSelector | toJson }}
       volumes:
       - name: cloudsql-instance-credentials
         secret:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -452,6 +452,7 @@ analyticsPublisher:
     sourceBucket: binder-billing
     fileName: cloud-costs.jsonl
     kind: csv
+  nodeSelector: {}
 
 # this is defined in secrets/ for the OVH cluster
 eventsArchiver:
@@ -493,3 +494,4 @@ federationRedirect:
       weight: 1
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
+  nodeSelector: {}


### PR DESCRIPTION
This PR makes nodeSelector configurable for: analytics-publisher, federation-redirect, matomo's mysqld-exporter.

It does not firmly close #1729 as initially intended as we opted to not make them schedule on the core node pool, but with #1731 we should be fine anyhow with regards to that.

---

I inspected these pods resource requests in k8s and how much free resources were around on the core nodes. They didn't request anything which means in k8s cluster they are unlimited I think. The nodes seem to have some room for these pods overall.

Assuming k8s node upgrades are done by adding a node and then removing a node using _node surge upgrades_, there should be no issues then either I think.