### PR TITLE
give prod CHP a whole CPU

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -42,6 +42,12 @@ binderhub:
 
     proxy:
       nodeSelector: *coreNodeSelector
+      chp:
+        resources:
+          requests:
+            cpu: "1"
+          limits:
+            cpu: "1"
     ingress:
       hosts:
         - hub.mybinder.org


### PR DESCRIPTION
since it's staying maxed out at current 500m cap, let's see what it will actually use, up to a full CPU

when often hitting the limit, reservation should equal limit

Only on prod because all other deployments still use very little