### PR TITLE
disable jupyterhub chart cloudMetadata init-container

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -294,6 +294,9 @@ binderhub:
         enabled: true
         # replicas set in config/<deployment>
     singleuser:
+      cloudMetadata:
+        # we do this in our own network policy
+        blockWithIptables: false
       networkPolicy:
         enabled: true
         egress: []


### PR DESCRIPTION
we block the same endpoint in our egress network policy, so it should be redundant

plus, this way it's another image we don't need to pull for every user

I'd like to land and verify this (I have done so on OVH with manual pod creation, but I'd like to check the real thing), and then revert #1871 restoring OVH to the cluster.