### PR TITLE
federation-redirect: merge config into default config

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -59,14 +59,14 @@ CONFIG = {
 
 def get_config(config_path):
     app_log.info(f"Using config from '{config_path}'.")
+    config = CONFIG.copy()
 
     with open(config_path) as f:
-        config = json.load(f)
+        config.update(json.load(f))
 
     # merge default config
-    config.setdefault("check", CONFIG["check"])
-    for key in CONFIG["check"]:
-        config["check"].setdefault(key, CONFIG["check"][key])
+    for key, value in CONFIG["check"].items():
+        config["check"].setdefault(key, value)
 
     for h in list(config["hosts"].keys()):
         # Remove empty entries from CONFIG["hosts"], these can happen because we


### PR DESCRIPTION
avoids loaded config from unsetting default values, resulting in undefined keys instead of default behavior

previously, every config field defined in app.py had to be duplicated to values.yaml, even if unchanged. #2433 resulted in KeyErrors on the new `host_cookie_age_hours` option.