### PR TITLE
Revert "Updates ingress-nginx chart to 4.4.3"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   # NOTE: chart v3.36.0 maps to v0.49.0 and has support for networking.k8s.io/v1
   #       chart v4.1.2 maps to v1.2.0 and has dropped support for networking.k8s.io/v1beta1
   - name: ingress-nginx
-    version: "4.4.3"
+    version: "4.4.2"
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#2491 which has started failing because there is no 4.4.3! Seems to have been yanked.