### PR TITLE
Test of GitHub Actions lint workflows access to secrets

### DIFF
--- a/mybinder/templates/netpol.yaml
+++ b/mybinder/templates/netpol.yaml
@@ -4,6 +4,9 @@ kind: NetworkPolicy
 metadata:
   name: binder-users
   labels:
+
+
+
     app: binderhub
     component: user-netpol
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
Dummy PR to test what I thought was invalid logic in the linting workflow. The GitHub project's `secrets` will be made available when a pull_request is triggered from any branch it seems though which was something I for a while thought was made available only on the default branch.