### PR TITLE
Re-enable cryptnono on turing

### DIFF
--- a/config/turing.yaml
+++ b/config/turing.yaml
@@ -84,7 +84,7 @@ binderhub:
     imageGCThresholdType: "absolute"
 
 cryptnono:
-  enabled: false
+  enabled: true
 
 grafana:
   nodeSelector: *coreNodeSelector


### PR DESCRIPTION
After https://github.com/jupyterhub/mybinder.org-deploy/pull/2254
was merged
