### PR TITLE
limit concurrent deployment workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,11 @@
 
 name: Continuous Deployment
 
+# only allow one deploy workflow to be running at a time
+# serializes multiple outstanding deploys if PRs are merged before the last deploy finishes
+# ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency: deploy
+
 # Only trigger the workflow when pushing to master or a label is applied to a
 # Pull Request
 on:


### PR DESCRIPTION
serializes multiple outstanding deploys if PRs are merged before the last deploy finishes

to avoid multiple helm deploys racing with each other

I just learned about this checking [the changelog](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/) looking for the upcoming workflow permissions feature, and it seems useful!