### PR TITLE
relax health-check timeout to 5s

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -539,7 +539,7 @@ federationRedirect:
     period: 10
     jitter: 0.1
     retries: 5
-    timeout: 2
+    timeout: 5
   load_balancer: "rendezvous"
   pod_headroom: 10
   hosts:


### PR DESCRIPTION
Turing is often missing the 2 second deadline when it's busy. Checking turing logs suggests it usually takes ~3s when this is happening.
