### PR TITLE
Update prometheus / grafana partially

### DIFF
--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
  #       chart v11.16.9 maps to app v2.21.0
  #       chart v12 requires Helm 3
  - name: prometheus
-   version: 11.0.2
+   version: 11.16.9
    repository: https://prometheus-community.github.io/helm-charts
 
  # Grafana for dashboarding of metrics.
@@ -33,7 +33,7 @@ dependencies:
  #       chart v5.1.2 maps to app v7.0.1
  #       chart v6 requires Helm 3
  - name: grafana
-   version: 3.10.1
+   version: 5.0.26
    repository: https://grafana.github.io/helm-charts
 
  - name: binderhub

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
  #       chart v12 requires Helm 3
  - name: prometheus
    version: 11.0.2
-   repository: https://charts.helm.sh/stable
+   repository: https://prometheus-community.github.io/helm-charts
 
  # Grafana for dashboarding of metrics.
  # Source code:   https://github.com/grafana/helm-charts/tree/main/charts/grafana
@@ -34,7 +34,7 @@ dependencies:
  #       chart v6 requires Helm 3
  - name: grafana
    version: 3.10.1
-   repository: https://charts.helm.sh/stable
+   repository: https://grafana.github.io/helm-charts
 
  - name: binderhub
    version: 0.2.0-n451.h6a2b398

--- a/mybinder/requirements.yaml
+++ b/mybinder/requirements.yaml
@@ -1,13 +1,41 @@
 dependencies:
+ # Ingress-Nginx to route network traffic according to Ingress resources using
+ # this controller from within k8s.
+ # Source code:   https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
+ # App changelog: https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md
+ #
+ # NOTE: chart v2.13.0 maps to app v0.35.0  - 2020-09-01
+ #       chart v3 upgrade require k8s 1.16
+ #       chart v3.3.0 maps to app v0.35.0
+ #       chart v3.12.0 requires Helm 3
  - name: ingress-nginx
    version: 2.13.0
    repository: https://kubernetes.github.io/ingress-nginx
+
+ # Prometheus for collection of metrics.
+ # Source code:   https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+ # App changelog: https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md
+ #
+ # NOTE: chart v11.0.2 maps to app v2.16.0   - 2020-07-10
+ #       chart v11.16.9 maps to app v2.21.0
+ #       chart v12 requires Helm 3
  - name: prometheus
    version: 11.0.2
    repository: https://charts.helm.sh/stable
+
+ # Grafana for dashboarding of metrics.
+ # Source code:   https://github.com/grafana/helm-charts/tree/main/charts/grafana
+ # App changelog: https://github.com/grafana/grafana/blob/master/CHANGELOG.md
+ #
+ # NOTE: chart v3.10.1 maps to app v6.4.2   - 2019-11-22
+ #       chart v5 upgrade requires helm2 --force
+ #       chart v5.0.26 maps to app v6.7.3
+ #       chart v5.1.2 maps to app v7.0.1
+ #       chart v6 requires Helm 3
  - name: grafana
    version: 3.10.1
    repository: https://charts.helm.sh/stable
+
  - name: binderhub
    version: 0.2.0-n451.h6a2b398
    repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
## Relocation of chart repo
Both grafana and promethus have migrated from the now read-only chart repo that were "stable" before to their self managed chart repos, this PR updates to use those repos.

## Version bumps
Prometheus chart is upgraded from v11.0.2 to v11.16.9, that in turn makes prometheus transition from v2.16.0 to v2.21.0, which doesn't introduce app breaking changes or chart breaking changes.
- Grafana chart is upgraded from v3.10.1 to v5.0.26, that makes grafana transition from v6.4.2 to v6.7.3, which doesn't introduce app breaking changes but requires a `helm2 --force` upgrade due to changes in labels for matchSelector of the deployment and perhaps more.

## Upgrade notes - EDIT: easier than I thought because only grafana deployment needed to be deleted
We don't have Helm2 in staging/ovh/turing any more, so we can't rely on `helm2 --force` to make things work without manual effort I think. What we need to do, is to manually delete the deployments in advance, and if needed, also PVCs.

__Deleting PVCs__

By default, deleting a PVC will with our clusters settings lead to the deletion of the PV which we don't want for prometheus or grafana, as we would loose collected metrics for the prometheus storage and dashboard definitions for the grafana storage.

So, if needed, how do we replace the PVCs without loosing the associated PV data? I'm not 100% on this, but when I've done it in the past, I believe this is what I did.

1. Edit the the PV that was dynamically created for the PVC we need to update with a deletion/creation cycle.
   - The `persistentVolumeReclaimPolicy` should have a value of `Retain` instead of `Delete`. This means that when they ar unbound by a PVC, the PV won't be cleaned up and deleted, and the associated cloud storage that the PV maps to will not be deleted either.
2. Manually delete the PVCs that turned out to require to be updated with a deletion/creation cycle.
3. When the old PVCs is deleted, we make this PV available to be re-bound by a PVC by cleaning up some references it contain under its `claimRef` field.
4. We make another upgrade attempt which will create a PVC again that can be bound to the already existing PV.

## Federation members helm2/helm3 status
Only GKE prod use helm2 still, so this upgrade will need to handle both helm2 / helm3 systems which makes it quite complicated.

