### PR TITLE
lower cap on petlja

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -85,6 +85,9 @@ binderhub:
         - pattern: ^ipython/ipython-in-depth.*
           config:
             quota: 100
+        - pattern: ^petlja/.*
+          config:
+            quota: 50
       # - pattern: ^github-owner/github-repo-prefix.*
       #   # YYYY-MM-DD of workshop
       #   config:


### PR DESCRIPTION
reduces impact of sustained high load across the federation (over 100,000 sessions in 3 weeks, over 50% of all traffic other not from the top two links from try.jupyter.org that are now going to JupyterLite)

related to #2143