### PR TITLE
Reinstate Turing into the federation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -171,11 +171,11 @@ jobs:
             hub_url: https://hub.gke.mybinder.org
             chartpress_args: ""
             helm_version: ""
-          # - federation_member: turing
-          #   binder_url: https://turing.mybinder.org
-          #   hub_url: https://hub.mybinder.turing.ac.uk
-          #   chartpress_args: ""
-          #   helm_version: ""
+          - federation_member: turing
+            binder_url: https://turing.mybinder.org
+            hub_url: https://hub.mybinder.turing.ac.uk
+            chartpress_args: ""
+            helm_version: ""
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -7,7 +7,7 @@ letsencrypt:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 0
+      pod_quota: 80
       hub_url: https://hub.mybinder.turing.ac.uk
       badge_base_url: https://mybinder.org
       sticky_builds: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -505,7 +505,7 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
-      weight: 0
+      weight: 100
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
   nodeSelector: {}


### PR DESCRIPTION
This PR reverts #1800 and reinstates the Turing

After local running of deploy.py, Turing can't pull the minesweeper pod images, I wonder if this will be resolved when run through CI which runs chartpress?