### PR TITLE
Avoid redirect to GESIS during fresh installation

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -570,7 +570,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://gesis.mybinder.org
-      weight: 100
+      weight: 0
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     ovh2:


### PR DESCRIPTION
Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/2549.