### PR TITLE
override imagePullPolicy on ovh

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -46,8 +46,15 @@ binderhub:
       registry: https://index.docker.io/v1/
       username: binderhubovh
       email: betatim+ovhhub@gmail.com
+    
+    hub:
+      image:
+        pullPolicy: IfNotPresent
 
     proxy:
+      chp:
+        image:
+          pullPolicy: IfNotPresent
       https:
         type: offload
 
@@ -71,6 +78,13 @@ binderhub:
       userPlaceholder:
         enabled: true
         replicas: 5
+    
+    singleuser:
+      image:
+        pullPolicy: IfNotPresent
+      networkTools:
+        image:
+          pullPolicy: IfNotPresent
 
   imageCleaner:
     # Use 40GB as upper limit, size is given in bytes

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -291,6 +291,7 @@ binderhub:
       initContainers:
         - name: tc-init
           image: minrk/tc-init:0.0.4
+          imagePullPolicy: IfNotPresent
           env:
             - name: WHITELIST_CIDR
               value: 10.0.0.0/8
@@ -482,8 +483,6 @@ federationRedirect:
     retries: 5
     timeout: 2
   load_balancer: "rendezvous"
-  # note: rendezvous load-balancer ignores weights
-  # the only weights that matter are 0 (disabled) and >= 1 (enabled)
   hosts:
     gke:
       prime: true


### PR DESCRIPTION
OVH cluster has the wrong default imagePullPolicy (#1786), so we must specify IfNotPresent a bunch to avoid rate limiting