### PR TITLE
let ovh back into the federation at low capacity

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -3,7 +3,7 @@ projectName: ovh
 binderhub:
   config:
     BinderHub:
-      pod_quota: 60
+      pod_quota: 10
       hub_url: https://hub-binder.mybinder.ovh
       badge_base_url: https://mybinder.org
       sticky_builds: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -505,7 +505,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 10
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
start small, since it has a new local registry which will populate slowly:

- weight 10 (out of 300 + 10)
- pod quota: 10

following docs in #1815 (thanks @sgibson91)

cf #1786