### PR TITLE
Remove Turing from federation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -201,11 +201,15 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run
+    continue-on-error: ${{ matrix.experimental }}
     # We run this job multiple times with different parameters
     # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
     strategy:
       fail-fast: false # Do not cancel all jobs if one fails
       matrix:
+        experimental:
+          - false
         include:
           - federation_member: prod
             binder_url: https://gke.mybinder.org
@@ -220,6 +224,9 @@ jobs:
             helm_version: ""
             release_name: turing
             cluster_name: turing-prod
+            # TODO: Remove this when turing is reliable
+            # https://github.com/jupyterhub/mybinder.org-deploy/issues/2252
+            experimental: true
 
           - federation_member: ovh
             binder_url: https://ovh.mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -604,7 +604,8 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
-      weight: 100
+      # https://github.com/jupyterhub/mybinder.org-deploy/issues/2252#issuecomment-1295141310
+      weight: 0
       health: https://turing.mybinder.org/health
       versions: https://turing.mybinder.org/versions
   nodeSelector: {}


### PR DESCRIPTION
Turing is unreliable at the moment:
https://github.com/jupyterhub/mybinder.org-deploy/issues/2252

The CI deployment is kept, but I've set `continue-on-error` so hopefully this will prevent GitHub notifying us of CI failures for Turing on every merge.