### PR TITLE
remove legacy ovh from federation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -226,14 +226,6 @@ jobs:
             # https://github.com/jupyterhub/mybinder.org-deploy/issues/2252
             experimental: true
 
-          - federation_member: ovh
-            binder_url: https://ovh.mybinder.org
-            hub_url: https://hub-binder.mybinder.ovh
-            # image-prefix should match ovh registry config in secrets/config/ovh.yaml
-            chartpress_args: "--push --image-prefix=3i2li627.gra7.container-registry.ovh.net/binder/mybinder-"
-            helm_version: ""
-            experimental: false
-
           - federation_member: ovh2
             binder_url: https://ovh2.mybinder.org
             hub_url: https://hub.ovh2.mybinder.org
@@ -292,15 +284,6 @@ jobs:
         uses: sliteteam/github-action-git-crypt-unlock@8b1fa3ccc81e322c5c45fbab261eee46513fd3f8
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-
-      # Action Repo: https://github.com/Azure/docker-login
-      - name: "Stage 3: Login to Docker registry (OVH)"
-        if: matrix.federation_member == 'ovh'
-        uses: azure/docker-login@v1
-        with:
-          login-server: 3i2li627.gra7.container-registry.ovh.net
-          username: ${{ secrets.DOCKER_USERNAME_OVH }}
-          password: ${{ secrets.DOCKER_PASSWORD_OVH }}
 
       - name: "Stage 3: Run chartpress to update values.yaml"
         run: |

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -40,19 +40,6 @@ CONFIG = {
             versions="https://gke.mybinder.org/versions",
             prime=True,
         ),
-        "ovh": dict(
-            url="https://ovh.mybinder.org",
-            weight=1,
-            health="https://ovh.mybinder.org/health",
-            # health="https://httpbin.org/status/404",
-            versions="https://ovh.mybinder.org/versions",
-        ),
-        "gesis": dict(
-            url="https://gesis.mybinder.org",
-            weight=200,
-            health="https://gesis.mybinder.org/health",
-            versions="https://gesis.mybinder.org/versions",
-        ),
     },
 }
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -614,11 +614,6 @@ federationRedirect:
       weight: 0
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
-    ovh:
-      url: https://ovh.mybinder.org
-      weight: 100
-      health: https://ovh.mybinder.org/health
-      versions: https://ovh.mybinder.org/versions
     ovh2:
       url: https://ovh2.mybinder.org
       weight: 100


### PR DESCRIPTION
we have a new ovh cluster to replace it

and the old one seems to be unhealthy
