### PR TITLE
Update Turing's external cluster IP address

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -121,7 +121,7 @@ prometheus:
 ingress-nginx:
   controller:
     service:
-      loadBalancerIP: 20.76.57.82
+      loadBalancerIP: 51.138.65.80
 
 
 static:


### PR DESCRIPTION
The tests failed on Turing after the merger of #1803 since the Cluster IP address had changed and I forgot to update it.