### PR TITLE
pin down docutils

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=3.0.1
 recommonmark
 pydata-sphinx-theme==0.1.1
+docutils<0.17 # pin for https://github.com/readthedocs/recommonmark/issues/220


### PR DESCRIPTION
temporary workaround while we wait for upstream fixes for https://github.com/readthedocs/recommonmark/issues/220

I think ~every one of our rtd builds is going to need this...