### PR TITLE
Double size of Turing's prometheus PVC to 16GiB

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -119,7 +119,8 @@ prometheus:
             - prometheus.mybinder.turing.ac.uk
             - prometheus.turing.mybinder.org
           secretName: turing-prometheus-tls-crt
-
+    persistentVolume:
+      size: 16Gi
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
We maxed out the space on the prometheus PV on Turing. This PR doubles the size of the claim.