### PR TITLE
increase turing prometheus size, reduce retention to 21d

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -97,7 +97,7 @@ grafana:
 
 prometheus:
   server:
-    retention: 30d
+    retention: 21d
     ingress:
       annotations:
         kubernetes.io/ingress.class: nginx
@@ -111,7 +111,7 @@ prometheus:
             - prometheus.turing.mybinder.org
           secretName: turing-prometheus-tls-crt
     persistentVolume:
-      size: 32Gi
+      size: 64Gi
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
Recently failed to start due to lack of space

reference #1940 when this happened before, and for pv-resize process on AKS.

cc @callummole @sgibson91 since the increase in pv size increases turing costs (not by much, I think).

I think we can do either/or, too: just reduce retention, or just increase size, if folks prefer.
