### PR TITLE
Run tests from the top level tests directory only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: py.test -vx -n 2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }}
+          command: py.test -vx -n 2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }} tests/
 
       - name: "Stage 5: Post message to Grafana that deployment to production has started"
         run: |
@@ -264,4 +264,4 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: py.test -vx -n 2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }}
+          command: py.test -vx -n 2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }} tests/


### PR DESCRIPTION
The tests in the federation redirector sub-directory don't run in our CI
environment and are not meant to run there either. This selects only the
tests in the top level `tests/` directory.

In #1641 I added a test in the federation redirector sub directory. Hadn't realised that pytest would search all directories in the repo to look for tests.