### PR TITLE
Revert "Remove OVH from the rotation"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -534,7 +534,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 60
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1871

The container image we were fetching from docker hub wasn't needed and got turned off in #1872 -> adding OVH back to the party