### PR TITLE
bump prometheus memory limit to 23G

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -119,7 +119,8 @@ prometheus:
         memory: 20Gi
       limits:
         cpu: "2"
-        memory: 20Gi
+        # 20Gi isn't enough to rebuild WAL on startup
+        memory: 23Gi
     persistentVolume:
       # Use a large SSD Volume in production
       size: 2000Gi


### PR DESCRIPTION
WAL startup needs more than 20G, node limit is 24

we are getting close to needing bigger core nodes just for prometheus

cc @betatim 