### PR TITLE
get-prs.py: Ignore merge commits

### DIFF
--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -58,7 +58,9 @@ if len(commits) > args.max_commits:
     ]
 else:
     for c in commits:
-        prs.update(c.get_pulls())
+        if len(c.parents() == 1):
+            # Chartpress ignores merge commits when generating the Helm chart SHA
+            prs.update(c.get_pulls())
     pr_summaries = [
         f"- [#{pr.number}]({pr.html_url}) {pr.title}"
         for pr in sorted(prs, key=lambda pr: pr.number)

--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -58,7 +58,7 @@ if len(commits) > args.max_commits:
     ]
 else:
     for c in commits:
-        if len(c.parents() == 1):
+        if len(c.parents) == 1:
             # Chartpress ignores merge commits when generating the Helm chart SHA
             prs.update(c.get_pulls())
     pr_summaries = [


### PR DESCRIPTION
Haven't tested this yet

Chartpress won't include the most recent commit in the Helm chart hash because it's a merge commit which doesn't change anything. This means the merge commit from the previous chart update will instead be associated with the current chart update.