### PR TITLE
report pod quota as unhealthy when pod_headroom is the reason

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -364,6 +364,7 @@ async def health_check(host, active_hosts):
                             check["total_pods"] + CONFIG["pod_headroom"]
                             >= check["quota"]
                         ):
+                            check["ok"] = False
                             raise FailedCheck(
                                 f"{host} is approaching pod quota: {check['total_pods']}/{check['quota']}",
                                 reason=check["service"],


### PR DESCRIPTION
avoids mysterious 'ovh2 is unhealthy, but every check is ok' state when `pod occupancy >= limit - headroom`, which looks like:

![Screenshot 2022-11-21 at 11 11 33](https://user-images.githubusercontent.com/151929/203024149-4c34f5c4-18e6-46d4-8a1b-7d48ce8f9a3f.png)
