### PR TITLE
Upgrade to z2jh 1.0

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -50,8 +50,8 @@ binderhub:
       nodeSelector: *coreNodeSelector
 
     proxy:
-      nodeSelector: *coreNodeSelector
       chp:
+        nodeSelector: *coreNodeSelector
         resources:
           requests:
             cpu: "1"

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -24,9 +24,6 @@ binderhub:
       - turing.mybinder.org
     annotations:
       kubernetes.io/ingress.class: nginx
-      https:
-        enabled: true
-        type: nginx
     tls:
       - secretName: turing-binder-tls-crt
         hosts:
@@ -51,9 +48,6 @@ binderhub:
       annotations:
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
-        https:
-          enabled: true
-          type: nginx
       hosts:
         - hub.mybinder.turing.ac.uk
       tls:

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -44,5 +44,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n600.h36369a7
+    version: 0.2.0-n604.h9bc978a
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Moved as part of z2jh 1.0

- Deploys following binderhub changes: https://github.com/jupyterhub/binderhub/compare/36369a7...9bc978a
- Fixes validation error from moving to z2jh v1.0
- Remove invalid annotations in turing cluster