### PR TITLE
Banning repository due to excessive use

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -61,6 +61,7 @@ binderhub:
         - ^hmharshit/cn-ait.*
         - ^shishirchoudharygic/mltraining.*
         - ^hmharshit/mltraining.*
+        - ^FDesnoyer/MathExp.*
       high_quota_specs:
         - ^jupyterlab/.*
         - ^jupyter/.*


### PR DESCRIPTION
https://github.com/FDesnoyer/MathExp has been using too much CPU
