### PR TITLE
Bump quota on 05/27/2022 for workshop at conference

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -102,6 +102,11 @@ binderhub:
         - pattern: ^petlja/.*
           config:
             quota: 50
+        - pattern: ^NavAbility/BinderNotebooks.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2165
+          # 2022-05-27
+          config:
+            quota: 400
       # - pattern: ^github-owner/github-repo-prefix.*
       #   # YYYY-MM-DD of workshop
       #   config:


### PR DESCRIPTION
PR for request to bump quota on [conference workshop notebooks](https://github.com/NavAbility/BinderNotebooks) for 05/27/2022.

Thanks again and please let me know if I made any mistakes with the change.

Ref: https://github.com/jupyterhub/mybinder.org-deploy/issues/2165