### PR TITLE
fix roxy-patches secret key

### DIFF
--- a/mybinder/templates/proxy-patches/deployment.yaml
+++ b/mybinder/templates/proxy-patches/deployment.yaml
@@ -67,5 +67,5 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: hub
-                key: proxy.token
+                key: hub.config.ConfigurableHTTPProxy.auth_token
 {{- end }}


### PR DESCRIPTION
token moved, not just the secret name
