### PR TITLE
test-this-pr: fix author_association check

### DIFF
--- a/.github/workflows/test-this-pr.yml
+++ b/.github/workflows/test-this-pr.yml
@@ -13,8 +13,8 @@ jobs:
       (github.event.issue.pull_request != null) &&
       contains(github.event.comment.body, '/test-this-pr') &&
       contains(
-        github.event.comment.author_association,
-        ['OWNER', 'COLLABORATOR', 'MEMBER']
+        fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'),
+        github.event.comment.author_association
       )
     steps:
       - uses: sgibson91/test-this-pr-action@main


### PR DESCRIPTION
arguments to contains were reversed - we want `if author_association in ['owner', etc.]`

contains wants the container as the first argument, and item to check for as the second

also, for some reason workflow syntax doesn't allow array literal as argument to contains, so I had to use `fromJSON` to construct the array. :shrug:
