### PR TITLE
add ovh.mybinder.org host to ovh2

### DIFF
--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -36,6 +36,7 @@ binderhub:
   ingress:
     hosts:
       - ovh2.mybinder.org
+      - ovh.mybinder.org
 
   jupyterhub:
     singleuser:


### PR DESCRIPTION
ovh cluster has been removed, DNS now points to ovh2 in case of old links

@mael-le-gal  you can safely shutdown the old OVH cluster, if you haven't. It has been removed from the federation.