### PR TITLE
retry failed health checks every 90 seconds

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -64,6 +64,11 @@ def get_config(config_path):
     with open(config_path) as f:
         config = json.load(f)
 
+    # merge default config
+    config.setdefault("check", CONFIG["check"])
+    for key in CONFIG["check"]:
+        config["check"].setdefault(key, CONFIG["check"][key])
+
     for h in list(config["hosts"].keys()):
         # Remove empty entries from CONFIG["hosts"], these can happen because we
         # can't remove keys in our helm templates/config files. All we can do is

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -536,11 +536,11 @@ federationRedirect:
     name: jupyterhub/mybinder.org-federation-redirect
     tag: 'set-by-chartpress'
   check:
-    period: 10
+    period: 15
     jitter: 0.1
     retries: 5
     timeout: 5
-    failed_period: 300
+    failed_period: 90
   load_balancer: "rendezvous"
   pod_headroom: 10
   hosts:


### PR DESCRIPTION
instead of 5 minutes

quicker re-admission, especially during version upgrades
