### PR TITLE
Minor deploy refactoring; add `turing` release name to cd.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -201,6 +201,7 @@ jobs:
             hub_url: https://hub.mybinder.turing.ac.uk
             chartpress_args: ""
             helm_version: ""
+            release_name: turing
 
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org

--- a/deploy.py
+++ b/deploy.py
@@ -265,7 +265,7 @@ def main():
     )
 
     args = argparser.parse_args()
-    
+
     # Check if the local flag is set
     if not args.local:
         # Check if the script is being run on CI
@@ -294,7 +294,7 @@ def main():
 
         # script is running on CI, proceed with auth and helm setup
         cluster = args.cluster or args.release
-      
+
         if cluster == "ovh":
             setup_auth_ovh(args.release, cluster)
         elif cluster in AZURE_RGs:

--- a/deploy.py
+++ b/deploy.py
@@ -97,9 +97,6 @@ def setup_auth_gcloud(release, cluster=None):
         ]
     )
 
-    if not cluster:
-        cluster = release
-
     project = GCP_PROJECTS[release]
     zone = GCP_ZONES[release]
 
@@ -249,7 +246,7 @@ def main():
     argparser.add_argument(
         "release",
         help="Release to deploy",
-        choices=["staging", "prod", "ovh", "turing"],
+        choices=["staging", "prod", "ovh", "turing-prod", "turing-staging", "turing"],
     )
     argparser.add_argument(
         "--name",
@@ -268,7 +265,7 @@ def main():
     )
 
     args = argparser.parse_args()
-
+    
     # Check if the local flag is set
     if not args.local:
         # Check if the script is being run on CI
@@ -296,12 +293,14 @@ def main():
                 raise ValueError("Unrecognised input. Expecting either yes or no.")
 
         # script is running on CI, proceed with auth and helm setup
-        if args.cluster == "ovh":
-            setup_auth_ovh(args.release, args.cluster)
-        elif args.cluster in AZURE_RGs:
-            setup_auth_turing(args.release)
-        elif args.cluster in GCP_PROJECTS:
-            setup_auth_gcloud(args.release, args.cluster)
+        cluster = args.cluster or args.release
+      
+        if cluster == "ovh":
+            setup_auth_ovh(args.release, cluster)
+        elif cluster in AZURE_RGs:
+            setup_auth_turing(cluster)
+        elif cluster in GCP_PROJECTS:
+            setup_auth_gcloud(args.release, cluster)
         else:
             raise Exception("Cloud cluster not recognised!")
 


### PR DESCRIPTION
Changed `deploy.py` so that `cluster = args.cluster or args.release` if no cluster name was given. This means you can pass just one argument to `deploy.py`, which is what happens for the CD staging deployment (`deploy.py staging`). 

Also added a turing `release_name` to the CD deployment. During redeployment of the Turing cluster (#2304 ) I didn't want to delete the old turing cluster before redeployment so I renamed the cluster to `turing-prod`, but the release name defaulted to `turing` at that time. 

Finally, I expanded the release options to include `turing-staging` and `turing-prod`, so that in the future we can keep the convention of `release == cluster` without renaming the cluster.  