### PR TITLE
Increase number of concurrent fetch requests in federation proxy

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -85,6 +85,7 @@ class FailedCheck(Exception):
     until the next interval.
     """
 
+
 def blake2b_hash_as_int(b):
     """Compute digest of the bytes `b` using the Blake2 hash function.
     Returns a unsigned 64bit integer.
@@ -365,7 +366,9 @@ def make_app():
 
 
 def main():
-    AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
+    AsyncHTTPClient.configure(
+        "tornado.curl_httpclient.CurlAsyncHTTPClient", max_clients=32
+    )
     options.define("port", default=8080, help="port to listen on")
     options.parse_command_line()
 


### PR DESCRIPTION
The HTTP client used by the federation proxy can only make 10 concurrent
requests with the default settings. This change increases the limit to
32. There seems to be nearly no downside to increasing this limit by a
small amount like we are doing here. But it might provide shorter wait
times for clients using mybinder.org.

While we don't serve any (very) long running requests from the proxy (they are all handled by the hubs directly) we do serve a lot of assets. Sometimes I observe a long wait/large difference in request time between two otherwise similar assets when loading mybinder.org. This kind of anecdotal evidence is what made me increase the number of concurrent requests we support. I am not quite sure how to measure this before and after to really tell if we improved things or not :-/

For other tornado servers I run which do make very long running outgoing requests setting the `max_clients` parameter to a larger number makes a big difference and I haven't observed any downsides.