### PR TITLE
Remove note about not being able to deploy Chart.yaml changes only to staging

### DIFF
--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -177,6 +177,12 @@ master.
 
 ### Deploying to *only* `staging`
 
+```eval_rst
+.. note::
+    Currently, only pull requests from a branch on the `jupyterhub/mybinder.org-deploy` repo
+    can be deployed to staging, not pull requests from forks.
+```
+
 Sometimes you want to test out a deployment live before you make a deployment
 to `prod`.
 

--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -177,10 +177,6 @@ master.
 
 ### Deploying to *only* `staging`
 
-```eval_rst
-.. note::
-   Currently you cannot deploy changes to `mybinder/Chart.yaml` only to staging.
-```
 Sometimes you want to test out a deployment live before you make a deployment
 to `prod`.
 


### PR DESCRIPTION
I did exactly this in #1953 so it seems to work okay. Is there anything I missed, or is this just an out-of-date note?