### PR TITLE
restore network policy on turing

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -70,10 +70,6 @@ binderhub:
         enabled: true
         replicas: 5
 
-    singleuser:
-      networkPolicy:
-        enabled: false
-
   imageCleaner:
     # Use 40GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 40e9


### PR DESCRIPTION
reverts #1715 

with singleuser policy enabled, the result is more restrictive than it should be. With it disabled, it is *less* restrictive than it should be.

Plus, this will make it easier to verify that the next deploy of the turing cluster fixes the issue.

#1744 includes a workaround for AKS, so let's not merge that one if we are still trying to figure out the root of #1468