### PR TITLE
Remove GESIS from federation redirect

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -594,7 +594,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://gesis.mybinder.org
-      weight: 100
+      weight: 0
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     ovh:


### PR DESCRIPTION
We are currently having some communication issues in our Kubernetes cluster.
