### PR TITLE
 move federationRedirect hosts to prod config

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -217,3 +217,20 @@ gcsProxy:
 
 federationRedirect:
   enabled: true
+  hosts:
+    gke:
+      prime: true
+      url: https://gke.mybinder.org
+      weight: 100
+      health: https://gke.mybinder.org/health
+      versions: https://gke.mybinder.org/versions
+    gesis:
+      url: https://gesis.mybinder.org
+      weight: 0
+      health: https://gesis.mybinder.org/health
+      versions: https://gesis.mybinder.org/versions
+    ovh2:
+      url: https://ovh2.mybinder.org
+      weight: 100
+      health: https://ovh2.mybinder.org/health
+      versions: https://ovh2.mybinder.org/versions

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -193,10 +193,8 @@ federationRedirect:
       memory: 200Mi
   hosts:
     gke:
+      prime: true
       url: https://gke2.staging.mybinder.org
       weight: 4
       health: https://gke2.staging.mybinder.org/health
       versions: https://gke2.staging.mybinder.org/versions
-    # unset the rest of the federation
-    gesis:
-      weight: 0

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -575,23 +575,7 @@ federationRedirect:
     failed_period: 90
   load_balancer: "rendezvous"
   pod_headroom: 10
-  hosts:
-    gke:
-      prime: true
-      url: https://gke.mybinder.org
-      weight: 100
-      health: https://gke.mybinder.org/health
-      versions: https://gke.mybinder.org/versions
-    gesis:
-      url: https://gesis.mybinder.org
-      weight: 0
-      health: https://gesis.mybinder.org/health
-      versions: https://gesis.mybinder.org/versions
-    ovh2:
-      url: https://ovh2.mybinder.org
-      weight: 100
-      health: https://ovh2.mybinder.org/health
-      versions: https://ovh2.mybinder.org/versions
+  hosts: {}
   nodeSelector: {}
 
 minesweeper:


### PR DESCRIPTION
so staging doesn't have to 'unset' the values when the federation changes

no changes, other than removing 'ovh2' from staging federatino redirect, since this opt-out aspect of cnfig was missed when it was added.