### PR TITLE
pin setup-gcloud to version tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -222,7 +222,7 @@ jobs:
       # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
       - name: "Stage 1: Install gcloud ${{ env.GCLOUD_SDK_VERION }}"
         if: matrix.federation_member == 'prod'
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: ${{ env.GCLOUD_SDK_VERION }}
 


### PR DESCRIPTION
instead of to-be-removed branch name, according to warning

missed that there were two of these in #2112 (🎸)
