### PR TITLE
Add @callummole to list of secret holders

### DIFF
--- a/docs/source/getting_started/production_environment.md
+++ b/docs/source/getting_started/production_environment.md
@@ -281,7 +281,8 @@ People who currently have the git-crypt secret include:
 - @sgibson91
 - @bitnik
 - @arnim
-- @MridulS.
+- @MridulS
+- @callummole
 - *add yourself here if you have it*
 
 Contact one of them if you need access to the git-crypt key.


### PR DESCRIPTION
I've passed the git-crypt secret to @callummole so he can edit Turing secrets if required