### PR TITLE
Temporarily remove the Turing from the Federation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -162,10 +162,10 @@ jobs:
             binder_url: https://gke.mybinder.org
             hub_url: https://hub.gke.mybinder.org
             helm_version: "v3.3.4"
-          - federation_member: turing
-            binder_url: https://turing.mybinder.org
-            hub_url: https://hub.mybinder.turing.ac.uk
-            helm_version: "v3.3.4"
+          # - federation_member: turing
+          #   binder_url: https://turing.mybinder.org
+          #   hub_url: https://hub.mybinder.turing.ac.uk
+          #   helm_version: "v3.3.4"
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -7,7 +7,7 @@ letsencrypt:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 80
+      pod_quota: 0
       hub_url: https://hub.mybinder.turing.ac.uk
       badge_base_url: https://mybinder.org
       sticky_builds: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -495,6 +495,6 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
-      weight: 1
+      weight: 0
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions


### PR DESCRIPTION
This PR is removing the Turing from the federation while I redeploy the cluster with a new network policy controller. This should resolve #1468