### PR TITLE
Revert "Use a staging environment to test PRs from forks"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,9 +36,6 @@ jobs:
   # In this dedicated job to deploy our staging environment we build and push
   # images that the jobs to deploy to the production environments depend on.
   staging-deploy:
-    # Run this job in the staging environment
-    # This means that PRs from forks can be tested on staging before being merged
-    environment: staging
     # Only run the job if the 'test-staging' label is present OR if the event
     # is a push to master
     if: |


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#1959

environments don't seem to allow us to *expand* access to secrets, which is what we were after.

What we learned: environments are useful for creating *collections* of secrets for workflows, but all environments have the same "only from branches on this repo" restriction, which is what we were trying to deal with. Since our secrets are the same in both contexts, it's not helpful to duplicate them into two environments.