### PR TITLE
bump turing pod quota to 200

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -7,7 +7,7 @@ letsencrypt:
 binderhub:
   config:
     BinderHub:
-      pod_quota: 80
+      pod_quota: 200
       hub_url: https://hub.mybinder.turing.ac.uk
       badge_base_url: https://mybinder.org
       sticky_builds: true


### PR DESCRIPTION
To pick up some of the short-term GKE capacity loss (see [gke.mybinder.org](https://github.com/jupyterhub/team-compass/issues/463) issue) we bump Turing up to 200. Based on current costs the Turing credits will last for just over a month, but we can apply for more in the new year.