### PR TITLE
Node update part 2

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -36,48 +36,6 @@ module "mybinder" {
 # 5. once drained, remove old pool(s) here
 # 6. deploy again to remove old pool
 
-resource "google_container_node_pool" "core" {
-  name     = "core-202009"
-  cluster  = module.mybinder.cluster_name
-  location = local.location # location of *cluster*
-  # node_locations lets us specify a single-zone regional cluster:
-  node_locations = ["${local.location}-a"]
-
-  autoscaling {
-    min_node_count = 0
-    max_node_count = 1
-  }
-
-  version = local.gke_version
-
-  node_config {
-    machine_type = "n1-highmem-4"
-    disk_size_gb = 250
-    disk_type    = "pd-ssd"
-
-    labels = {
-      "mybinder.org/pool-type" = "core"
-    }
-    # https://www.terraform.io/docs/providers/google/r/container_cluster.html#oauth_scopes-1
-    oauth_scopes = [
-      "storage-ro",
-      "logging-write",
-      "monitoring",
-    ]
-
-    metadata = {
-      disable-legacy-endpoints = "true"
-    }
-  }
-
-  # do not recreate pools that have been auto-upgraded
-
-  lifecycle {
-    ignore_changes = [
-      version
-    ]
-  }
-}
 
 resource "google_container_node_pool" "core1" {
   name     = "core-202201"

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -86,6 +86,7 @@ resource "google_container_node_pool" "core1" {
   # node_locations lets us specify a single-zone regional cluster:
   node_locations = ["${local.location}-a"]
 
+  initial_node_count = 1
   autoscaling {
     min_node_count = 1
     max_node_count = 4
@@ -117,7 +118,8 @@ resource "google_container_node_pool" "core1" {
 
   lifecycle {
     ignore_changes = [
-      version
+      version,
+      initial_node_count,
     ]
   }
 }
@@ -174,6 +176,7 @@ resource "google_container_node_pool" "user1" {
   node_locations = ["${local.location}-a"]
   version        = local.gke_version
 
+  initial_node_count = 2
   autoscaling {
     min_node_count = 2
     max_node_count = 12
@@ -205,7 +208,8 @@ resource "google_container_node_pool" "user1" {
 
   lifecycle {
     ignore_changes = [
-      version
+      version,
+      initial_node_count,
     ]
   }
 }


### PR DESCRIPTION
follow-up to #2102 (PR 2/4 probably)

- old core pool is drained, so can be removed
- set initial_node_count on new pools, otherwise they won't get any nodes to start until an autoscale event triggers
- ignore initial_node_count in lifecycle hook, since it will change with autoscaling, and changing it triggers destroy & recreate

Will probably delete old user pool tonight or tomorrow, after cordoning and draining to the new pool