### PR TITLE
prometheus can't have 24G RAM

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -116,10 +116,10 @@ prometheus:
     resources:
       requests:
         cpu: "2"
-        memory: 24Gi
+        memory: 20Gi
       limits:
         cpu: "2"
-        memory: 24Gi
+        memory: 20Gi
     persistentVolume:
       # Use a large SSD Volume in production
       size: 2000Gi


### PR DESCRIPTION
oops! that's more than a core node has
