### PR TITLE
ci: attempt to fix set-output again

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -76,19 +76,16 @@ jobs:
         if: steps.local.outputs.tag != steps.latest.outputs.tag
         run: git --no-pager diff --color=always
 
-      - name: PR summary
+      - name: Fetch PR summary
         id: prsummary
         if: steps.local.outputs.tag != steps.latest.outputs.tag
         run: |
           pip install PyGithub
-
-          # We want to set multiline output, so we rely on this technique:
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          #
-          eof_randomized=EOF_$RANDOM
-          echo "prs<<$eof_randomized" >> $GITHUB_OUTPUT
-          ./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} >> $GITHUB_OUTPUT
-          echo "$eof_randomized" >> $GITHUB_OUTPUT
+          ./scripts/get-prs.py \
+              ${{matrix.github_repo}} \
+              ${{steps.local.outputs.version}} \
+              ${{steps.latest.outputs.version}} \
+              --write-github-actions-output=prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -208,19 +205,16 @@ jobs:
       - name: git diff
         run: git --no-pager diff --color=always
 
-      - name: PR summary
+      - name: Fetch PR summary
         id: prsummary
         if: matrix.github_repo && (steps.local.outputs.version != steps.latest.outputs.version)
         run: |
           pip install PyGithub
-
-          # We want to set multiline output, so we rely on this technique:
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          #
-          eof_randomized=EOF_$RANDOM
-          echo "prs<<$eof_randomized" >> $GITHUB_OUTPUT
-          ./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} >> $GITHUB_OUTPUT
-          echo "$eof_randomized" >> $GITHUB_OUTPUT
+          ./scripts/get-prs.py \
+              ${{matrix.github_repo}} \
+              ${{steps.local.outputs.version}} \
+              ${{steps.latest.outputs.version}} \
+              --write-github-actions-output=prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -79,12 +79,16 @@ jobs:
       - name: PR summary
         id: prsummary
         if: steps.local.outputs.tag != steps.latest.outputs.tag
-        # Needs to be a single line string
-        # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
         run: |
           pip install PyGithub
-          PR_LIST=$(./scripts/get-prs.py ${{matrix.repository}} ${{steps.local.outputs.tag}} ${{steps.latest.outputs.tag}} --github-action-escape)
-          echo "prs=$PR_LIST" >> $GITHUB_OUTPUT
+
+          # We want to set multiline output, so we rely on this technique:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          #
+          eof_randomized=EOF_$RANDOM
+          echo "prs<<$eof_randomized" >> $GITHUB_OUTPUT
+          ./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} >> $GITHUB_OUTPUT
+          echo "$eof_randomized" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -207,12 +211,16 @@ jobs:
       - name: PR summary
         id: prsummary
         if: matrix.github_repo && (steps.local.outputs.version != steps.latest.outputs.version)
-        # Needs to be a single line string
-        # https://trstringer.com/github-actions-multiline-strings/#option-1---string-substitution
         run: |
           pip install PyGithub
-          PR_LIST=$(./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} --github-action-escape)
-          echo "prs=$PR_LIST" >> $GITHUB_OUTPUT
+
+          # We want to set multiline output, so we rely on this technique:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          #
+          eof_randomized=EOF_$RANDOM
+          echo "prs<<$eof_randomized" >> $GITHUB_OUTPUT
+          ./scripts/get-prs.py ${{matrix.github_repo}} ${{steps.local.outputs.version}} ${{steps.latest.outputs.version}} >> $GITHUB_OUTPUT
+          echo "$eof_randomized" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -30,11 +30,6 @@ parser.add_argument("repo", help="The repository in format user/repo")
 parser.add_argument("start", help="commit or image/chart version from which to start")
 parser.add_argument("end", help="commit or image/chart version to which to end")
 parser.add_argument(
-    "--github-action-escape",
-    action="store_true",
-    help="Escape output for GitHub Action",
-)
-parser.add_argument(
     "--max-commits",
     type=int,
     default=100,
@@ -65,7 +60,4 @@ else:
     ]
 
 md = ["# PRs"] + pr_summaries + ["", f"{r.html_url}/compare/{start}...{end}"]
-if args.github_action_escape:
-    print("%0A".join(md))
-else:
-    print("\n".join(md))
+print("\n".join(md))


### PR DESCRIPTION
This PR is my attempt to address what @minrk observed in #2413. Closes #2413.

> @consideRatio the new way to use set-output seems to handle newlines differently. They are showing up as %0A (url-escaped \n) instead of actual newlines, as in jupyterhub/mybinder.org-deploy#2416 following jupyterhub/mybinder.org-deploy#2413

> Multiline fields are trouble for sure, maybe I've made a change where something was a multiline field but I assumed it wasn't.
This is https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings. I'll fix the issue in mybinder.org-deploy

> Hmmm hmmm, confused, as it seems there is some work done to put things on a single line string.
>
> https://github.com/jupyterhub/mybinder.org-deploy/pull/2413/files#diff-0b5791a525845ca4e9757d7fb779b85cef36a1aa351e74f8f1722e76a3b8c7cdL82-R87