### PR TITLE
set maintenance window to weekends

### DIFF
--- a/terraform/modules/mybinder/resource.tf
+++ b/terraform/modules/mybinder/resource.tf
@@ -35,6 +35,18 @@ resource "google_container_cluster" "cluster" {
   remove_default_node_pool = true
   initial_node_count       = 1
 
+  maintenance_policy {
+    # times are UTC
+    # allow maintenance only on weekends,
+    # from late Western Friday night (10pm Honolulu UTC-10)
+    # to early Eastern Monday AM (4am Sydney UTC+11)
+    recurring_window {
+      start_time = "2021-01-02T08:00:00Z"
+      end_time   = "2021-01-03T17:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=SA"
+    }
+  }
+
   network_policy {
     enabled  = true
     provider = "CALICO"

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 }
 
 locals {
-  gke_version        = "1.17.9-gke.1504"
+  gke_version        = "1.17.14-gke.400"
   location           = "us-central1" # for regional clusters
   federation_members = ["gke-old", "gesis", "turing", "ovh"]
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 }
 
 locals {
-  gke_version = "1.17.9-gke.1504"
+  gke_version = "1.17.14-gke.400"
 }
 
 module "mybinder" {


### PR DESCRIPTION
to avoid node auto-upgrades during high traffic periods

from late Friday night UTC-10 to early Monday morning UTC+11

also bump kube version, which has already been auto-upgraded

Already deployed to staging to verify, will deploy to prod after merge