### PR TITLE
bump binderhub 48bc0f6...8da69f2

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -45,5 +45,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n868.h48bc0f6
+    version: 0.2.0-n878.h8da69f2
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/48bc0f6...8da69f2
