### PR TITLE
repo2docker bump

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -107,7 +107,7 @@ binderhub:
 
     BinderHub:
       use_registry: true
-      build_image: quay.io/jupyterhub/repo2docker:2021.08.0-127.g7f89926
+      build_image: quay.io/jupyterhub/repo2docker:2021.08.0-136.g47ea95a
       per_repo_quota: 100
       per_repo_quota_higher: 200
       build_memory_limit: "3G"


### PR DESCRIPTION
This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/7f89926...47ea95a

Associated PRs:
- put micromamba in /usr/local/bin and use mamba for installs [#1128](https://github.com/jupyterhub/repo2docker/pull/1128)
- Allow passing in traitlets via commandline [#1123](https://github.com/jupyterhub/repo2docker/pull/1123)
- Allow passing in extra args to Docker initialization [#1124](https://github.com/jupyterhub/repo2docker/pull/1124)