### PR TITLE
ban GuitarsAI fake web scraper github account

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -64,6 +64,9 @@ binderhub:
         - ^hmharshit/mltraining.*
         - ^FDesnoyer/MathExp.*
         - ^GuitarsAI/.*
+        # ferarussia is clearly a fake GitHub account created by GuitarsAI to get around ban
+        # it was created the day GuitarsAI was blocked and does the same thing
+        - ^ferarussia/.*
       high_quota_specs:
         - ^jupyterlab/.*
         - ^jupyter/.*


### PR DESCRIPTION
created the day GuitarsAI was blocked. We should report the GuitarsAI itself as abuse to GitHub and report the violation to YouTube as well.