### PR TITLE
Allocate resources for all PyHEP 2021 talks and tutorials

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -85,11 +85,64 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 128
+        # 2021-07-05
         - pattern: ^henryiii/level-up-your-python.*
           # https://github.com/jupyterhub/mybinder.org-deploy/issues/1975
           # 2021-07-05 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#53-level-up-your-python-part-i
           config:
             quota: 500
+        # 2021-07-06
+        - pattern: ^b-fontana/PyHEP21BokehPresentation.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1972
+          # 2021-07-06 PyHEP 2021 https://indico.cern.ch/event/1019958/contributions/4420290/
+          config:
+            quota: 300
+        - pattern: ^pyhf/pyhep-2021-notebook-talk.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1950
+          # 2021-07-06 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#24-distributed-statistical-inf
+          config:
+            quota: 300
+        - pattern: ^alexander-held/PyHEP-2021-cabinetry.*
+          # 2021-07-06 PyHEP 2021 https://indico.cern.ch/event/1019958/contributions/4421868/
+          config:
+            quota: 300
+        - pattern: ^jpivarski-talks/2021-07-06-pyhep-uproot-awkward-tutorial.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1948
+          # 2021-07-06 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#58-uproot-and-awkward-array-tu
+          config:
+            quota: 300
+        - pattern: ^GilesStrong/talk_pyhep21_pytorch_inferno.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1949
+          # 2021-07-06 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#21-pytorch-inferno
+          config:
+            quota: 300
+        # 2021-07-07
+        - pattern: ^zfit/PyHEP2021.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1974
+          # 2021-07-07 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#10-zfit-introduction-minimizat
+          config:
+            quota: 300
+        - pattern: ^lovaslin/pyHEP-notebook-talk.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1973
+          # 2021-07-07 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#6-pybumphunter-a-model-agnosti
+          config:
+            quota: 300
+        - pattern: ^AndreScaffidi/Natpy_pyhep_2021.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1970
+          # 2021-07-07 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#25-introduing-natpy-a-simple-a
+          config:
+            quota: 300
+        # 2021-07-08
+        - pattern: ^dnicotra/pyhep2021-qml4jet.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1971
+          # 20201-07-08 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#5-quantum-machine-learning-for
+          config:
+            quota: 300
+        - pattern: ^irinaespejo/excursion.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/1947
+          # 20201-07-08 PyHEP 2021 https://indico.cern.ch/event/1019958/timetable/#14-active-learning-for-level-s
+          config:
+            quota: 300
       # - pattern: ^github-owner/github-repo-prefix.*
       #   # YYYY-MM-DD of workshop
       #   config:


### PR DESCRIPTION
Following @manics's recommendation in https://github.com/jupyterhub/mybinder.org-deploy/issues/1947#issuecomment-873577455 this PR allocates 300 pods per talk or tutorial for [days 2 through 5 of PyHEP 2021 (2021-07-06 through 2021-07-09)](https://indico.cern.ch/event/1019958/timetable/).

* 2021-07-05 xref: PR #1976
* 2021-07-06 xref: #1972, #1950, #1948, #1949
* 2021-07-07 xref: #1974, #1973, #1970
* 2021-07-08 xref: #1971, #1947

(This PR is currently in draft mode to account for any straggling presenters who haven't gotten us their GitHub repo links yet, but the Binder team PR reviewers should feel free to override that and merge at their leisure.)

cc @sgibson91 (per request in https://github.com/jupyterhub/team-compass/issues/400) @manics

---

I'll open a follow up PR that will deallocate all resources and close all Issues after the workshop ends on 2021-07-09