### PR TITLE
Fully transition to Ingress with apiVersion networking.k8s.io/v1

### DIFF
--- a/config/ovh/ovh_mybinder_org_ingress.yaml
+++ b/config/ovh/ovh_mybinder_org_ingress.yaml
@@ -1,19 +1,22 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ovh-mybinder-org
   annotations:
-    kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/tls-acme: "true"
 spec:
   rules:
     - host: ovh.mybinder.org
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: binder
-              servicePort: 8585
+              service:
+                name: binder
+                port:
+                  number: 8585
   tls:
     - secretName: kubelego-tls-binder-ovh
       hosts:

--- a/mybinder/templates/federation-redirect/ingress.yaml
+++ b/mybinder/templates/federation-redirect/ingress.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.federationRedirect.enabled }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
-{{ $root := . }}
 kind: Ingress
 metadata:
   name: federation-redirect
@@ -21,20 +16,14 @@ spec:
       http:
         paths:
           - path: /
-            {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
                 name: federation-redirect
                 port:
                   number: 80
-            {{- else }}
-            backend:
-              serviceName: federation-redirect
-              servicePort: 80
-            {{- end }}
   tls:
     - secretName: kubelego-tls-federation-redirect
       hosts:
-      - {{ .Values.federationRedirect.host | quote }}
+        - {{ .Values.federationRedirect.host | quote }}
 {{- end }}

--- a/mybinder/templates/gcs-proxy/ingress.yaml
+++ b/mybinder/templates/gcs-proxy/ingress.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.gcsProxy.enabled }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
-{{ $root := . }}
 kind: Ingress
 metadata:
   name: gcs-proxy
@@ -18,28 +13,22 @@ metadata:
     kubernetes.io/tls-acme: "true"
 spec:
   rules:
-    {{ range $bucket := .Values.gcsProxy.buckets }}
+    {{- range $bucket := .Values.gcsProxy.buckets }}
     - host: {{ $bucket.host | quote }}
       http:
         paths:
           - path: /
-            {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
                 name: gcs-proxy
                 port:
                   number: 80
-            {{- else }}
-            backend:
-              serviceName: gcs-proxy
-              servicePort: 80
-            {{- end }}
-    {{ end }}
+    {{- end }}
   tls:
     - secretName: kubelego-tls-gcs-proxy
       hosts:
-      {{- range $bucket := .Values.gcsProxy.buckets }}
-      - {{ $bucket.host }}
-      {{- end }}
+        {{- range $bucket := .Values.gcsProxy.buckets }}
+        - {{ $bucket.host }}
+        {{- end }}
 {{- end }}

--- a/mybinder/templates/matomo/ingress.yaml
+++ b/mybinder/templates/matomo/ingress.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.matomo.enabled }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
-{{ $root := . }}
 kind: Ingress
 metadata:
   name: matomo
@@ -17,28 +12,22 @@ metadata:
     kubernetes.io/tls-acme: "true"
 spec:
   rules:
-    {{ range $host := .Values.matomo.ingress.hosts }}
+    {{- range $host := .Values.matomo.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           - path: /matomo
-            {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
                 name: matomo
                 port:
                   number: 9000
-            {{- else }}
-            backend:
-              serviceName: matomo
-              servicePort: 9000
-            {{- end }}
-    {{ end }}
+    {{- end }}
   tls:
     - secretName: kubelego-tls-matomo
       hosts:
-      {{ range $host := .Values.matomo.ingress.hosts }}
-      - {{ $host }}
-      {{- end }}
+        {{- range $host := .Values.matomo.ingress.hosts }}
+        - {{ $host }}
+        {{- end }}
 {{- end }}

--- a/mybinder/templates/redirector/ingress.yaml
+++ b/mybinder/templates/redirector/ingress.yaml
@@ -1,9 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
-{{ $root := . }}
 kind: Ingress
 metadata:
   name: redirector
@@ -15,27 +10,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{ range $redirect := .Values.redirector.redirects }}
+    {{- range $redirect := .Values.redirector.redirects }}
     - host: {{ $redirect.host.from | quote }}
       http:
         paths:
           - path: /
-            {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
                 name: redirector
                 port:
                   number: 80
-            {{- else }}
-            backend:
-              serviceName: redirector
-              servicePort: 80
-            {{- end }}
-    {{ end }}
+    {{- end }}
   tls:
     - secretName: {{ .Values.redirector.ingress.tls.secretName }}
       hosts:
-      {{- range $redirect := .Values.redirector.redirects }}
-      - {{ $redirect.host.from }}
-      {{- end }}
+        {{- range $redirect := .Values.redirector.redirects }}
+        - {{ $redirect.host.from }}
+        {{- end }}

--- a/mybinder/templates/static/ingress.yaml
+++ b/mybinder/templates/static/ingress.yaml
@@ -5,12 +5,7 @@
 #
 # This is a separate path-whitelisted ingress rather than just
 # a domain alias to prevent possible reflection attacks.
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
-{{ $root := . }}
 kind: Ingress
 metadata:
   name: static
@@ -23,29 +18,23 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{ range $host := .Values.static.ingress.hosts }}
+    {{- range $host := .Values.static.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
-          {{ range $path := $root.Values.static.paths }}
+          {{- range $path := $.Values.static.paths }}
           - path: {{ $path }}
-            {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
                 name: binder
                 port:
                   number: 80
-            {{- else }}
-            backend:
-              serviceName: binder
-              servicePort: 80
-            {{- end }}
-          {{ end }}
-    {{ end }}
+          {{- end }}
+    {{- end }}
   tls:
     - secretName: {{ .Values.static.ingress.tls.secretName }}
       hosts:
-      {{ range $host := .Values.static.ingress.hosts }}
-      - {{ $host }}
-      {{- end }}
+        {{- range $host := .Values.static.ingress.hosts }}
+        - {{ $host }}
+        {{- end }}


### PR DESCRIPTION
It seems the ingress-nginx controller we use can handle networking.k8s.io/v1/Ingress resources already, but I found that one OVH Ingress resource was not yet migrated to v1 but stuck at v1beta1.

This PR removes conditional logic no longer needed as we are a k8s v1.20+ systematically already.

---

This makes me think that we don't need to upgrade ingress-nginx in #2214, but can go straight for #2203. But, it won't hurt doing it step by step.