### PR TITLE
Update repo2docker (Python 3.10 by default) and BinderHub (switch to jupyter-server)

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3018.he00ec49"
+    version: "1.0.0-0.dev.git.3024.h9641ab8"
     repository: https://jupyterhub.github.io/helm-chart
 
   # Ingress-Nginx to route network traffic according to Ingress resources using

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -160,7 +160,7 @@ binderhub:
 
     BinderHub:
       use_registry: true
-      build_image: quay.io/jupyterhub/repo2docker:2022.10.0-113.g8c0f49e
+      build_image: quay.io/jupyterhub/repo2docker:2022.10.0-128.g4c6b5bc
       per_repo_quota: 100
       per_repo_quota_higher: 200
       cors_allow_origin: "*"


### PR DESCRIPTION
combines bot updates #2509 and #2515

closes #2509 
closes #2515 