### PR TITLE
Pause turing

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -8,7 +8,7 @@ coreNodeSelector: &coreNodeSelector
 binderhub:
   config:
     BinderHub:
-      pod_quota: 200
+      pod_quota: 400
       build_node_selector: *userNodeSelector
       hub_url: https://hub.gke2.mybinder.org
       badge_base_url: https://mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -597,7 +597,7 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
-      weight: 100
+      weight: 0
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
   nodeSelector: {}


### PR DESCRIPTION
It's unhealthy for a few reasons - pods are getting evicted due to DiskPressure, plus lots of intermittent network issues (especially internal DNS resolution)


increase GKE capacity since it's funded now and both OVH and turing are unhealthy