### PR TITLE
Use Helm 3 to manage GKE prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -161,7 +161,7 @@ jobs:
           - federation_member: prod
             binder_url: https://gke.mybinder.org
             hub_url: https://hub.gke.mybinder.org
-            helm_version: "v2.16.10"
+            helm_version: "v3.3.4"
           - federation_member: turing
             binder_url: https://turing.mybinder.org
             hub_url: https://hub.mybinder.turing.ac.uk


### PR DESCRIPTION
As I've already migrated GKE prod to use Helm3 step by step locally, this is just to ensure that the CI system won't start going back to using Helm2.

The steps taken locally were:

```shell
# update values.yaml and Chart.yaml with image tags etc
chartpress

# ensure helm3 has the chart revision history in the namespace as it expects
helm 2to3 convert --release-versions-max=100 -n cert-manager cert-manager
helm 2to3 convert --release-versions-max=100 -n prod prod

# upgrade cert-manager and the mybinder helm chart releases with helm3
CERT_MANAGER_VERSION=v0.15.2 HELM_VERSION=v3.4.1 ./deploy.py --local
```

There was no need for manually deleting deployments for this as we had already ensured that there were no matchLabels etc of deployments that would change.