### PR TITLE
netpol: allow image-builder

### DIFF
--- a/mybinder/templates/netpol.yaml
+++ b/mybinder/templates/netpol.yaml
@@ -16,7 +16,10 @@ spec:
         operator: In
         values:
           - singleuser-server
+          # TODO: Remove dind after upgrade is complete
+          # https://github.com/jupyterhub/binderhub/pull/1543
           - dind
+          - image-builder
     matchLabels:
       release: {{ .Release.Name }}
   policyTypes:


### PR DESCRIPTION
`component=dind` is changing to `component=image-builder` https://github.com/jupyterhub/binderhub/pull/1543
