### PR TITLE
turing-staging: don't block production deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false # Do not cancel all jobs if one fails
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run
+      continue-on-error: ${{ matrix.experimental }}
       matrix:
+        experimental: false
         include:
           # Now we have only one staging environment, but we have had two when
           # we transitioned from one k8s cluster to another.
@@ -87,6 +90,8 @@ jobs:
             hub_url: https://hub-staging.mybinder.turing.ac.uk
             chartpress_args: ""
             helm_version: ""
+            # TODO: Remove this when turing-staging reliably passes
+            experimental: true
 
     steps:
       - name: "Stage 0: Update env vars based on job matrix arguments"


### PR DESCRIPTION
turing-staging currently fails, which blocks all production deploys on the master branch (https://github.com/jupyterhub/mybinder.org-deploy/issues/2337). We currently have several PRs merged to master that aren't deployed.

This will hopefully ignore the status of the turing-staging job until it can be fixed.