### PR TITLE
ci: add workflow to create bump PRs for repo2docker image and helm charts

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -1,0 +1,191 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# - Watch the image tag referenced in mybinder/values.yaml under
+#   binderhub.config.BinderHub.build_image to match the latest image tag for
+#   quay.io/jupyterhub/repo2docker.
+#
+# - Watch the chart versions referenced as dependencies in mybinder/Chart.yaml
+#   to match the latest chart versions available.
+#
+name: Watch dependencies
+
+on:
+  push:
+    paths:
+      - ".github/workflows/watch-dependencies.yaml"
+  schedule:
+    # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-image-dependencies:
+    # Don't run this job on forks
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: repo2docker
+            registry: quay.io
+            repository: jupyterhub/repo2docker
+            values_path: binderhub.config.BinderHub.build_image
+            changelog_url: https://repo2docker.readthedocs.io/en/latest/changelog.html
+            source_url: https://github.com/jupyterhub/repo2docker
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get values.yaml pinned tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: local
+        # The local_full_image_spec can be a full image spec like
+        # "registry/repo:tag" or just the tag, but the local_tag will always
+        # become just the tag if ":" is part of the local_full_image_spec. See
+        # https://stackoverflow.com/a/15149278/2220152 for some details.
+        #
+        run: |
+          local_full_image_spec=$(cat mybinder/values.yaml | yq e '.${{ matrix.values_path }}' -)
+          local_tag=${local_full_image_spec#*:}
+          echo "::set-output name=tag::$local_tag"
+
+      - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: latest
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We use jq to filter out tags of the x.y.z(-a) format, and
+        # then sort based on the numerical x, y, z, and a values. Finally, we
+        # pick the last value in the list.
+        #
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
+            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+(-\\d+\\..*)$"))] | sort_by(split(".-") | map(tonumber? // 0)) | last'
+          )
+          echo "::set-output name=tag::$latest_tag"
+
+      - name: Update values.yaml pinned tag
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: sed --in-place 's/${{ steps.local.outputs.tag }}/${{ steps.latest.outputs.tag }}/g' mybinder/values.yaml
+
+      - name: git diff
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          token: "${{ secrets.jupyterhub_bot_pat }}"
+          author: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          committer: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          branch: update-image-${{ matrix.name }}
+          labels: maintenance,dependencies
+          commit-message: Update ${{ matrix.registry }}/${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          title: Update ${{ matrix.registry }}/${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          body: >-
+            A new ${{ matrix.registry }}/${{ matrix.repository }} image version
+            has been detected, version `${{ steps.latest.outputs.tag }}`.
+
+
+            ## Related
+
+            - Source code: ${{ matrix.source_url }}
+            - Changelog: ${{ matrix.changelog_url }}
+
+
+
+  update-chart-dependencies:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Updates mybinder/Chart.yaml declared chart dependencies versions by
+          # creating a PRs when a new stable version is available in the Helm
+          # chart repository.
+          #
+          - chart_dep_index: "0"
+            chart_dep_name: binderhub
+            chart_dep_chart_changelog_url: ""
+            chart_dep_app_changelog_url: "https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md"
+            chart_dep_source_url: "https://github.com/jupyterhub/binderhub/tree/master/helm-chart"
+            chart_dep_devel_flag: "--devel"
+
+          - chart_dep_index: "1"
+            chart_dep_name: ingress-nginx
+            chart_dep_chart_changelog_url: ""
+            chart_dep_app_changelog_url: "https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md"
+            chart_dep_source_url: "https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx"
+            chart_dep_devel_flag: ""
+
+          - chart_dep_index: "2"
+            chart_dep_name: prometheus
+            chart_dep_chart_changelog_url: ""
+            chart_dep_app_changelog_url: "https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md"
+            chart_dep_source_url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+            chart_dep_devel_flag: ""
+
+          - chart_dep_index: "3"
+            chart_dep_name: grafana
+            chart_dep_chart_changelog_url: ""
+            chart_dep_app_changelog_url: "https://github.com/grafana/grafana/blob/master/CHANGELOG.md"
+            chart_dep_source_url: "https://github.com/grafana/helm-charts/tree/main/charts/grafana"
+            chart_dep_devel_flag: ""
+
+          - chart_dep_index: "4"
+            chart_dep_name: cryptnono
+            chart_dep_chart_changelog_url: ""
+            chart_dep_app_changelog_url: ""
+            chart_dep_source_url: "https://github.com/yuvipanda/cryptnono/"
+            chart_dep_devel_flag: "--devel"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Chart.yaml pinned version of ${{ matrix.chart_dep_name }} chart
+        id: local
+        run: |
+          local_version=$(cat mybinder/Chart.yaml | yq e '.dependencies.${{ matrix.chart_dep_index }}.version' -)
+          echo "::set-output name=version::$local_version"
+
+      - name: Get latest version of ${{ matrix.chart_dep_name }} chart
+        id: latest
+        run: |
+          chart_dep_repo=$(cat mybinder/Chart.yaml | yq e '.dependencies.${{ matrix.chart_dep_index }}.repository' -)
+          latest_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.version' -)
+          echo "::set-output name=version::$latest_version"
+
+      - name: Update Chart.yaml pinned version
+        # "<old version>" is replaced with "<new version>", where also the
+        # quotes are included.
+        #
+        run: sed --in-place 's/"${{ steps.local.outputs.version }}"/"${{ steps.latest.outputs.version }}"/g' mybinder/Chart.yaml
+
+      - name: git diff
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          token: "${{ secrets.DASK_BOT_TOKEN }}"
+          branch: update-chart-${{ matrix.chart_dep_name }}
+          labels: dependencies
+          commit-message: Updates ${{ matrix.chart_dep_name }} chart to ${{ steps.latest.outputs.version }}
+          title: Updates ${{ matrix.chart_dep_name }} chart to ${{ steps.latest.outputs.version }}
+          body: >-
+            Updates mybinder to depend on the ${{ matrix.chart_dep_name }} chart
+            version `${{ steps.latest.outputs.version }}`.
+
+
+            ## Related
+
+
+            - Chart source code: ${{ matrix.chart_dep_source_url }}
+            - Chart changelog: ${{ matrix.chart_dep_chart_changelog_url }}
+            - Application changelog: ${{ matrix.chart_dep_app_changelog_url }}

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # - Watch the image tag referenced in mybinder/values.yaml under
 #   binderhub.config.BinderHub.build_image to match the latest image tag for
@@ -21,8 +21,10 @@ on:
 
 jobs:
   update-image-dependencies:
-    # Don't run this job on forks
-    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    # Don't schedule runs on forks, but allow the job to execute on push and
+    # workflow_dispatch for CI development purposes.
+    if: github.repository == 'jupyterhub/mybinder.org-deploy' || github.event_name != 'schedule'
+
     runs-on: ubuntu-20.04
     environment: watch-dependencies-env
 
@@ -76,7 +78,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         uses: peter-evans/create-pull-request@v4.0.3
         with:
           token: "${{ secrets.jupyterhub_bot_pat }}"
@@ -99,7 +101,10 @@ jobs:
 
 
   update-chart-dependencies:
-    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    # Don't schedule runs on forks, but allow the job to execute on push and
+    # workflow_dispatch for CI development purposes.
+    if: github.repository == 'jupyterhub/mybinder.org-deploy' || github.event_name != 'schedule'
+
     runs-on: ubuntu-20.04
     environment: watch-dependencies-env
 
@@ -174,6 +179,7 @@ jobs:
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
         uses: peter-evans/create-pull-request@v4.0.3
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         with:
           token: "${{ secrets.DASK_BOT_TOKEN }}"
           branch: update-chart-${{ matrix.chart_dep_name }}

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -24,6 +24,7 @@ jobs:
     # Don't run this job on forks
     if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-20.04
+    environment: watch-dependencies-env
 
     strategy:
       fail-fast: false
@@ -100,6 +101,7 @@ jobs:
   update-chart-dependencies:
     if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-20.04
+    environment: watch-dependencies-env
 
     strategy:
       fail-fast: false

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -1,9 +1,16 @@
 apiVersion: v2
 description: A meta-chart for the binderhub deployment on mybinder.org
 name: mybinder
-version: 0.0.1-set.by.chartpress
+version: "0.0.1-set.by.chartpress"
 kubeVersion: ">= 1.15.0-0"
 dependencies:
+  # BinderHub
+  # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
+  # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
+  - name: binderhub
+    version: "0.2.0-n919.he87e25a"
+    repository: https://jupyterhub.github.io/helm-chart
+
   # Ingress-Nginx to route network traffic according to Ingress resources using
   # this controller from within k8s.
   # Source code:   https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
@@ -14,7 +21,7 @@ dependencies:
   #       chart v3.3.0 maps to app v0.35.0
   #       chart v3.12.0 requires Helm 3
   - name: ingress-nginx
-    version: 2.13.0
+    version: "2.13.0"
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
 
@@ -26,7 +33,7 @@ dependencies:
   #       chart v11.16.9 maps to app v2.21.0  - 2020-12-06
   #       chart v12 requires Helm 3
   - name: prometheus
-    version: 11.16.9
+    version: "11.16.9"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
 
@@ -40,20 +47,13 @@ dependencies:
   #       chart v6 requires Helm 3
   #       chart v6.17.1 gives us Grafana v8.2.1
   - name: grafana
-    version: 6.17.1
+    version: "6.17.1"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
 
-  # BinderHub
-  # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
-  # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
-  - name: binderhub
-    version: 0.2.0-n919.he87e25a
-    repository: https://jupyterhub.github.io/helm-chart
-
   # cryptnono, counters crypto mining
-  # Source: https://github.com/yuvipanda/cryptnono/
+  # Source code: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono
-    version: 0.0.1-n019.h571fa96
+    version: "0.0.1-n019.h571fa96"
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled


### PR DESCRIPTION
Since https://github.com/henchbot/mybinder.org-upgrades/issues/13 about henchbot being down and given recent work in related work about bumping images and helm charts in dask/helm-chart and jupyterhub/zero-to-jupyterhub-k8s, I open this PR to automate version bumping of both image dependencies and helm chart depedencies here as well.

Below are the dependencies we automate bumping of with this PR.

- image: quay.io/jupyterhub/repo2docker
- chart: binderhub
- chart: ingress-nginx
- chart: prometheus
- chart: grafana
- chart: cryptnono

---

I've tested this to function to the part of making a PR, and I've added a dedicated jupyterhub-bot PAT for this repo's GitHub environment `watch-dependencies-env` (and `test-this-pr-env`) according to steps in https://github.com/jupyterhub/team-compass/issues/516#issuecomment-1129961954, and I've given @jupyterhub-bot write access to this repo.

---

@sgibson91 has developed https://github.com/sgibson91/bump-helm-deps-action which can be relevant bumping the helm chart versions, but I wanted to wait adopting a dedicated github action for reasons described in https://github.com/henchbot/mybinder.org-upgrades/issues/13#issuecomment-1139411542 and hope that we can get going with this for now.