### PR TITLE
JupyterLab 3.0: bump image prefix across the federation

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -8,7 +8,7 @@ binderhub:
       badge_base_url: https://mybinder.org
       sticky_builds: true
       use_registry: true
-      image_prefix: 3i2li627.gra7.container-registry.ovh.net/binder/ovhbhub-
+      image_prefix: 3i2li627.gra7.container-registry.ovh.net/binder/ovhbhub-r2d-g5b5b759
     DockerRegistry:
       # Docker Registry uses harbor
       # ref: https://github.com/goharbor/harbor/wiki/Harbor-FAQs#api

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -5,7 +5,7 @@ binderhub:
     BinderHub:
       hub_url: https://hub.gke2.staging.mybinder.org
       badge_base_url: https://staging.mybinder.org
-      image_prefix: gcr.io/binderhub-288415/r2d-staging-72d7634-
+      image_prefix: gcr.io/binderhub-288415/r2d-staging-g5b5b759-
       sticky_builds: true
       build_memory_limit: "2G"
   extraEnv:

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -13,7 +13,7 @@ binderhub:
       sticky_builds: true
       # Docker Hub registry for Turing
       use_registry: true
-      image_prefix: turingmybinder/binder-prod-
+      image_prefix: turingmybinder/binder-prod-r2d-g5b5b759-
 
   replicas: 1
 

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -44,5 +44,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n671.hbe94c46
+    version: 0.2.0-n676.h0cbee48
     repository: https://jupyterhub.github.io/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -98,7 +98,7 @@ binderhub:
         - ^(git|https?)%3A%2F%2Fnotabug.org%2FulslcuRux3Y%2F.*
     BinderHub:
       use_registry: true
-      build_image: quay.io/jupyterhub/repo2docker:2021.08.0-8.gf1d01b6
+      build_image: quay.io/jupyterhub/repo2docker:2021.08.0-10.g5b5b759
       per_repo_quota: 100
       per_repo_quota_higher: 200
       build_memory_limit: "3G"


### PR DESCRIPTION
The order these things should be done in (they can be simultaneous, but some should not be before others):

1. update jupyterlab default UI in repo2docker (merged https://github.com/jupyterhub/repo2docker/pull/1035)
2. invalidate image cache by bumping image prefix (this pr). Cache should be invalidated with/after the r2d bump so we can assume new builds have lab 3.1.
3. bump binderhub filepath handling to use jupyterlab https://github.com/jupyterhub/binderhub/pull/1288 . This change is where we start to *apply* the assumption that cached builds have jupyterlab 3, and provide consistent UI for both filepath and default URLs.

This PR currently does all 3 (includes #2011 and #2014)

Purging the image cache means *lots* of new builds, and we will probably want to sweep out our old cache (related: #2012)
