### PR TITLE
Add port 16286 to egress whitelist

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -48,6 +48,7 @@ binderhub:
         - 873 # rsync
         - 1094 # xroot
         - 1095 # xroot
+        - 16286 # Wolfram Engine on-demand licensing
       cidr: 0.0.0.0/0
 
   config:


### PR DESCRIPTION
TCP port 16286 is used by the [Wolfram Engine software](https://www.wolfram.com/engine/) for product licensing functionality, as noted [here](https://support.wolfram.com/12409). When egress on this port is blocked on mybinder.org, repos/images based on the [Wolfram Language kernel](https://github.com/WolframResearch/WolframLanguageForJupyter) can't be run in on-demand licensing mode.