### PR TITLE
Update ingress-nginx chart to 3.36.0 (0.49.0) for networking.k8s.io/v1 and v1beta support

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -16,12 +16,10 @@ dependencies:
   # Source code:   https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
   # App changelog: https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md
   #
-  # NOTE: chart v2.13.0 maps to app v0.35.0  - 2020-09-01
-  #       chart v3 upgrade require k8s 1.16
-  #       chart v3.3.0 maps to app v0.35.0
-  #       chart v3.12.0 requires Helm 3
+  # NOTE: chart v3.36.0 maps to v0.49.0 and has support for networking.k8s.io/v1
+  #       chart v4.1.2 maps to v1.2.0 and has dropped support for networking.k8s.io/v1beta1
   - name: ingress-nginx
-    version: "2.13.0"
+    version: "3.36.0"
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
 


### PR DESCRIPTION
After this, we should have the ability to update our Ingress resources to v1. After we have done that, we can then keep updating ingress-nginx further. This is outlined in an action plan at #2182.