### PR TITLE
fix path to new deploy key

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -56,8 +56,12 @@ def test_build_binder(binder_url):
     branch = str(time.time())
     repo = 'binderhub-ci-repos/cached-minimal-dockerfile'
 
-    with push_dummy_gh_branch(f'git@github.com:/{repo}.git', branch, os.path.abspath('secrets/binderhub-ci-repos-deploy-key')):
-        build_url = binder_url + f'/build/gh/{repo}/{branch}'
+    with push_dummy_gh_branch(
+        f"git@github.com:/{repo}.git",
+        branch,
+        os.path.abspath("secrets/binderhub-ci-repos-key"),
+    ):
+        build_url = binder_url + f"/build/gh/{repo}/{branch}"
         print(f"building {build_url}")
         r = requests.get(build_url, stream=True)
         r.raise_for_status()


### PR DESCRIPTION
key was renamed in #1735, but path to key in test was not where the new key was added