### PR TITLE
bump binderhub d19a36a...e87e25a

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -48,5 +48,5 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: 0.2.0-n880.hd19a36a
+    version: 0.2.0-n919.he87e25a
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/d19a36a...e87e25a


gets https://github.com/jupyterhub/binderhub/pull/1472