### PR TITLE
Fix outdated configuration reference (nginx -> traefik -> not relevant and removed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 config/common/datacenter-*.yaml
 mybinder/charts
 mybinder/requirements.lock
+mybinder/Chart.lock
 
 .ipynb_checkpoints
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -254,6 +254,9 @@ binderhub:
       chp:
         # FIXME: remove when hub chart dependency is bumped
         # to include https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2081
+        #
+        # This is when we update to a binderhub that reference z2jh 1.0.0 instead of z2jh 0.11.1.
+        #
         image:
           tag: 4.3.1
         networkPolicy:
@@ -274,7 +277,7 @@ binderhub:
           # - --default-target=http://$(PROXY_PATCHES_SERVICE_HOST):$(PROXY_PATCHES_SERVICE_PORT)
           - --error-target=http://$(PROXY_PATCHES_SERVICE_HOST):$(PROXY_PATCHES_SERVICE_PORT)/hub/error
           - --log-level=error
-      nginx:
+      traefik:
         resources:
           requests:
             memory: 512Mi

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -277,14 +277,6 @@ binderhub:
           # - --default-target=http://$(PROXY_PATCHES_SERVICE_HOST):$(PROXY_PATCHES_SERVICE_PORT)
           - --error-target=http://$(PROXY_PATCHES_SERVICE_HOST):$(PROXY_PATCHES_SERVICE_PORT)/hub/error
           - --log-level=error
-      traefik:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: "0.25"
-          limits:
-            memory: 512Mi
-            cpu: 1
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
I was trying out https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2200 which includes a schema validation that can also detect references to values that aren't recognized. Just using `helm template .` made me spot this reference to `nginx` in the JupyterHub helm chart configuration. This probably refers to `traefik` which is now running in the autohttps pod rather than `nginx` which was running there before (perhaps 0.9.X or earlier).
