### PR TITLE
Pin Sphinx and other docs deps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.0.1
+sphinx==4.0.1
 recommonmark
 pydata-sphinx-theme==0.1.1
 docutils<0.17 # pin for https://github.com/readthedocs/recommonmark/issues/220

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.0.1
-recommonmark
+recommonmark==0.7.1
 pydata-sphinx-theme==0.1.1
-docutils<0.17 # pin for https://github.com/readthedocs/recommonmark/issues/220
+docutils==0.16 # 0.17 breaks https://github.com/readthedocs/recommonmark/issues/220


### PR DESCRIPTION
Sphinx 4.0.2 has broken the docs build: https://github.com/jupyterhub/mybinder.org-deploy/pull/1912#issuecomment-850399699

To avoid problems like this in future this PR pins all docs dependencies and configures dependabot to bump versions for docs only.