### PR TITLE
avoid ovh node-1

### DIFF
--- a/config/ovh.yaml
+++ b/config/ovh.yaml
@@ -67,6 +67,15 @@ binderhub:
       networkTools:
         image:
           pullPolicy: IfNotPresent
+      # there appear to be networking problems on node-1
+      # can't cordon due to the ingress controller
+      extraNodeAffinity:
+        required:
+          - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                  - node-1
 
   imageCleaner:
     # Use 40GB as upper limit, size is given in bytes


### PR DESCRIPTION
mysterious networking health problem in #2378 only seems to affect node-1.

can't use the simple solution of cordoning because the ingress controller is pinned to node-1, so use node affinity instead