### PR TITLE
Change test-this-pr.yml workflow to use jupyterhub-bot PAT

### DIFF
--- a/.github/workflows/test-this-pr.yml
+++ b/.github/workflows/test-this-pr.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: sgibson91/test-this-pr-action@main
         with:
-          access_token: ${{ secrets.TEST_THIS_PR_ACCESS_TOKEN }}
+          access_token: ${{ secrets.jupyterhub_bot_pat }}


### PR DESCRIPTION
Stops initial comment coming from my personal GitHub account

for example: https://github.com/jupyterhub/mybinder.org-deploy/pull/2437#issuecomment-1326416601

The PAT needs `public_repo` scope at a minimum: https://github.com/sgibson91/test-this-pr-action/blob/main/README.md (We could probably investigate the new fine-grained access PATs too)