### PR TITLE
Reduce GKE capacity to 200

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -8,7 +8,7 @@ coreNodeSelector: &coreNodeSelector
 binderhub:
   config:
     BinderHub:
-      pod_quota: 400
+      pod_quota: 200
       build_node_selector: *userNodeSelector
       hub_url: https://hub.gke2.mybinder.org
       badge_base_url: https://mybinder.org


### PR DESCRIPTION
While we're running low on funds (#2138), reduce GKE capacity to match the next largest member (turing) to keep costs down.

With the switch on try.jupyter to JupyterLite, today's peak would not have exceeded overall mybinder.org capacity even after this reduction, though this would have shifted load from GKE to other federation members because GKE happens to be the destination for several of the busiest repos