### PR TITLE
Deploy cryptnono

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -50,3 +50,9 @@ dependencies:
   - name: binderhub
     version: 0.2.0-n919.he87e25a
     repository: https://jupyterhub.github.io/helm-chart
+
+  # cryptnono, counters crypto mining
+  # Source: https://github.com/yuvipanda/cryptnono/
+  - name: cryptnono
+    version: 0.0.1-n012.h3e298eb
+    repository: https://yuvipanda.github.io/cryptnono/

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,3 +1,15 @@
+cryptnono:
+  tolerations:
+    # deploy anti-cryptomining cryptnono on all nodes
+    - effect: NoSchedule
+      key: hub.jupyter.org/dedicated
+      operator: Equal
+      value: user
+    - effect: NoSchedule
+      key: hub.jupyter.org_dedicated
+      operator: Equal
+      value: user
+
 imagePullSecrets:
 
 tags: {}


### PR DESCRIPTION
cryptnono (https://github.com/yuvipanda/cryptnono/) is a
helm chart that uses [bpftrace](https://github.com/iovisor/bpftrace)
to detect monero mining and kill all processes that mine monero
instantly. It is based off [this blog
post](https://blog.px.dev/detect-monero-miners/)
and installs a daemonset.

This is in addition to our minesweeper program, and focused
specifically on monero.

Ref https://github.com/jupyterhub/team-compass/issues/514
