### PR TITLE
Revert "binderhub: 0.2.0-n577.h14cc6c7...0.2.0-n590.h9f942c5"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -44,5 +44,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n590.h9f942c5
+    version: 0.2.0-n577.h14cc6c7
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1943 deploying build tokens, which are preventing launch through the federation proxy