### PR TITLE
increase ovh prometheus server storage

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -122,7 +122,7 @@ grafana:
 prometheus:
   server:
     persistentVolume:
-      size: 20Gi
+      size: 50Gi
     retention: 60d
     ingress:
       annotations:


### PR DESCRIPTION
20Gi is crashing with out of space errors, so increase to 50

I'm not actually sure if this will resize the PV or not, but deleting the PV won't be a huge loss if we need to recreate it