### PR TITLE
cert-manager 1.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ env:
   # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the
   #       test-helm-template.yaml workflow.
   #
-  CERT_MANAGER_VERSION: "v1.8.0"
+  CERT_MANAGER_VERSION: "v1.1.0"
 
   # These variables influence git directly
   # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ env:
   # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the
   #       test-helm-template.yaml workflow.
   #
-  CERT_MANAGER_VERSION: "v0.15.2"
+  CERT_MANAGER_VERSION: "v1.8.0"
 
   # These variables influence git directly
   # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing

--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -7,7 +7,7 @@ env:
   # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the cd.yaml
   #       workflow.
   #
-  CERT_MANAGER_VERSION: "v0.15.2"
+  CERT_MANAGER_VERSION: "v1.8.0"
 
 on:
   pull_request:

--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -7,7 +7,7 @@ env:
   # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the cd.yaml
   #       workflow.
   #
-  CERT_MANAGER_VERSION: "v1.8.0"
+  CERT_MANAGER_VERSION: "v1.1.0"
 
 on:
   pull_request:

--- a/deploy.py
+++ b/deploy.py
@@ -244,9 +244,9 @@ def setup_certmanager():
     manifest_url = f"https://github.com/jetstack/cert-manager/releases/download/{version}/cert-manager.crds.yaml"
     print(BOLD + GREEN + f"Installing cert-manager CRDs {version}" + NC, flush=True)
 
-    subprocess.check_call(
-        ["kubectl", "apply", "-f", manifest_url]
-    )
+    # Sometimes 'replace' is needed for upgrade (e.g. 1.1->1.2)
+    # this should be equivalent to apply
+    subprocess.check_call(["kubectl", "replace", "-f", manifest_url])
 
     print(BOLD + GREEN + f"Installing cert-manager {version}" + NC, flush=True)
     helm_upgrade = [

--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging
@@ -10,11 +10,11 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:
-    - http01:
-        ingress:
-          class: nginx
+      - http01:
+          ingress:
+            class: nginx
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -25,6 +25,6 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
-    - http01:
-        ingress:
-          class: nginx
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
switches to 'replace' for CRDs based on recommendation [here](https://cert-manager.io/docs/installation/upgrading/upgrading-1.1-1.2)