### PR TITLE
Disable tracking cookies in matomo

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -143,6 +143,11 @@ binderhub:
           console.log("Loading Matomo tracking, since Do Not Track is off");
             var _paq = _paq || [];
             /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            // this is matomo's own respect-DoNotTrack
+            // should be redundant, but good to be extra explicit
+            _paq.push(["setDoNotTrack", true]);
+            // disable tracking cookies
+            _paq.push(["disableCookies"]);
             _paq.push(['trackPageView']);
             (function() {
               var u="//" + window.location.hostname + "/matomo/";


### PR DESCRIPTION
To avoid cookie banners in EU, it seems we need to avoid using a state cookie for analytics

also sets matomo's own "respect DoNotTrack" option, which ought to be redundant, but no harm in being extra explicit.