### PR TITLE
increase ovh2 capacity to 150

### DIFF
--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -8,7 +8,7 @@ coreNodeSelector: &coreNodeSelector
 binderhub:
   config:
     BinderHub:
-      pod_quota: 100
+      pod_quota: 150
       hub_url: https://hub.ovh2.mybinder.org
       badge_base_url: https://mybinder.org
       build_node_selector: *userNodeSelector


### PR DESCRIPTION
it seems healthier after the image-cleaner bump

failure to clean was causing disk exhaustion, but that doesn't seem to have happened since the bump.
