### PR TITLE
remove ovh from staging federation

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -162,8 +162,6 @@ federationRedirect:
     # unset the rest of the federation
     gesis:
       weight: 0
-    ovh:
-      weight: 0
     turing:
       url: https://binder-staging.mybinder.turing.ac.uk
       weight: 4

--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -62,6 +62,10 @@ def get_config(config_path):
         # can modify the dict while iterating over it
         if config["hosts"][h] is None:
             config["hosts"].pop(h)
+        # remove zero-weight entries
+        if config["hosts"][h].get("weight", 0) == 0:
+            app_log.warning(f"Removing host {h} with 0 weight")
+            config["hosts"].pop(h)
         # remove trailing slashes in host urls
         # these can cause 404 after redirection (RedirectHandler) and we don't
         # realize it


### PR DESCRIPTION
explicitly remove 0-weight hosts from federation

so they don't need to be checked, which caused the deployment failure to staging
