### PR TITLE
allow disabling ingress-controller, grafana, prometheus

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -16,6 +16,7 @@ dependencies:
   - name: ingress-nginx
     version: 2.13.0
     repository: https://kubernetes.github.io/ingress-nginx
+    condition: ingress-nginx.enabled
 
   # Prometheus for collection of metrics.
   # Source code:   https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
@@ -27,6 +28,7 @@ dependencies:
   - name: prometheus
     version: 11.16.9
     repository: https://prometheus-community.github.io/helm-charts
+    condition: prometheus.enabled
 
   # Grafana for dashboarding of metrics.
   # Source code:   https://github.com/grafana/helm-charts/tree/main/charts/grafana
@@ -40,6 +42,7 @@ dependencies:
   - name: grafana
     version: 6.17.1
     repository: https://grafana.github.io/helm-charts
+    condition: grafana.enabled
 
   # BinderHub
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -365,6 +365,7 @@ binderhub:
                 - NET_ADMIN
 
 ingress-nginx:
+  enabled: true
   rbac:
     create: true
   defaultBackend:
@@ -441,6 +442,7 @@ static:
       secretName: kubelego-tls-static
 
 grafana:
+  enabled: true
   ingress:
     enabled: true
     annotations:
@@ -465,6 +467,7 @@ grafana:
       allow_embedding: true
 
 prometheus:
+  enabled: true
   nodeExporter:
     updateStrategy:
       type: RollingUpdate


### PR DESCRIPTION
for easier step-by-step deployment

Helpful trying to get KAUST running.

KAUST already has an ingress-controller, so that will want to stay off.

Grafana and prometheus require ClusterRoles, which we don't yet have permission to deploy. I don't intend to leave them off, but it's nice to be able to toggle them easily so we can work on the deployment piece by piece.
