### PR TITLE
BinderHub 0.2.0-0.dev.git.2782.h3ccfc44 (most recent version using JupyterHub<2)

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/master/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/master/CHANGES.md
   - name: binderhub
-    version: "0.2.0-n988.h72e1852"
+    version: "0.2.0-0.dev.git.2782.h3ccfc44"
     repository: https://jupyterhub.github.io/helm-chart
 
   # Ingress-Nginx to route network traffic according to Ingress resources using


### PR DESCRIPTION
This is the most recent BinderHub chart using JupyterHub 1.* Subsequent versions use Z2JH 2.0.0 JupyterHub 3.0.0

---

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/72e1852...3ccfc44
