### PR TITLE
Set prometheus data retention limit to 30 days

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -123,7 +123,7 @@ prometheus:
   server:
     persistentVolume:
       size: 50Gi
-    retention: 60d
+    retention: 30d
     ingress:
       annotations:
         kubernetes.io/ingress.class: nginx

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -125,7 +125,7 @@ prometheus:
       # Use a large SSD Volume in production
       size: 2000Gi
       storageClass: ssd
-    retention: 60d
+    retention: 30d
     ingress:
       hosts:
         - prometheus.mybinder.org

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -103,6 +103,7 @@ grafana:
 
 prometheus:
   server:
+    retention: 30d
     ingress:
       annotations:
         kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Some clusters had no limit, others used 60days. Lets shorten it to 30 to
see if this helps reduce disk usage as well as memory consumption.

cc @minrk 