### PR TITLE
Fix OVH YAML to not override z2jh defaults

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -44,9 +44,6 @@ binderhub:
           - binder.mybinder.ovh
 
   jupyterhub:
-    imagePullSecret:
-      # config in secrets/config
-
     hub:
       image:
         pullPolicy: IfNotPresent
@@ -57,7 +54,6 @@ binderhub:
           pullPolicy: IfNotPresent
       https:
         type: offload
-
 
     ingress:
       annotations:


### PR DESCRIPTION
If you for example have a config like...

```yaml
# dummy-test-values.yaml
hub:
proxy:
  secretToken: asdfasdf
```

It would override z2jh's default values for hub.

```shell
# example executed from z2jh folder

tools/generate-json-schema.py

helm template ./jupyterhub --values dummy-test-values.yaml

Error: values don't meet the specifications of the schema(s) in the following chart(s):
jupyterhub:
- (root): hub is required
```

---

This PR fixes a situation where imagePullSecret was set like `hub` is set in the example above. It didn't cause much of an issue as there was another secret config file setting all values of relevance  explicitly for the imagePullSecret dictionary - i think.

Let's not have it configured like this anyhow so a practice like this isn't normalized as it often cause problems.