### PR TITLE
make binderhub itself optional

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,8 +84,6 @@ jobs:
           #   pass --image-prefix to override the chartpress.yaml configuration
           #   for one of the environments.
           - federation_member: staging
-            binder_url: https://gke2.staging.mybinder.org
-            hub_url: https://hub.gke2.staging.mybinder.org
             chartpress_args: ""
             helm_version: ""
             experimental: false
@@ -168,7 +166,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: pytest -vx --color=yes --numprocesses=2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }} tests/
+          command: pytest -vx --color=yes --numprocesses=2 --release=${{ matrix.federation_member }} tests/
 
       - name: "Stage 5: Post message to Grafana that deployment to production has started"
         run: |
@@ -201,15 +199,11 @@ jobs:
       matrix:
         include:
           - federation_member: prod
-            binder_url: https://gke.mybinder.org
-            hub_url: https://hub.gke.mybinder.org
             chartpress_args: ""
             helm_version: ""
             experimental: false
 
           - federation_member: ovh2
-            binder_url: https://ovh2.mybinder.org
-            hub_url: https://hub.ovh2.mybinder.org
             helm_version: ""
             experimental: false
 
@@ -281,7 +275,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: pytest -vx --color=yes --numprocesses=2 --binder-url=${{ matrix.binder_url }} --hub-url=${{ matrix.hub_url }} tests/
+          command: pytest -vx --color=yes --numprocesses=2 --release=${{ matrix.federation_member }} tests/
 
   report-status:
     # This job will wait for staging-deploy to finish and report its status

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,7 +1,8 @@
 projectName: binderhub-288415
 
+# binderhubEnabled: false
+
 binderhub:
-  enabled: false
   config:
     BinderHub:
       pod_quota: 20

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,6 +1,7 @@
 projectName: binderhub-288415
 
 binderhub:
+  enabled: false
   config:
     BinderHub:
       pod_quota: 20

--- a/deploy.py
+++ b/deploy.py
@@ -131,6 +131,19 @@ def update_networkbans(cluster):
     subprocess.check_call(ban_command)
 
 
+def get_config_files(release):
+    """Return the list of config files to load"""
+    # common config files
+    config_files = sorted(glob.glob(os.path.join("config", "common", "*.yaml")))
+    config_files.extend(
+        sorted(glob.glob(os.path.join("secrets", "config", "common", "*.yaml")))
+    )
+    # release-specific config files
+    for config_dir in ("config", "secrets/config"):
+        config_files.append(os.path.join(config_dir, release + ".yaml"))
+    return config_files
+
+
 def deploy(release, name=None):
     """Deploys a federation member to a k8s cluster.
 
@@ -157,14 +170,7 @@ def deploy(release, name=None):
         "mybinder",
     ]
 
-    # common config files
-    config_files = sorted(glob.glob(os.path.join("config", "common", "*.yaml")))
-    config_files.extend(
-        sorted(glob.glob(os.path.join("secrets", "config", "common", "*.yaml")))
-    )
-    # release-specific config files
-    for config_dir in ("config", "secrets/config"):
-        config_files.append(os.path.join(config_dir, release + ".yaml"))
+    config_files = get_config_files(release)
     # add config files to helm command
     for config_file in config_files:
         helm.extend(["-f", config_file])

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -10,6 +10,7 @@ dependencies:
   - name: binderhub
     version: "1.0.0-0.dev.git.3035.h32213a4"
     repository: https://jupyterhub.github.io/helm-chart
+    condition: binderhub.enabled
 
   # Ingress-Nginx to route network traffic according to Ingress resources using
   # this controller from within k8s.

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
   - name: binderhub
     version: "1.0.0-0.dev.git.3035.h32213a4"
     repository: https://jupyterhub.github.io/helm-chart
-    condition: binderhub.enabled
+    condition: binderhubEnabled
 
   # Ingress-Nginx to route network traffic according to Ingress resources using
   # this controller from within k8s.

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -40,8 +40,9 @@ etcJupyter:
       cull_connected: true
 
 # values ref: https://github.com/jupyterhub/binderhub/blob/main/helm-chart/binderhub/values.yaml
+# can't use binderhub.enabled due to validation errors
+binderhubEnabled: true
 binderhub:
-  enabled: true
   replicas: 2
 
   resources:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -41,6 +41,7 @@ etcJupyter:
 
 # values ref: https://github.com/jupyterhub/binderhub/blob/main/helm-chart/binderhub/values.yaml
 binderhub:
+  enabled: true
   replicas: 2
 
   resources:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,79 @@
+import sys
+from pathlib import Path
+
 import pytest
+import yaml
+
+# make sure repo root is on path so we can import from `deploy`
+here = Path(__file__).parent.resolve()
+repo_root = here.parent
+sys.path.insert(0, str(repo_root))
+
+from deploy import get_config_files
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--binder-url", help="Fully qualified URL to the binder installation"
+        "--release",
+        default="staging",
+        help="Name of the federation member release. For loading configuration",
     )
 
-    parser.addoption("--hub-url", help="Fully qualified URL to the hub installation")
+
+def _helm_merge(a, b):
+    """Merge two items, similar to helm
+
+    - dicts are merged
+    - lists and scalars are overridden without merge
+    - 'a' is modified in place, if a merge occurs
+    """
+    if not (isinstance(b, dict) and isinstance(a, dict)):
+        # if either one is not a dict,
+        # there's no merging to do: use 'b'
+        return b
+    for key, value in b.items():
+        if key in a:
+            a[key] = _helm_merge(a[key], value)
+        else:
+            a[key] = value
+    return a
+
+
+@pytest.fixture(scope="session")
+def release(request):
+    return request.config.getoption("--release")
+
+
+@pytest.fixture(scope="session")
+def helm_config(release):
+    """Load the helm values"""
+    config = {}
+    for config_file in [repo_root / "mybinder/values.yaml"] + get_config_files(release):
+        # don't load secret config
+        if "secrets" in config_file:
+            continue
+        with open(config_file) as f:
+            loaded = yaml.safe_load(f)
+        config = _helm_merge(config, loaded)
+    return config
 
 
 @pytest.fixture
-def binder_url(request):
-    return request.config.getoption("--binder-url").rstrip("/")
+def binder_url(helm_config):
+    if not helm_config["binderhubEnabled"]:
+        pytest.skip("binderhub not enabled")
+    return helm_config["binderhub"]["ingress"]["hosts"][0]
 
 
 @pytest.fixture
-def hub_url(request):
-    return request.config.getoption("--hub-url").rstrip("/")
+def hub_url(helm_config):
+    if not helm_config["binderhubEnabled"]:
+        pytest.skip("binderhub not enabled")
+    return helm_config["binderhub"]["config"]["BinderHub"]["hub_url"]
+
+
+@pytest.fixture
+def federation_url(helm_config):
+    if not helm_config["federationRedirect"]["enabled"]:
+        pytest.skip("federationRedirect not enabled")
+    return "https://" + helm_config["federationRedirect"]["host"]

--- a/tests/test_federation_redirect.py
+++ b/tests/test_federation_redirect.py
@@ -1,0 +1,16 @@
+import requests
+
+
+def test_active_hosts(helm_config, federation_url):
+    r = requests.get(federation_url + "/active_hosts")
+    r.raise_for_status()
+    resp = r.json()
+    assert "active_hosts" in resp
+    # assert anything about the state of active hosts?
+    # 'empty' is a valid state
+
+
+def test_proxy_page(helm_config, federation_url):
+    r = requests.get(federation_url)
+    r.raise_for_status()
+    assert "How it works" in r.text


### PR DESCRIPTION
So we can deploy the redirector, etc. separately in their own cluster, without a federation member at all.