### PR TITLE
use 503 error code for requests to stopped servers

### DIFF
--- a/mybinder/templates/proxy-patches/configmap.yaml
+++ b/mybinder/templates/proxy-patches/configmap.yaml
@@ -8,15 +8,15 @@ data:
     server {
       listen 80;
 
-      # Return 404 for anything that comes here
+      # Return 424 for anything that comes here
       # serve an informative error about stopped pods
-      error_page 404 /404.html;
-      location /404.html {
+      error_page 424 /424.html;
+      location /424.html {
         root /srv/proxy-patches;
         internal;
       }
       location / {
-        return 404;
+        return 424;
       }
     }
 
@@ -26,7 +26,7 @@ apiVersion: v1
 metadata:
   name: proxy-html-files
 data:
-  404.html: >
+  424.html: >
     <html>
     <head>
     <title>Binder not found</title>
@@ -37,7 +37,7 @@ data:
     <div class="container">
     <h2 class="text-center">Oops!</h2>
     <h3 class="text-center">We can't seem to find the Binder page you are looking for.</h3>
-    <h4>404 error</h4>
+    <h4>424 error</h4>
     <p>
     Here are some helpful tips.
     </p>

--- a/mybinder/templates/proxy-patches/configmap.yaml
+++ b/mybinder/templates/proxy-patches/configmap.yaml
@@ -8,15 +8,15 @@ data:
     server {
       listen 80;
 
-      # Return 424 for anything that comes here
+      # Return 503 for anything that comes here
       # serve an informative error about stopped pods
-      error_page 424 /424.html;
-      location /424.html {
+      error_page 503 /nosuchserver.html;
+      location /nosuchserver.html {
         root /srv/proxy-patches;
         internal;
       }
       location / {
-        return 424;
+        return 503;
       }
     }
 
@@ -26,7 +26,7 @@ apiVersion: v1
 metadata:
   name: proxy-html-files
 data:
-  424.html: >
+  nosuchserver.html: >
     <html>
     <head>
     <title>Binder not found</title>
@@ -37,7 +37,7 @@ data:
     <div class="container">
     <h2 class="text-center">Oops!</h2>
     <h3 class="text-center">We can't seem to find the Binder page you are looking for.</h3>
-    <h4>424 error</h4>
+    <h4>503 error</h4>
     <p>
     Here are some helpful tips.
     </p>

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -35,4 +35,4 @@ def test_hub_user_redirect(hub_url):
     """Requesting a Hub URL for a non-running user"""
     # this should *not* redirect for now,
     resp = requests.get(hub_url + "/user/doesntexist")
-    assert resp.status_code == 404
+    assert resp.status_code == 424

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -35,4 +35,5 @@ def test_hub_user_redirect(hub_url):
     """Requesting a Hub URL for a non-running user"""
     # this should *not* redirect for now,
     resp = requests.get(hub_url + "/user/doesntexist")
-    assert resp.status_code == 424
+    assert resp.status_code == 503
+    assert "Binder not found" in resp.text


### PR DESCRIPTION
I think JupyterLab retrying on 404 is driving most of the traffic to the Hub. https://github.com/jupyterlab/jupyterlab/issues/11207

Using another error code that doesn't already mean something for the REST API seems to behave better, based on https://github.com/jupyterhub/jupyterhub/pull/3636#issuecomment-934174628

503 might be even more appropriate, since that's what JupyterHub 1.x uses and JupyterLab expects for a stopped server, though that may [change in 2.0][].

[change in 2.0]: https://github.com/jupyterhub/jupyterhub/pull/3636


**Edit:** switched to 503, which behaves slightly better than 424 with current JupyterLab.