### PR TITLE
ovh: back in

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -115,7 +115,14 @@ prometheus:
 ingress-nginx:
   controller:
     hostNetwork: true
+    # host networking requires single instance
+    # with recreate to avoid new pods being unschedulable
+    # due to '1 node(s) didn't have free ports'
+    # Bumping the ingress causes downtime!
     replicaCount: 1
+    updateStrategy:
+      type: Recreate
+
     # OVH host-networking requires ingress controller on node-1
     nodeSelector:
       kubernetes.io/hostname: node-1

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -593,7 +593,7 @@ federationRedirect:
       versions: https://gesis.mybinder.org/versions
     ovh:
       url: https://ovh.mybinder.org
-      weight: 0
+      weight: 100
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
     turing:


### PR DESCRIPTION
disks have been cleaned

also fix ingress-nginx update strategy to deal with a single node port, which prevents rolling updates from working