### PR TITLE
Allocate resources for all PyHEP 2022 talks and tutorials

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -107,6 +107,71 @@ binderhub:
           # 2022-05-27
           config:
             quota: 400
+        - pattern: ^henryiii/level-up-your-python.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-12 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#18-level-up-your-python
+          config:
+            quota: 500
+        - pattern: ^SengerM/the_bureaucrat.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-12 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#30-thebureaucrat-a-package-to
+          config:
+            quota: 500
+        - pattern: ^amangoel185/pyhep-2022-histogramming-talk.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-12 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#43-histograms-as-objects-tools
+          config:
+            quota: 500
+        - pattern: ^jpivarski-talks/2022-09-12-pyhep22-awkward-combinatorics.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-12 PyHEP 2022 #13-combinatorics-with-uproot-a
+          config:
+            quota: 500
+        - pattern: ^sauerburger/pyhep-uhepp.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-12 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#23-uhepp-sharing-plots-in-a-se
+          config:
+            quota: 500
+        - pattern: ^hdembinski/pyhep-2022-iminuit.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-13 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#4-iminuit-fitting-models-to-da
+          config:
+            quota: 400
+        - pattern: ^Saransh-cpp/PyHEP22-Constructing-HEP-vectors-and-analyzing-HEP-data-using-Vector.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-13 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#32-constructing-hep-vectors-an
+          config:
+            quota: 400
+        - pattern: ^cooperative-computing-lab/coffea-wq-notebook.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-14 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#14-automatic-resource-manageme
+          config:
+            quota: 400
+        - pattern: ^alexander-held/PyHEP-2022-AGC.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-15 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#16-end-to-end-physics-analysis
+          config:
+            quota: 400
+        - pattern: ^goi42/pythia8_python_interface_pyHEP_2022.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-15 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#8-the-pythia8-python-interface
+          config:
+            quota: 400
+        - pattern: ^masonproffitt/pyhep-2022-abcd-pyhf.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-16 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#17-abcd_pyhf-likelihood-based
+          config:
+            quota: 400
+        - pattern: ^peterridolfi/Pyhf-to-Combine-converter.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-16 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#19-pyhf-to-combine-converter
+          config:
+            quota: 400
+        - pattern: ^jet-net/demo-pyhep-2022.*
+          # https://github.com/jupyterhub/mybinder.org-deploy/issues/2333
+          # 2021-09-16 PyHEP 2022 https://indico.cern.ch/event/1150631/timetable/#29-jetnet-library-for-machine
+          config:
+            quota: 400
       # - pattern: ^github-owner/github-repo-prefix.*
       #   # YYYY-MM-DD of workshop
       #   config:


### PR DESCRIPTION
This PR allocates pods for talks on days 1 through 5 of [PyHEP 2022](https://indico.cern.ch/event/1150631/timetable/) as requested in Issue #2333. There may be some additional stragglers as we're still waiting on some speakers to complete registration, but I will work to get their repo info as soon as possible and make any follow up PRs as needed.

I've set the `quota` to be 500 on day 1 of the workshop (2022-09-12) as there will be more attendance on the first day and we have some of the more historically popular talks then. I've set the `quota` to be 400 for all following days. For context we currently have just over 1000 attendees registered.

I'll open a follow up PR that will deallocate all resources and close Issue #2333 after the workshop ends on 2022-09-17.

I'm following the PR I made for PyHEP 2021 https://github.com/jupyterhub/mybinder.org-deploy/pull/1980/ as a template, so let me know if there are any changes to procedure in the last year. :+1: 