### PR TITLE
add OVH2 to federation

### DIFF
--- a/docs/source/operation_guide/federation.rst
+++ b/docs/source/operation_guide/federation.rst
@@ -14,6 +14,7 @@ the BinderHub federation, who is in it, how to join it, etc, see
 ==========================  ========  ===============  ==============  =============== =====
 gke.mybinder.org
 ovh.mybinder.org
+ovh2.mybinder.org
 gesis.mybinder.org
 turing.mybinder.org
 ==========================  ========  ===============  ==============  =============== =====
@@ -24,6 +25,7 @@ turing.mybinder.org
    var fedUrls = [
        "https://gke.mybinder.org",
        "https://ovh.mybinder.org",
+       "https://ovh2.mybinder.org",
        "https://gesis.mybinder.org",
        "https://turing.mybinder.org",
    ]

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -618,6 +618,11 @@ federationRedirect:
       weight: 100
       health: https://ovh.mybinder.org/health
       versions: https://ovh.mybinder.org/versions
+    ovh2:
+      url: https://ovh2.mybinder.org
+      weight: 100
+      health: https://ovh2.mybinder.org/health
+      versions: https://ovh2.mybinder.org/versions
     turing:
       url: https://turing.mybinder.org
       # https://github.com/jupyterhub/mybinder.org-deploy/issues/2252#issuecomment-1295141310


### PR DESCRIPTION
#2414 seems to be working fine.

This adds OVH2 to the cluster with a capacity of only 10, to see how it goes. Can slowly increase capacity over the week.