### PR TITLE
cd: don't manually install latest azure cli, its pre-installed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -248,11 +248,6 @@ jobs:
         with:
           version: ${{ env.GCLOUD_SDK_VERION }}
 
-      - name: "Stage 1: Install Azure CLI"
-        if: matrix.federation_member == 'turing'
-        run: |
-          sudo apt-get update && sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && AZ_REPO=$(lsb_release -cs) && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list && sudo apt-get update && sudo apt-get install azure-cli
-
       - name: "Stage 1: Install kubectl ${{ env.KUBECTL_VERSION }}"
         uses: azure/setup-kubectl@v1
         with:


### PR DESCRIPTION
Install of the `az` (azure) CLI takes ~1 min in CI. It is part of the GitHub environment by default though, so instead of manually installing the latest version, we can use the GitHub virtual environments provided version.

With other CLI, we have version pins, but now with this because we have no easy way of installing a specific version. Due to this, I suggest we simply rely directly on the [GitHub virtual environment's provided `az` CLI](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#cli-tools).

The benefit of this is that we cut the CD time for turing with ~1 minute.