### PR TITLE
bump ovh2 out of rotation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -621,7 +621,7 @@ federationRedirect:
       versions: https://ovh.mybinder.org/versions
     ovh2:
       url: https://ovh2.mybinder.org
-      weight: 100
+      weight: 0
       health: https://ovh2.mybinder.org/health
       versions: https://ovh2.mybinder.org/versions
     turing:


### PR DESCRIPTION
seems to be having network problems, and credential problems:

> unauthorized: unauthorized to access repository: mybinder-builds/r2d-g5b5b759binder-2dexamples-2drequirements-55ab5c, action: push: unauthorized to access repository: mybinder-builds/r2d-g5b5b759binder-2dexamples-2drequirements-55ab5c, action: push

Did something change in how repo2docker's credentials are passed?
