### PR TITLE
make several prime-only components opt-in

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -25,8 +25,7 @@ binderhub:
       mountPath: /secrets
       readOnly: true
   extraEnv:
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /secrets/service-account.json
+    GOOGLE_APPLICATION_CREDENTIALS: /secrets/service-account.json
 
   ingress:
     hosts:
@@ -129,15 +128,3 @@ static:
       - static-mybinder.mybinder.ovh
     tls:
       secretName: kubelego-tls-static
-
-redirector:
-  enabled: false
-
-matomo:
-  enabled: false
-
-analyticsPublisher:
-  enabled: false
-
-gcsProxy:
-  enabled: false

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -152,6 +152,7 @@ proxyPatches:
   nodeSelector: *coreNodeSelector
 
 redirector:
+  enabled: true
   nodeSelector: *coreNodeSelector
   redirects:
     - type: host
@@ -176,6 +177,7 @@ redirector:
         to: mybinder.org/matomo/index.php
 
 matomo:
+  enabled: true
   replicas: 3
   nodeSelector: *coreNodeSelector
   db:
@@ -198,6 +200,7 @@ matomo:
       memory: 1Gi
 
 analyticsPublisher:
+  enabled: true
   project: binderhub-288415
   destinationBucket: binder-events-archive
   events:
@@ -206,6 +209,7 @@ analyticsPublisher:
     sourceBucket: binder-billing-archive
 
 gcsProxy:
+  enabled: true
   buckets:
     - name: binder-events-archive
       host: archive.analytics.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -10,8 +10,7 @@ binderhub:
       sticky_builds: true
       build_memory_limit: "2G"
   extraEnv:
-    - name: EVENT_LOG_NAME
-      value: "binderhub-staging-events-text"
+    EVENT_LOG_NAME: "binderhub-staging-events-text"
 
   resources:
     requests:
@@ -112,6 +111,7 @@ static:
       - static.gke2.staging.mybinder.org
 
 redirector:
+  enabled: true
   redirects:
     - type: host
       host:
@@ -143,6 +143,7 @@ analyticsPublisher:
     sourceBucket: binder-billing-archive
 
 gcsProxy:
+  enabled: true
   buckets:
     - name: binder-staging-events-archive
       host: archive.analytics.gke2.staging.mybinder.org

--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -45,8 +45,7 @@ binderhub:
       mountPath: /event-secret
       readOnly: true
   extraEnv:
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /event-secret/service-account.json
+    GOOGLE_APPLICATION_CREDENTIALS: /event-secret/service-account.json
 
   jupyterhub:
     singleuser:
@@ -144,19 +143,3 @@ static:
       - static.mybinder.turing.ac.uk
     tls:
       secretName: turing-static-tls-crt
-
-redirector:
-  redirects:
-    - type: host
-      host:
-        from: docs-mybinder.turing.10.0.0.1.xip.io
-        to: mybinder.readthedocs.io
-
-matomo:
-  enabled: false
-
-analyticsPublisher:
-  enabled: false
-
-gcsProxy:
-  enabled: false

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -449,7 +449,7 @@ ingress-nginx:
       externalTrafficPolicy: Local
 
 redirector:
-  enabled: true
+  enabled: false
   nodeSelector: {}
   redirects: []
   ingress:
@@ -530,7 +530,7 @@ proxyPatches:
   nodeSelector: {}
 
 matomo:
-  enabled: true
+  enabled: false
   nodeSelector: {}
   resources: {}
   replicas: 1
@@ -542,12 +542,12 @@ matomo:
     tables_prefix: matomo_
 
 gcsProxy:
-  enabled: true
+  enabled: false
   replicas: 1
   nodeSelector: {}
 
 analyticsPublisher:
-  enabled: true
+  enabled: false
   events:
     logName: binderhub-events-text
   image:


### PR DESCRIPTION
- redirector
- matomo
- analyticsPublisher
- gcsProxy

simplifies other federation config to not have to opt-out all the time

updated some extraEnvs from lists to better-supported dicts, since it was confusing my checks with `helm diff` verifying that there are no actual changes.