### PR TITLE
Stop generating datacenter IP ban lists

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,10 +112,6 @@ jobs:
           curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION=${HELM_VERSION} bash
           helm dependency update ./mybinder
 
-      - name: Collect datacenter addresses
-        run: |
-          python scripts/datacenters.py
-
       # Action Repo: https://github.com/sliteteam/github-action-git-crypt-unlock
       - name: "Stage 2: Unlock git-crypt secrets"
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
@@ -243,10 +239,6 @@ jobs:
         run: |
           curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION=${HELM_VERSION} bash
           helm dependency update ./mybinder
-
-      - name: Collect datacenter addresses
-        run: |
-          python scripts/datacenters.py
 
       - name: "Stage 2: Unlock git-crypt secrets"
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b

--- a/.github/workflows/lint-validate.yml
+++ b/.github/workflows/lint-validate.yml
@@ -102,10 +102,6 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
-      - name: Collect datacenter addresses
-        run: |
-          python scripts/datacenters.py
-
       - name: Run chartpress to update values.yaml
         run: |
           chartpress --skip-build


### PR DESCRIPTION
With the new build token approach we can test what happens in terms of
abuse levels if we allow traffic from cloud providers again. This commit
removes the script that generates the lists of IPs used by cloud
providers. As a result the ban should end.