### PR TITLE
update events archive log sink rule

### DIFF
--- a/terraform/modules/mybinder/resource.tf
+++ b/terraform/modules/mybinder/resource.tf
@@ -174,7 +174,7 @@ resource "google_logging_project_sink" "events-archive" {
   project = data.google_client_config.provider.project
 
   name                   = "binderhub-${var.name}-events-raw-text"
-  filter                 = "resource.type=\"global\" AND logName=\"projects/${data.google_client_config.provider.project}/logs/${local.events_log_prefix}-events-text\""
+  filter                 = "logName=\"projects/${data.google_client_config.provider.project}/logs/${local.events_log_prefix}-events-text\""
   destination            = "storage.googleapis.com/${google_storage_bucket.raw-export.name}"
   unique_writer_identity = true
 }


### PR DESCRIPTION
GKE sets resource_type=k8s_container instead of global, since google-cloud-logging 3

This stops the loss of sink data in https://github.com/jupyterhub/mybinder.org-deploy/issues/2394#issuecomment-1324910806, but doesn't recover the gap, yet