### PR TITLE
Bump prometheus persitentVolume size on Tuting to 32GiB

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -117,7 +117,7 @@ prometheus:
             - prometheus.turing.mybinder.org
           secretName: turing-prometheus-tls-crt
     persistentVolume:
-      size: 16Gi
+      size: 32Gi
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
After a recent deploy, Turing's prometheus server failed to rollout in time with the following error:

```
level=error ts=2021-06-22T14:31:25.917Z caller=main.go:787 err="opening storage failed: open /data/wal/00000890: no space left on device"
```

This PR tries to overcome this by increasing the size of the persistent volume for prometheus