### PR TITLE
Use test-this-pr action for Pull Requests made from forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
       (github.event.label.name == 'test-staging') ||
       ((github.event_name == 'push') &&
       (github.ref == 'refs/heads/master')) ||
-      ((github.even_name == 'push') &&
+      ((github.event_name == 'push') &&
       contains(github.ref, 'test-this-pr'))
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,10 +41,8 @@ jobs:
     # is a push to master
     if: |
       (github.event.label.name == 'test-staging') ||
-      ((github.event_name == 'push') &&
-      (github.ref == 'refs/heads/master')) ||
-      ((github.event_name == 'push') &&
-      contains(github.ref, 'test-this-pr'))
+      ((github.event_name == 'push') && (github.ref == 'refs/heads/master')) ||
+      ((github.event_name == 'push') && contains(github.ref, 'test-this-pr'))
     runs-on: ubuntu-20.04
 
     strategy:
@@ -273,3 +271,70 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: pytest -vx --numprocesses=2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }} tests/
+
+  report-status:
+    # This job will wait for staging-deploy to finish and report its status
+    #
+    # This job will only run on push events made to test-this-pr/** branches
+    if: github.event_name == 'push' && contains(github.ref, 'test-this-pr')
+    runs-on: ubuntu-latest
+    steps:
+      # Poll the GitHub REST API and wait for staging-deploy job to finish
+      - name: Wait for staging-deploy completion
+        id: staging-deploy-status
+        shell: bash
+        run: |
+          STATUS=""
+          CONCLUSION=""
+
+          while [ "$STATUS" != "completed" ]; do
+            RESPONSE=$(curl --silent --request GET \
+              --url 'https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs' \
+              --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'Accept: application/vnd.github.v3+json')
+
+            STATUS=$(echo $RESPONSE | jq -r '.jobs[] | select(.name=="staging-deploy") | .status')
+            echo "Status: $STATUS"
+
+            if [[ "$STATUS" == "completed" ]]; then
+              CONCLUSION=$(echo $RESPONSE | jq -r '.jobs[] | select(.name=="staging-deploy") | .conclusion')
+              echo "Conclusion: $CONCLUSION"
+            else
+              sleep 30s
+            fi
+          done
+
+          echo "::set-output name=status::$STATUS"
+          echo "::set-output name=conclusion::$CONCLUSION"
+
+      - name: Set PR number as variable
+        id: get-pr-number
+        shell: bash
+        run: |
+          PR_NUM=$(echo ${{ github.ref }} | awk -F'/' '{print $NF}')
+          echo "::set-output name=prnum::$PR_NUM"
+
+      - name: Comment on PR with Job Status and delete the test branch
+        if: ${{ steps.staging-deploy-status.outputs.status }} == 'completed'
+        uses: actions/github-script@v4.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var JOB_STATUS = process.env.JOB_STATUS;
+            var PR_NUMBER = process.env.PR_NUMBER;
+
+            github.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/test-this-pr/${PR_NUMBER}`
+            })
+
+            github.issues.createComment({
+              issue_number: PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Job status:** ${JOB_STATUS}\nBranch 'test-this-pr/${PR_NUMBER}' has been deleted`
+            })
+        env:
+          JOB_STATUS: ${{ steps.staging-deploy-status.outputs.conclusion }}
+          PR_NUMBER: ${{ steps.get-pr-number.outputs.prnum }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - master
+      - test-this-pr/**
   pull_request:
     types: [labeled]
 
@@ -41,7 +42,9 @@ jobs:
     if: |
       (github.event.label.name == 'test-staging') ||
       ((github.event_name == 'push') &&
-      (github.ref == 'refs/heads/master'))
+      (github.ref == 'refs/heads/master')) ||
+      ((github.even_name == 'push') &&
+      contains(github.ref, 'test-this-pr'))
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/test-this-pr.yml
+++ b/.github/workflows/test-this-pr.yml
@@ -1,11 +1,11 @@
-name: Test a Pull Request from a fork
+name: Run test-this-pr action
 
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  test-this-pr:
+  run-test-this-pr:
     runs-on: ubuntu-latest
     if: |
       (github.event.issue.pull_request != null) &&
@@ -14,8 +14,7 @@ jobs:
         github.event.comment.author_association,
         ['OWNER', 'COLLABORATOR', 'MEMBER']
       )
-
     steps:
-      - uses: sgibson91/thest-this-pr-action@main
+      - uses: sgibson91/test-this-pr-action@main
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/test-this-pr.yml
+++ b/.github/workflows/test-this-pr.yml
@@ -1,0 +1,21 @@
+name: Test a Pull Request from a fork
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  test-this-pr:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.issue.pull_request != null) &&
+      contains(github.event.comment.body, '/test-this-pr') &&
+      contains(
+        github.event.comment.author_association,
+        ['OWNER', 'COLLABORATOR', 'MEMBER']
+      )
+
+    steps:
+      - uses: sgibson91/thest-this-pr-action@main
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/test-this-pr.yml
+++ b/.github/workflows/test-this-pr.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   run-test-this-pr:
+    # Run this job in an env where the token with elevated permissions is stored
+    environment: test-this-pr-env
     runs-on: ubuntu-latest
     if: |
       (github.event.issue.pull_request != null) &&
@@ -17,4 +19,4 @@ jobs:
     steps:
       - uses: sgibson91/test-this-pr-action@main
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.TEST_THIS_PR_ACCESS_TOKEN }}

--- a/docs/source/deployment/how.md
+++ b/docs/source/deployment/how.md
@@ -177,23 +177,26 @@ master.
 
 ### Deploying to *only* `staging`
 
-```eval_rst
-.. note::
-    Currently, only pull requests from a branch on the `jupyterhub/mybinder.org-deploy` repo
-    can be deployed to staging, not pull requests from forks.
-```
+Sometimes you want to test out a deployment live before you make a deployment to `prod`.
+There are a few ways we can achieve this.
 
-Sometimes you want to test out a deployment live before you make a deployment
-to `prod`.
+#### Testing Pull Requests from **branches** of `mybinder.org-deploy`
 
-This simplest way to achieve this is to apply the `test-staging` label to an open PR. This will trigger GitHub Actions to deploy the changes in the PR to the staging cluster **only**.
+This simplest way to deploy a PR to staging only is to apply the `test-staging` label to an open PR. This will trigger GitHub Actions to deploy the changes in the PR to the staging cluster **only**.
 
 ```eval_rst
 .. note::
    If you need to re-deploy the changes in a PR to staging only, then the label will need to be removed and then re-added.
 ```
 
-Another way to achieve this is by editing `staging`-only config files. To deploy
+#### Testing Pull Requests from **forks** of `mybinder.org-deploy`
+
+If the PR has been made from a fork of the repo, the labelling approach discussed in the previous section will fail due to a lack of access to secrets.
+In this scenario, a user with `OWNER`, `COLLABORATOR` or `MEMBER` association with the `mybinder.org-deploy` repo can leave a `/test-this-pr` comment on the PR to trigger a deploy to staging.
+
+#### Editing staging config directly
+
+The final option to deploy to staging only is by editing `staging`-only config files. To deploy
 to staging only, follow these steps:
 
 1. Make changes to [`config/staging.yaml`](https://github.com/jupyterhub/mybinder.org-deploy/blob/master/config/staging.yaml)
@@ -216,8 +219,6 @@ to staging only, follow these steps:
 
 The [what](./what.html) document has more details on common ways deployments can go
 wrong, and how to debug them.
-
-
 ## Changing the mybinder.org infrastructure
 
 Sometimes we need to make changes to the mybinder.org core infrastructure.


### PR DESCRIPTION
### The Problem

Our usual workflow is "fork the repo -> develop -> open PR". The only downside to this is that repository secrets are not made available to PRs from forks by default. However, sometimes we want to be able to test a PR in our staging environment before merging and deploying for real.

### What does this PR do?

We add the `test-this-pr.yml` workflow file which will run the [`test-this-pr-action`](https://github.com/sgibson91/test-this-pr-action) (written by me) when triggered by a comment containing `/test-this-pr` left by someone with appropriate rights to the repo (OWNER, COLLABORATOR, MEMBER).

This action basically takes the `pull/{PR_NUM}/merge` ref and creates a new branch in **this** repo called `test-this-pr/{PR_NUM}`. The `staging-deploy` job in `cd.yaml` has now been configured to be triggered by **both** pushes to `master` and `test-this-pr/**` branches, so it will start running and now have access to secrets! The action will also leave a comment on the original PR with a link to the GitHub Actions page of the branch to track progress.

A `report-status` job has also been added to the `cd.yml` file which will **only run on pushes to `test-this-pr/**` branches**. This job will poll the GitHub REST API to check when `staging-deploy` has completed. Upon receiving confirmation that the job has finished, it will post a `success` or `failure` comment to the original PR and then delete the `test-this-pr` branch that was created by the `test-this-pr-action`. This is so that the single source of truth is **always** the original PR, not any automatically generated branches.

Multiple `/test-this-pr` comments can be left on the same PR.

### Some quirks

We need a GitHub PAT with `public_repo` scope to pass to `test-this-pr-action`. While giving the `GITHUB_TOKEN` [write permissions on contents and pull requests](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions) would actually satisfy our requirements, GitHub has configured Actions such that [workflows cannot be triggered by events that were authenticated by `GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow). In short, `staging-deploy` won't run _even though_ a push to a `test-this-pr/**` branch has been made if we use `GITHUB_TOKEN`.

As a result of using a PAT, the comment made by the `test-this-pr-action` will look like it came from whoever provided the PAT. I don't think this is a major issue and I also don't mind providing the PAT, but just thought I'd highlight this quirk.

### Testing

You can see all the work I did to test this workflow in this repo: https://github.com/binderhub-test-org/pr-test