### PR TITLE
set DockerRegistry.token_url for ovh

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -9,8 +9,10 @@ binderhub:
       sticky_builds: true
       use_registry: true
       image_prefix: 3i2li627.gra7.container-registry.ovh.net/binder/ovhbhub-
-      # auth config in secrets/config
-
+    DockerRegistry:
+      # Docker Registry uses harbor
+      # ref: https://github.com/goharbor/harbor/wiki/Harbor-FAQs#api
+      token_url: "https://3i2li627.gra7.container-registry.ovh.net/service/token?service=harbor-registry"
 
   replicas: 1
 


### PR DESCRIPTION
OVH uses a harbor registry, we need to set the token url accordingly

I thought this was in #1821, but hadnt pushed my last commit before that was merged.