### PR TITLE
grafana: direct access to prometheus is removed

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -101,7 +101,6 @@ grafana:
           orgId: 1
           type: prometheus
           url: https://prometheus.mybinder.org
-          access: direct
           isDefault: true
           editable: false
   persistence:


### PR DESCRIPTION
<img width="806" alt="Screen Shot 2022-10-25 at 08 46 52" src="https://user-images.githubusercontent.com/151929/197701853-956164b4-47af-4d85-a6cd-2b89bcbb43dc.png">

default is 'proxy' (aka 'server', not sure why the names are different), which is the only supported value.