### PR TITLE
Set grafana.deploymentStrategy to Recreate to fix blocked upgrades

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -477,6 +477,10 @@ grafana:
     annotations:
       kubernetes.io/ingress.class: nginx
       kubernetes.io/tls-acme: 'true'
+  # deploymentStrategy.type is set to Recreate as we have storage that can only
+  # be attached once, we can't have two replicas as RollingUpdate leads to.
+  deploymentStrategy:
+    type: Recreate
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
I merged #2204 but ran into failures, the failure relates to attempting to upgrade grafana will RollingUpdate, while there can't be more than one replica started at the same time because storage can only be mounted once at the time. This fixed that but using an upgrade strategy of "Recreate" so that a replica first terminate and then another starts.