### PR TITLE
No rolling updates for prometheus-server with its attached storage

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -97,6 +97,11 @@ grafana:
 prometheus:
   server:
     nodeSelector: *coreNodeSelector
+    strategy:
+      # RollingUpdate fails because the attached storage can only be mounted on
+      # one pod, so we need to use Recreate that first shut down the pod and
+      # then starts it up during updates.
+      type: Recreate
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
prometheus-server has a PVC storage attached to it, which it needs to be alone in working with to startup properly. Due to this, we cannot use a rolling update and should use recreate as a update strategy instead.

Example of an error that can be seen. Another error is that the pod get stuck in ContainerCreating waiting for the PVC to be available for mount.

```
level=error ts=2020-12-06T15:20:14.659Z caller=main.go:787 err="opening storage failed: lock DB directory: resource temporarily unavailable"
```
