### PR TITLE
test-this-pr: fix check for staging-deploy in wait-for-result

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -293,11 +293,11 @@ jobs:
               --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
               --header 'Accept: application/vnd.github.v3+json')
 
-            STATUS=$(echo $RESPONSE | jq -r '.jobs[] | select(.name=="staging-deploy") | .status')
+            STATUS=$(echo $RESPONSE | jq -r '.jobs[] | select(.name | startswith("staging-deploy")) | .status')
             echo "Status: $STATUS"
 
             if [[ "$STATUS" == "completed" ]]; then
-              CONCLUSION=$(echo $RESPONSE | jq -r '.jobs[] | select(.name=="staging-deploy") | .conclusion')
+              CONCLUSION=$(echo $RESPONSE | jq -r '.jobs[] | select(.name | startswith("staging-deploy")) | .conclusion')
               echo "Conclusion: $CONCLUSION"
             else
               sleep 30s


### PR DESCRIPTION
matrix values are added to the job name, so it ends up as `staging-deploy (staging.gke.mybinder.org, ...)` instead of just `staging-deploy`

use startswith to select the job, instead