### PR TITLE
Remove OVH from the rotation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -531,7 +531,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 60
+      weight: 0
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
Pulling the k8s-network-tools image from dockerhub is running into the rate limit

I thought we had changed our setup to fetch this and the other support images from the local docker registry?