### PR TITLE
federation-redirect: check versions before health

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -254,7 +254,10 @@ async def health_check(host, active_hosts):
                 versions = json.loads(response.body)
                 # if this is the prime host store the versions so we can compare to them later
                 if all_hosts[host].get("prime", False):
-                    CONFIG["versions"] = versions
+                    old_versions = CONFIG.get("versions", None)
+                    if old_versions != versions:
+                        app_log.info(f"Updating prime versions {old_versions}->{versions}")
+                        CONFIG["versions"] = versions
                 # check if this cluster is on the same versions as the prime
                 # w/o information about the prime's version we allow each
                 # cluster to be on its own versions

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -244,6 +244,28 @@ async def health_check(host, active_hosts):
                 # TODO we could use `asyncio.gather()` and fetch health and versions in parallel
                 # raises an `HTTPError` if the request returned a non-200 response code
                 # health url returns 503 if a (hard check) service is unhealthy
+
+                # check versions
+                # run this first, because it updates the prime version to check against,
+                # and we don't want to skip that if the prime cluster is otherwise unhealthy
+                response = await client.fetch(
+                    all_hosts[host]["versions"], request_timeout=check_config["timeout"]
+                )
+                versions = json.loads(response.body)
+                # if this is the prime host store the versions so we can compare to them later
+                if all_hosts[host].get("prime", False):
+                    CONFIG["versions"] = versions
+                # check if this cluster is on the same versions as the prime
+                # w/o information about the prime's version we allow each
+                # cluster to be on its own versions
+                if versions != CONFIG.get("versions", versions):
+                    raise FailedCheck(
+                        "{} has different versions ({}) than prime ({})".format(
+                            host, versions, CONFIG["versions"]
+                        )
+                    )
+
+                # check health
                 response = await client.fetch(
                     all_hosts[host]["health"], request_timeout=check_config["timeout"]
                 )
@@ -266,23 +288,6 @@ async def health_check(host, active_hosts):
                             )
 
                         break
-                # check versions
-                response = await client.fetch(
-                    all_hosts[host]["versions"], request_timeout=check_config["timeout"]
-                )
-                versions = json.loads(response.body)
-                # if this is the prime host store the versions so we can compare to them later
-                if all_hosts[host].get("prime", False):
-                    CONFIG["versions"] = versions
-                # check if this cluster is on the same versions as the prime
-                # w/o information about the prime's version we allow each
-                # cluster to be on its own versions
-                if versions != CONFIG.get("versions", versions):
-                    raise FailedCheck(
-                        "{} has different versions ({}) than prime ({})".format(
-                            host, versions, CONFIG["versions"]
-                        )
-                    )
             except FailedCheck:
                 # don't retry failures such as quotas/version checks
                 # those aren't likely to change in 1s


### PR DESCRIPTION
checking versions on the prime host updates the version for other hosts to be checked against

if the prime host is unhealthy (e.g. full), the version check was skipped, which means the prime version will not be updated.

This can result in starving fully up-to-date federation members as long as the prime host is full (which will be more likely to stay that way, as we don't stop routing requests to prime while it is full).

Sequence of events:

1. prime host is full, reference version not updated
2. deploy an upgrade
3. other members get latest version, are considered unhealthy
4. prime member gets all traffic, so is _more_ likely to stay 'full'
5. only when traffic drops such that the prime host passes health check (no longer full) will the version be updated and other members be considered healthy again.

That's why it looks like this:

<img width="913" alt="Screen Shot 2022-01-28 at 08 57 45" src="https://user-images.githubusercontent.com/151929/151516612-4fdfe9f7-3b3a-4a2f-8f86-3e67dfba4260.png">

where at 18:00 traffic to GKE dropped below its pod quota so it became healthy again, and the version was updated, admitting all other members back into the federation.