### PR TITLE
Revert "Bump prometheus persistentVolume size on Turing to 32GiB"

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -117,7 +117,7 @@ prometheus:
             - prometheus.turing.mybinder.org
           secretName: turing-prometheus-tls-crt
     persistentVolume:
-      size: 32Gi
+      size: 16Gi
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1938