### PR TITLE
Scope ingress-nginx to Namespace on Turing

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -121,7 +121,7 @@ prometheus:
 ingress-nginx:
   controller:
     service:
-      loadBalancerIP: 51.138.65.80
+      loadBalancerIP: 20.76.176.114
     scope:
       enabled: true
 

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -122,6 +122,8 @@ ingress-nginx:
   controller:
     service:
       loadBalancerIP: 51.138.65.80
+    scope:
+      enabled: true
 
 
 static:


### PR DESCRIPTION
This PR forces the ingress-nginx sub-chart to only look for ingresses in the deployment namespace. this is to avoid collisions with the Hub23 deployment also running on the cluster, which also has ingress-nginx as a sub-chart, as detailed in https://github.com/jupyterhub/mybinder.org-deploy/issues/1870#issuecomment-820388311 (Same fix has been applied to Hub23)