### PR TITLE
dependabot: monthly updates of github actions, and docs requirements

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Notes:
 # - Status and logs from dependabot are provided at
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: pip
     directory: /docs
     schedule:
-      interval: weekly
+      interval: monthly
       time: "05:00"
       timezone: Etc/UTC
     labels:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,27 +14,25 @@ updates:
     schedule:
       interval: weekly
       time: "05:00"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC
     labels:
       - dependencies
 
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: github-actions
-    directory: "/" # This should be / rather than .github/workflows
+    directory: /
+    labels: [ci]
     schedule:
-      interval: daily
+      interval: monthly
       time: "05:00"
-      timezone: "Etc/UTC"
-    labels:
-      - dependencies
+      timezone: Etc/UTC
 
   # Python dependencies in our deployment environment (pip-compile)
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly
-      day: "wednesday"
       time: "05:00"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC
     labels:
       - dependencies


### PR DESCRIPTION
This is one of several PRs opened in the juptyterhub github organization to systematically configure dependabot to update github actions on a monthly basis, for more information see https://github.com/jupyterhub/team-compass/issues/636.

I've also made the pip packages be updated on mondays instead of a wednesday like everything else.