### PR TITLE
disable privilege escalation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -218,6 +218,8 @@ binderhub:
       extraConfig:
         neverRestart: |
           c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
+        noPrivilegeEscalation: |
+          c.KubeSpawner.allow_privilege_escalation = False
         noAuthMetrics: |
           c.JupyterHub.authenticate_prometheus = False
       service:


### PR DESCRIPTION
disallows sudo, etc.

*builds* can create images with sudo access, etc. but we don't need (and shouldn't) allow containers to do this.