### PR TITLE
Block a webscraping repo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -62,6 +62,7 @@ binderhub:
         - ^shishirchoudharygic/mltraining.*
         - ^hmharshit/mltraining.*
         - ^FDesnoyer/MathExp.*
+        - ^GuitarsAI/.*
       high_quota_specs:
         - ^jupyterlab/.*
         - ^jupyter/.*


### PR DESCRIPTION
There are several repos in this org that launch lots of headless browsers to
interact with youtube. Posted on their repo to remind them that mybinder.org
isn't meant for this and that they are impacting other users. No response
so far.
