### PR TITLE
ci: let chart dep updates include appVersion changes

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -125,21 +125,21 @@ jobs:
 
           - chart_dep_index: "1"
             chart_dep_name: ingress-nginx
-            chart_dep_chart_changelog_url: ""
+            chart_dep_chart_changelog_url: "https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#upgrading-chart"
             chart_dep_app_changelog_url: "https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md"
             chart_dep_source_url: "https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx"
             chart_dep_devel_flag: ""
 
           - chart_dep_index: "2"
             chart_dep_name: prometheus
-            chart_dep_chart_changelog_url: ""
+            chart_dep_chart_changelog_url: "https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#upgrading-chart"
             chart_dep_app_changelog_url: "https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md"
             chart_dep_source_url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
             chart_dep_devel_flag: ""
 
           - chart_dep_index: "3"
             chart_dep_name: grafana
-            chart_dep_chart_changelog_url: ""
+            chart_dep_chart_changelog_url: "https://github.com/grafana/helm-charts/tree/main/charts/grafana#upgrading-an-existing-release-to-a-new-major-version"
             chart_dep_app_changelog_url: "https://github.com/grafana/grafana/blob/master/CHANGELOG.md"
             chart_dep_source_url: "https://github.com/grafana/helm-charts/tree/main/charts/grafana"
             chart_dep_devel_flag: ""
@@ -154,18 +154,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get Chart.yaml pinned version of ${{ matrix.chart_dep_name }} chart
+      - name: Get Chart.yaml pinned version/appVersion of ${{ matrix.chart_dep_name }} chart
         id: local
         run: |
           local_version=$(cat mybinder/Chart.yaml | yq e '.dependencies.${{ matrix.chart_dep_index }}.version' -)
           echo "::set-output name=version::$local_version"
+          local_app_version=$(cat mybinder/Chart.yaml | yq e '.dependencies.${{ matrix.chart_dep_index }}.appVersion' -)
+          echo "::set-output name=appVersion::$local_app_version"
 
-      - name: Get latest version of ${{ matrix.chart_dep_name }} chart
+      - name: Get latest version/appVersion of ${{ matrix.chart_dep_name }} chart
         id: latest
         run: |
           chart_dep_repo=$(cat mybinder/Chart.yaml | yq e '.dependencies.${{ matrix.chart_dep_index }}.repository' -)
           latest_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.version' -)
           echo "::set-output name=version::$latest_version"
+          latest_app_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.appVersion' -)
+          echo "::set-output name=appVersion::$latest_app_version"
 
       - name: Update Chart.yaml pinned version
         # "<old version>" is replaced with "<new version>", where also the
@@ -192,6 +196,11 @@ jobs:
           title: Updates ${{ matrix.chart_dep_name }} chart to ${{ steps.latest.outputs.version }}
           body: |
             Updates mybinder to depend on the ${{ matrix.chart_dep_name }} chart version `${{ steps.latest.outputs.version }}` from version `${{ steps.local.outputs.version }}`.
+
+            &nbsp; | Before | After
+            -|-|-
+            Chart.yaml's version | `${{ steps.local.outputs.version }}` | `${{ steps.latest.outputs.version }}`
+            Chart.yaml's appVersion | `${{ steps.local.outputs.appVersion }}` | `${{ steps.latest.outputs.appVersion }}`
 
             ## Related
 


### PR DESCRIPTION
Followup to #2180's functionality, allowing not only the `version` change to be shown, but also the `appVersion` change which can be quite critical to consider when reviewing an upgrade PR.