### PR TITLE
Include list of merged PRs in dependency bumps for jupyterhub repos

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -83,8 +83,7 @@ jobs:
         # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
         run: |
           pip install PyGithub
-          PR_LIST=$(./scripts/get-prs.py ${{matrix.repository}} ${{steps.local.outputs.tag}} ${{steps.latest.outputs.tag}})
-          PR_LIST="${PR_LIST//$'\n'/'%0A'}"
+          PR_LIST=$(./scripts/get-prs.py ${{matrix.repository}} ${{steps.local.outputs.tag}} ${{steps.latest.outputs.tag}} --github-action-escape)
           echo "::set-output name=prs::$PR_LIST"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -213,8 +212,7 @@ jobs:
         # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
         run: |
           pip install PyGithub
-          PR_LIST=$(./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}})
-          PR_LIST="${PR_LIST//$'\n'/'%0A'}"
+          PR_LIST=$(./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} --github-action-escape)
           echo "::set-output name=prs::$PR_LIST"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -76,6 +76,19 @@ jobs:
         if: steps.local.outputs.tag != steps.latest.outputs.tag
         run: git --no-pager diff --color=always
 
+      - name: PR summary
+        id: prsummary
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        # Needs to be a single line string
+        # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
+        run: |
+          pip install PyGithub
+          PR_LIST=$(./scripts/get-prs.py ${{matrix.repository}} ${{steps.local.outputs.tag}} ${{steps.latest.outputs.tag}})
+          PR_LIST="${PR_LIST//$'\n'/'%0A'}"
+          echo "::set-output name=prs::$PR_LIST"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
         uses: peter-evans/create-pull-request@v4.1.1
@@ -92,6 +105,9 @@ jobs:
           title: Update ${{ matrix.registry }}/${{ matrix.repository }} version to ${{ steps.latest.outputs.tag }}
           body: |
             Updates mybinder to depend on the `${{ matrix.registry }}/${{ matrix.repository }}` image version `${{ steps.latest.outputs.tag }}` from version `${{ steps.local.outputs.tag }}`.
+
+            ## Merged PRs:
+            ${{ steps.prsummary.outputs.prs }}
 
             ## Related
 
@@ -119,30 +135,35 @@ jobs:
             chart_dep_app_changelog_url: "https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md"
             chart_dep_source_url: "https://github.com/jupyterhub/binderhub/tree/master/helm-chart"
             chart_dep_devel_flag: "--devel"
+            github_repo: jupyterhub/binderhub
 
           - chart_dep_name: ingress-nginx
             chart_dep_chart_changelog_url: "https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#upgrading-chart"
             chart_dep_app_changelog_url: "https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md"
             chart_dep_source_url: "https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx"
             chart_dep_devel_flag: ""
+            github_repo: ""
 
           - chart_dep_name: prometheus
             chart_dep_chart_changelog_url: "https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#upgrading-chart"
             chart_dep_app_changelog_url: "https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md"
             chart_dep_source_url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
             chart_dep_devel_flag: ""
+            github_repo: ""
 
           - chart_dep_name: grafana
             chart_dep_chart_changelog_url: "https://github.com/grafana/helm-charts/tree/main/charts/grafana#upgrading-an-existing-release-to-a-new-major-version"
             chart_dep_app_changelog_url: "https://github.com/grafana/grafana/blob/master/CHANGELOG.md"
             chart_dep_source_url: "https://github.com/grafana/helm-charts/tree/main/charts/grafana"
             chart_dep_devel_flag: ""
+            github_repo: ""
 
           - chart_dep_name: cryptnono
             chart_dep_chart_changelog_url: ""
             chart_dep_app_changelog_url: ""
             chart_dep_source_url: "https://github.com/yuvipanda/cryptnono/"
             chart_dep_devel_flag: "--devel"
+            github_repo: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -185,6 +206,19 @@ jobs:
       - name: git diff
         run: git --no-pager diff --color=always
 
+      - name: PR summary
+        id: prsummary
+        if: matrix.github_repo && (steps.local.outputs.version != steps.latest.outputs.version)
+        # Needs to be a single line string
+        # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
+        run: |
+          pip install PyGithub
+          PR_LIST=$(./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}})
+          PR_LIST="${PR_LIST//$'\n'/'%0A'}"
+          echo "::set-output name=prs::$PR_LIST"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
         uses: peter-evans/create-pull-request@v4.1.1
@@ -206,6 +240,9 @@ jobs:
             -|-|-
             Chart.yaml's version | `${{ steps.local.outputs.version }}` | `${{ steps.latest.outputs.version }}`
             Chart.yaml's appVersion | `${{ steps.local.outputs.appVersion }}` | `${{ steps.latest.outputs.appVersion }}`
+
+            ## Merged PRs:
+            ${{ steps.prsummary.outputs.prs }}
 
             ## Related
 

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -105,7 +105,6 @@ jobs:
           body: |
             Updates mybinder to depend on the `${{ matrix.registry }}/${{ matrix.repository }}` image version `${{ steps.latest.outputs.tag }}` from version `${{ steps.local.outputs.tag }}`.
 
-            ## Merged PRs:
             ${{ steps.prsummary.outputs.prs }}
 
             ## Related
@@ -239,7 +238,6 @@ jobs:
             Chart.yaml's version | `${{ steps.local.outputs.version }}` | `${{ steps.latest.outputs.version }}`
             Chart.yaml's appVersion | `${{ steps.local.outputs.appVersion }}` | `${{ steps.latest.outputs.appVersion }}`
 
-            ## Merged PRs:
             ${{ steps.prsummary.outputs.prs }}
 
             ## Related

--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import os
+import re
+from argparse import ArgumentParser
+
+import github
+
+
+def extract_gitref(s):
+    """
+    Extract git ref from a container registry tag or Helm chart version
+
+    Examples:
+    - 2022.02.0 -> 2022.02.0
+    - 2022.02.0-90.g0345a86 -> 0345a86
+    - 0.2.0 -> 0.2.0
+    - 0.2.0-n1011.hb49edf6 -> b49edf6
+    - 0.2.0-0.dev.git.2752.h3450e52 -> 3450e52
+    """
+    m = re.match(r"[\d\.]+-[\w\.]+[gh]([0-9a-f]+)", s)
+    if m:
+        return m.group(1)
+    return s
+
+
+token = os.getenv("GITHUB_TOKEN")
+
+parser = ArgumentParser(description="Summarise PRs from a repo")
+parser.add_argument("repo", help="The repository in format user/repo")
+parser.add_argument("start", help="commit or image/chart version from which to start")
+parser.add_argument("end", help="commit or image/chart version to which to end")
+
+args = parser.parse_args()
+
+gh = github.Github(token)
+r = gh.get_repo(args.repo)
+
+start = extract_gitref(args.start)
+end = extract_gitref(args.end)
+
+prs = set()
+git_compare = r.compare(start, end)
+for c in git_compare.commits:
+    s = gh.search_issues("", type="pr", repo=args.repo, sha=c.sha)
+    prs.update(s)
+
+for pr in sorted(prs):
+    print(f"- [#{pr.number}]({pr.html_url}) {pr.title}")

--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -29,6 +29,11 @@ parser = ArgumentParser(description="Summarise PRs from a repo")
 parser.add_argument("repo", help="The repository in format user/repo")
 parser.add_argument("start", help="commit or image/chart version from which to start")
 parser.add_argument("end", help="commit or image/chart version to which to end")
+parser.add_argument(
+    "--github-action-escape",
+    action="store_true",
+    help="Escape output for GitHub Action",
+)
 
 args = parser.parse_args()
 
@@ -44,5 +49,12 @@ for c in git_compare.commits:
     s = gh.search_issues("", type="pr", repo=args.repo, sha=c.sha)
     prs.update(s)
 
-for pr in sorted(prs):
-    print(f"- [#{pr.number}]({pr.html_url}) {pr.title}")
+
+pr_summaries = [
+    f"- [#{pr.number}]({pr.html_url}) {pr.title}"
+    for pr in sorted(prs, key=lambda pr: pr.number)
+]
+if args.github_action_escape:
+    print("%0A".join(pr_summaries))
+else:
+    print("\n".join(pr_summaries))


### PR DESCRIPTION
This script takes a repository, current tag/commit/chart-version/docker-tag, new tag/commit/chart-version/docker-tag, and outputs a list of PRs in markdown that is used in a pull request body.

~Untested.... though I think it's ready to try.~

Closes https://github.com/jupyterhub/mybinder.org-deploy/issues/2290