### PR TITLE
Allocate resources for PyHEP 2021 2020-07-05 tutorial

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -85,6 +85,11 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
+        - pattern: ^henryiii/level-up-your-python.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1975
+          # 2021-07-05 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#53-level-up-your-python-part-i
+          config:
+            quota: 500
       # - pattern: ^github-owner/github-repo-prefix.*
       #   # YYYY-MM-DD of workshop
       #   config:


### PR DESCRIPTION
xref: #1975

This PR allocates 500 pods for the "Level Up Your Python" tutorial by @henryiii on [day 1 of PyHEP 2021 (2021-07-05)](https://indico.cern.ch/event/1019958/timetable/#day-2021-07-05).

This request is an overestimate, but @henryiii's tutorials have a history of being quite popular. All following requests for the workshop will be smaller (probably 300 pods) and if 500 is too much we can back it down. We will also ask CERN to see if their BinderHub can be used (cc @rochaporto @lukasheinrich).

@matthewfeickert will be monitoring the Grafana (can you remind me of the link?) to ensure the load stays reasonable.

cc @sgibson91 (per request in https://github.com/jupyterhub/team-compass/issues/400) @betatim @choldgraf