### PR TITLE
Revert "binderhub: 0.2.0-n557.h46ddaac...0.2.0-n562.h0b4462c"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -44,5 +44,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n562.h0b4462c
+    version: 0.2.0-n557.h46ddaac
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1898

Build pods were hanging/not starting with:
```
Warning  FailedMount  17m (x11 over 61m)  kubelet, gke-prod-user-202009-b9c03ca0-vivm  Unable to attach or mount volumes: unmounted volumes=[docker-push-secret], unattached volumes=[docker-socket docker-push-secret default-token-jcbqc]: timed out waiting for the condition
```