### PR TITLE
Enable cryptnono on turing and ovh

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -89,7 +89,7 @@ binderhub:
     imageGCThresholdType: "absolute"
 
 cryptnono:
-  enabled: false
+  enabled: true
 
 grafana:
   ingress:

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -70,7 +70,7 @@ binderhub:
     imageGCThresholdType: "absolute"
 
 cryptnono:
-  enabled: false
+  enabled: true
 
 grafana:
   ingress:

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono
-    version: 0.0.1-n012.h3e298eb
+    version: 0.0.1-n017.h6659c07
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono
-    version: 0.0.1-n017.h6659c07
+    version: 0.0.1-n019.h571fa96
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled


### PR DESCRIPTION
Brings in https://github.com/yuvipanda/cryptnono/commit/6659c07a89bb565624c17a6a44410a65f88b2f08,
https://github.com/yuvipanda/cryptnono/commit/571fa9615a9d30a22a42ef5be51a4b0cbc573923 and 
https://github.com/yuvipanda/cryptnono/commit/b063e6ac4fffa7300be98b2cf28b6f4dd6ce0c89
