### PR TITLE
bump binderhub chart 8da69f2...d19a36a

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -45,5 +45,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n878.h8da69f2
+    version: 0.2.0-n880.hd19a36a
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
Gets pycurl in the binderhub image, which may improve health checks

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/8da69f2...d19a36a
