### PR TITLE
Use a staging environment to test PRs from forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,8 +36,13 @@ jobs:
   # In this dedicated job to deploy our staging environment we build and push
   # images that the jobs to deploy to the production environments depend on.
   staging-deploy:
+    # Run this job in the staging environment
+    # This means that PRs from forks can be tested on staging before being merged
+    environment: staging
     # Only run the job if the 'test-staging' label is present OR if the event
     # is a push to master
+    # NOTE: Could deprecate the ''test-staging'' label in favour of the environment
+    # above
     if: |
       (github.event.label.name == 'test-staging') ||
       ((github.event_name == 'push') &&

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,8 +41,6 @@ jobs:
     environment: staging
     # Only run the job if the 'test-staging' label is present OR if the event
     # is a push to master
-    # NOTE: Could deprecate the ''test-staging'' label in favour of the environment
-    # above
     if: |
       (github.event.label.name == 'test-staging') ||
       ((github.event_name == 'push') &&


### PR DESCRIPTION
This PR adds a staging environment to our Continuous Deployment workflow. This will allow us to test PRs that come from forks on the staging cluster. When a PR is opened the `jupyterhub/mybinder-org-operators` team will be notified to approve the run in the environment.

Draft for now until I've added the secrets to the env :grin: