### PR TITLE
add mybinder- to ovh chart registry prefix

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -186,7 +186,7 @@ jobs:
             binder_url: https://ovh.mybinder.org
             hub_url: https://hub-binder.mybinder.ovh
             # image-prefix should match ovh registry config in secrets/config/ovh.yaml
-            chartpress_args: "--push --image-prefix=3i2li627.gra7.container-registry.ovh.net/binder/ovhbhub-"
+            chartpress_args: "--push --image-prefix=3i2li627.gra7.container-registry.ovh.net/binder/mybinder-"
             helm_version: ""
 
     steps:


### PR DESCRIPTION
easier to distinguish from r2d pushes for harbor retention policy purposes

I think the harbor retention policy kicked out our minesweeper image

