### PR TITLE
Use matchLabels for network policies

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -70,10 +70,6 @@ binderhub:
         enabled: true
         replicas: 5
 
-    singleuser:
-      networkPolicy:
-        enabled: false
-
   imageCleaner:
     # Use 40GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 40e9

--- a/mybinder/templates/netpol.yaml
+++ b/mybinder/templates/netpol.yaml
@@ -1,24 +1,29 @@
 {{- if .Values.binderhub.networkPolicy.enabled -}}
+{{- $root := . }}
+{{- range $component := tuple "singleuser-server" "dind" -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: binder-users
+  name: binder-users-{{ $component }}
   labels:
     app: binderhub
     component: user-netpol
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    chart: {{ $root.Chart.Name }}-{{ $root.Chart.Version | replace "+" "_" }}
+    release: {{ $root.Release.Name }}
 spec:
   podSelector:
     # apply this to both places user code runs: dind and singleuser-server
-    matchExpressions:
-      - key: component
-        operator: In
-        values:
-          - singleuser-server
-          - dind
+    # note: Azure NPM doesn't support matchExpressions, so we use a $range
+    # matchExpressions is the right thing to use here, though
+    # matchExpressions:
+    #   - key: component
+    #     operator: In
+    #     values:
+    #       - singleuser-server
+    #       - dind
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ $root.Release.Name }}
+      component: {{ $component }}
   policyTypes:
     - Ingress
     - Egress
@@ -39,17 +44,17 @@ spec:
     # allow access to the world,
     # but not the cluster
     - ports:
-        {{ range $port := .Values.binderhub.networkPolicy.egress.tcpPorts }}
+        {{ range $port := $root.Values.binderhub.networkPolicy.egress.tcpPorts }}
         - port: {{ $port }}
           protocol: TCP
         {{ end }}
       to:
       - ipBlock:
-          cidr: {{ .Values.binderhub.networkPolicy.egress.cidr }}
+          cidr: {{ $root.Values.binderhub.networkPolicy.egress.cidr }}
           except:
             - 169.254.169.254/32
             - 10.0.0.0/8
-          {{- range $ipOrCidr := .Values.binderhub.networkPolicy.egress.bannedIps }}
+          {{- range $ipOrCidr := $root.Values.binderhub.networkPolicy.egress.bannedIps }}
             {{- if (contains $ipOrCidr "/") }}
             - {{ $ipOrCidr }}
             {{- else }}
@@ -67,5 +72,6 @@ spec:
             matchLabels:
               app: nginx-ingress
               component: controller
-
+---
+{{- end }}
 {{- end }}


### PR DESCRIPTION
avoid matchExpressions in network policies

matchExpressions don't work as advertised on AKS ([cross-ref](https://github.com/jupyterhub/mybinder.org-deploy/issues/1468#issuecomment-738797895)).

Instead, produce the same intended result by rendering a separate policy with `matchLabels` for each label (there are only two).

restores default singleuser network policy enforcement on turing, reverting #1715

**EDIT:** my pr tool made a mess!