### PR TITLE
Apply prometheus-server Recreate strategy for all deployments

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -97,11 +97,6 @@ grafana:
 prometheus:
   server:
     nodeSelector: *coreNodeSelector
-    strategy:
-      # RollingUpdate fails because the attached storage can only be mounted on
-      # one pod, so we need to use Recreate that first shut down the pod and
-      # then starts it up during updates.
-      type: Recreate
     resources:
       requests:
         cpu: "2"

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -409,6 +409,11 @@ prometheus:
   rbac:
     create: true
   server:
+    strategy:
+      # The default of RollingUpdate fail because attached storage can only be
+      # mounted on one pod, so we need to use Recreate that first shut down the
+      # pod and then starts it up during updates.
+      type: Recreate
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
In #1734 I tried to fix an issue that I thought would only influence GKE prod with explicit storage for prometheus, but it seems like all the deployments get storage by default and will therefore need this fix.