### PR TITLE
terraform: switch to pd-balanced, reduce size to save cost

### DIFF
--- a/terraform/modules/mybinder/versions.tf
+++ b/terraform/modules/mybinder/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.0.0"
     }
   }
-  required_version = "~> 0.13"
+  required_version = "~> 1.1"
 }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 }
 
 locals {
-  gke_version        = "1.17.14-gke.400"
+  gke_version        = "1.19.14-gke.1900"
   location           = "us-central1" # for regional clusters
   federation_members = ["gke-old", "gesis", "turing", "ovh"]
 }
@@ -61,6 +61,14 @@ resource "google_container_node_pool" "core" {
       disable-legacy-endpoints = "true"
     }
   }
+
+  # do not recreate pools that have been auto-upgraded
+
+  lifecycle {
+    ignore_changes = [
+        version
+    ]
+  }
 }
 
 resource "google_container_node_pool" "user" {
@@ -96,6 +104,14 @@ resource "google_container_node_pool" "user" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
+  }
+
+  # do not recreate pools that have been auto-upgraded
+
+  lifecycle {
+    ignore_changes = [
+        version
+    ]
   }
 }
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -66,7 +66,7 @@ resource "google_container_node_pool" "core" {
 
   lifecycle {
     ignore_changes = [
-        version
+      version
     ]
   }
 }
@@ -80,8 +80,8 @@ resource "google_container_node_pool" "user" {
   version        = local.gke_version
 
   autoscaling {
-    min_node_count = 2
-    max_node_count = 12
+    min_node_count = 0
+    max_node_count = 1
   }
 
 
@@ -110,7 +110,51 @@ resource "google_container_node_pool" "user" {
 
   lifecycle {
     ignore_changes = [
-        version
+      version
+    ]
+  }
+}
+
+resource "google_container_node_pool" "user1" {
+  name     = "user-202201"
+  cluster  = module.mybinder.cluster_name
+  location = local.location # location of *cluster*
+  # node_locations lets us specify a single-zone regional cluster:
+  node_locations = ["${local.location}-a"]
+  version        = local.gke_version
+
+  autoscaling {
+    min_node_count = 2
+    max_node_count = 12
+  }
+
+
+  node_config {
+    machine_type    = "n1-highmem-8"
+    disk_size_gb    = 500
+    disk_type       = "pd-ssd"
+    local_ssd_count = 1
+
+    labels = {
+      "mybinder.org/pool-type" = "users"
+    }
+    # https://www.terraform.io/docs/providers/google/r/container_cluster.html#oauth_scopes-1
+    oauth_scopes = [
+      "storage-ro",
+      "logging-write",
+      "monitoring",
+    ]
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  # do not recreate pools that have been auto-upgraded
+
+  lifecycle {
+    ignore_changes = [
+      version
     ]
   }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 }
 
 locals {
-  gke_version = "1.17.14-gke.400"
+  gke_version = "1.19.14-gke.1900"
 }
 
 module "mybinder" {
@@ -49,6 +49,13 @@ resource "google_container_node_pool" "pool" {
       disable-legacy-endpoints = "true"
     }
   }
+  # do not recreate pools that have been auto-upgraded
+
+  lifecycle {
+    ignore_changes = [
+        version
+    ]
+  }
 }
 
 # output "public_ip" {
@@ -66,4 +73,3 @@ output "matomo_password" {
   value     = module.mybinder.matomo_password
   sensitive = true
 }
-


### PR DESCRIPTION
from 1T. Should save ~$1k/month

Ignore the version bumps, which are only to make terraform match what's already been auto-upgraded to, so the new pool has the same version as what's already deployed.

This creates a new user pool to replace the old one, but leaves the existing one with an autoscale max of 1 so it will slowly drain (will need some help with cordoning). Once it's drained, another PR can actually delete the old pool.

I'll do the apply after this is merged. I've synced the versions, but not created the new pool.

xref: [cost calculations](https://github.com/jupyterhub/team-compass/issues/463#issuecomment-998781376)