### PR TITLE
Revert "Revert "Bump prometheus persistentVolume size on Turing to 32GiB""

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -117,7 +117,7 @@ prometheus:
             - prometheus.turing.mybinder.org
           secretName: turing-prometheus-tls-crt
     persistentVolume:
-      size: 16Gi
+      size: 32Gi
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1939 (re-applies #1938)

After this, if the resize fails, we can delete the pv to force a new volume creation