### PR TITLE
take OVH out of rotation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -497,7 +497,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 10
+      weight: 0
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
OVH is hitting docker pull rate limits due to a bug in the cluster's imagePullPolicy (#1786)

take out of rotation to cool off. #1787 should workaround the bug by explicitly setting `imagePullPolicy: IfNotPresent` where it counts, but it needs time to reset in any case.