### PR TITLE
unpin pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 chartpress==1.0.*,>=1.0.2
 kubernetes
-# pin pytest until rerunfailures gets an update:
-# https://github.com/pytest-dev/pytest-rerunfailures/issues/128
-pytest<6.1.0
+pytest
 pytest-rerunfailures
 pytest-timeout
 pytest-xdist


### PR DESCRIPTION
pytest-rerunfailures has been fixed, and pinning down pytest causes failures on Python 3.10