### PR TITLE
make cluster_name and release_name for turing explicit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,12 +196,13 @@ jobs:
             chartpress_args: ""
             helm_version: ""
 
-          - federation_member: turing-prod
+          - federation_member: turing
             binder_url: https://turing.mybinder.org
             hub_url: https://hub.mybinder.turing.ac.uk
             chartpress_args: ""
             helm_version: ""
             release_name: turing
+            cluster_name: turing-prod
 
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org


### PR DESCRIPTION
As per #2315 comments (https://github.com/jupyterhub/mybinder.org-deploy/pull/2315#issuecomment-1203930197), the cd was looking for the config file `turing-prod.yml`.  

Changed `cd.yml` so that the federation member remains `turing`, but the cluster_name and release_name are explicit, to allow for easy updating in the future. 
