### PR TITLE
use ingress v1

### DIFF
--- a/mybinder/templates/federation-redirect/ingress.yaml
+++ b/mybinder/templates/federation-redirect/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.federationRedirect.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: federation-redirect
@@ -16,9 +16,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: federation-redirect
-              servicePort: 80
+              service:
+                name: federation-redirect
+                port:
+                  number: 80
   tls:
     - secretName: kubelego-tls-federation-redirect
       hosts:

--- a/mybinder/templates/gcs-proxy/ingress.yaml
+++ b/mybinder/templates/gcs-proxy/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gcsProxy.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gcs-proxy
@@ -18,9 +18,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: gcs-proxy
-              servicePort: 80
+              service:
+                name: gcs-proxy
+                port:
+                  number: 80
     {{ end }}
   tls:
     - secretName: kubelego-tls-gcs-proxy

--- a/mybinder/templates/matomo/ingress.yaml
+++ b/mybinder/templates/matomo/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.matomo.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: matomo
@@ -17,9 +17,12 @@ spec:
       http:
         paths:
           - path: /matomo
+            pathType: Prefix
             backend:
-              serviceName: matomo
-              servicePort: 9000
+              service:
+                name: matomo
+                port:
+                  number: 9000
     {{ end }}
   tls:
     - secretName: kubelego-tls-matomo

--- a/mybinder/templates/redirector/ingress.yaml
+++ b/mybinder/templates/redirector/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: redirector
@@ -15,9 +15,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: redirector
-              servicePort: 80
+              service:
+                name: redirector
+                port:
+                  number: 80
     {{ end }}
   tls:
     - secretName: {{ .Values.redirector.ingress.tls.secretName }}

--- a/mybinder/templates/static/ingress.yaml
+++ b/mybinder/templates/static/ingress.yaml
@@ -5,7 +5,7 @@
 #
 # This is a separate path-whitelisted ingress rather than just
 # a domain alias to prevent possible reflection attacks.
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: static
@@ -25,9 +25,12 @@ spec:
         paths:
           {{ range $path := $root.Values.static.paths }}
           - path: {{ $path }}
+            pathType: Prefix
             backend:
-              serviceName: binder
-              servicePort: 80
+              service:
+                name: binder
+                port:
+                  number: 80
           {{ end }}
     {{ end }}
   tls:


### PR DESCRIPTION
deprecated in 1.19, removed in 1.22

requires k8s 1.19, which all member have after #2155 
