### PR TITLE
apply pod quotas to prime federation members

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -8,6 +8,7 @@ coreNodeSelector: &coreNodeSelector
 binderhub:
   config:
     BinderHub:
+      pod_quota: 400
       build_node_selector: *userNodeSelector
       hub_url: https://hub.gke2.mybinder.org
       badge_base_url: https://mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -3,6 +3,7 @@ projectName: binderhub-288415
 binderhub:
   config:
     BinderHub:
+      pod_quota: 20
       hub_url: https://hub.gke2.staging.mybinder.org
       badge_base_url: https://staging.mybinder.org
       image_prefix: gcr.io/binderhub-288415/r2d-staging-g5b5b759-


### PR DESCRIPTION
now that pod quotas are enforced, we can have a limit on the 'prime' members, allowing cost mitigations

federation-redirect still ignores prime quotas, but launches will be rejected if they would exceed the limit

It might be good to have https://github.com/jupyterhub/binderhub/pull/1442 before we start doing this
