### PR TITLE
WIP: Binderhub update (breaking changes)

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.2874.h2811d52"
+    version: "1.0.0-0.dev.git.3002.h5f189ce"
     repository: https://jupyterhub.github.io/helm-chart
 
   # Ingress-Nginx to route network traffic according to Ingress resources using

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3002.h5f189ce"
+    version: "1.0.0-0.dev.git.3009.h9046454"
     repository: https://jupyterhub.github.io/helm-chart
 
   # Ingress-Nginx to route network traffic according to Ingress resources using

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -159,8 +159,6 @@ binderhub:
       build_image: quay.io/jupyterhub/repo2docker:2022.10.0-89.g49162fc
       per_repo_quota: 100
       per_repo_quota_higher: 200
-      build_memory_limit: "3G"
-      build_memory_request: "1G"
       cors_allow_origin: "*"
 
       banner_message: |
@@ -207,6 +205,9 @@ binderhub:
               g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
             })();
           }
+    KubernetesBuildExecutor:
+      memory_limit: "3G"
+      memory_request: "1G"
 
   extraConfig:
     # Send Events to StackDriver on Google Cloud
@@ -248,8 +249,8 @@ binderhub:
       enabled: true
       type: kube-lego
 
+  imageBuilderType: dind
   dind:
-    enabled: true
     resources:
       requests:
         cpu: "0.5"
@@ -264,8 +265,6 @@ binderhub:
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80
     imageGCThresholdLow: 40
-    host:
-      enabled: false
 
   jupyterhub:
     cull:


### PR DESCRIPTION
# BinderHub PRs
- [#1516](https://github.com/jupyterhub/binderhub/pull/1516) Using escaped username in progress api call affecting launch of serve…
- [#1521](https://github.com/jupyterhub/binderhub/pull/1521) Breaking: Default to traitlets based Build class
- [#1531](https://github.com/jupyterhub/binderhub/pull/1531) Breaking: Podman in k8s
- [#1568](https://github.com/jupyterhub/binderhub/pull/1568) How to activate Google Container Registry API
- [#1579](https://github.com/jupyterhub/binderhub/pull/1579) [pre-commit.ci] pre-commit autoupdate
- [#1580](https://github.com/jupyterhub/binderhub/pull/1580) [pre-commit.ci] pre-commit autoupdate
- [#1582](https://github.com/jupyterhub/binderhub/pull/1582) binderhub image: refreeze requirements.txt
- [#1583](https://github.com/jupyterhub/binderhub/pull/1583) [pre-commit.ci] pre-commit autoupdate
- [#1585](https://github.com/jupyterhub/binderhub/pull/1585) binderhub image: refreeze requirements.txt
- [#1586](https://github.com/jupyterhub/binderhub/pull/1586) Add compatibility for fetching tokens from other Docker registries
- [#1587](https://github.com/jupyterhub/binderhub/pull/1587) binderhub-chart-config-old.yaml `imageBuilderType: "local"`
- [#1588](https://github.com/jupyterhub/binderhub/pull/1588) Simplify image-cleaner handling
- [#1589](https://github.com/jupyterhub/binderhub/pull/1589) Add tolerations to binderhub
- [#1591](https://github.com/jupyterhub/binderhub/pull/1591) Bump repo2docker to 2022.10.0
- [#1592](https://github.com/jupyterhub/binderhub/pull/1592) Warn about build_docker_config being a Helm Chart option not a BinderHub option
- [#1593](https://github.com/jupyterhub/binderhub/pull/1593) Add breaking changes to CHANGES.md
- [#1595](https://github.com/jupyterhub/binderhub/pull/1595) [pre-commit.ci] pre-commit autoupdate
- [#1597](https://github.com/jupyterhub/binderhub/pull/1597) Fix the default `use_registry` value
- [#1598](https://github.com/jupyterhub/binderhub/pull/1598) Add `health_handler_class` to make `/health` handler is customisable
- [#1599](https://github.com/jupyterhub/binderhub/pull/1599) Fix auth docs config (again)
- [#1600](https://github.com/jupyterhub/binderhub/pull/1600) chore(deps): bump jupyterhub/action-k8s-await-workloads from 1 to 2
- [#1601](https://github.com/jupyterhub/binderhub/pull/1601) pink.daemonset.extraArgs[]
- [#1602](https://github.com/jupyterhub/binderhub/pull/1602) Test dind and pink
- [#1603](https://github.com/jupyterhub/binderhub/pull/1603) Add all `c.BinderHub.*` properties used in chart to Values.yaml
- [#1605](https://github.com/jupyterhub/binderhub/pull/1605) binderhub image: refreeze requirements.txt
- [#1606](https://github.com/jupyterhub/binderhub/pull/1606) bump image-cleaner tag
- [#1607](https://github.com/jupyterhub/binderhub/pull/1607) [pre-commit.ci] pre-commit autoupdate
- [#1609](https://github.com/jupyterhub/binderhub/pull/1609) breaking: require k8s 1.21 like z2jh does now
- [#1610](https://github.com/jupyterhub/binderhub/pull/1610) breaking: require Python 3.8, from Python 3.6
- [#1611](https://github.com/jupyterhub/binderhub/pull/1611) breaking: test and use Python 3.11 in Helm chart image, up from Python 3.9
- [#1612](https://github.com/jupyterhub/binderhub/pull/1612) ci: set GITHUB_ACCESS_TOKEN to temporary read only token
- [#1615](https://github.com/jupyterhub/binderhub/pull/1615) ci: fix changed resolved ref for dataverse test, fix recent github ratelimit PR
- [#1617](https://github.com/jupyterhub/binderhub/pull/1617) binderhub image: refreeze requirements.txt
- [#1618](https://github.com/jupyterhub/binderhub/pull/1618) Document breaking changes so far
- [#1619](https://github.com/jupyterhub/binderhub/pull/1619) ci: Debug versions health metrics endpoints after CI tests
- [#1626](https://github.com/jupyterhub/binderhub/pull/1626) Build memory limits/requests should be `ByteSpecification`

https://github.com/jupyterhub/binderhub/compare/2811d52...9046454
