### PR TITLE
Increase prometheus memory limit and remove node selector

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -111,16 +111,16 @@ grafana:
 
 prometheus:
   server:
-    nodeSelector: *coreNodeSelector
-    livenessProbeInitialDelay: 600
+    #nodeSelector: *coreNodeSelector
+    livenessProbeInitialDelay: 800
     resources:
       requests:
-        cpu: "2"
-        memory: 20Gi
+        cpu: "4"
+        memory: 30Gi
       limits:
-        cpu: "2"
+        cpu: "4"
         # 20Gi isn't enough to rebuild WAL on startup
-        memory: 23Gi
+        memory: 33Gi
     persistentVolume:
       # Use a large SSD Volume in production
       size: 2000Gi


### PR DESCRIPTION
Let's see if we can use a user node pool instance and more RAM to get
prometheus to start again. This will make debugging easier. Long term we
need a solution where pprometheus uses less memory.

Follow up PR to #1924 