### PR TITLE
enable artifact registry on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -6,16 +6,15 @@ binderhub:
       pod_quota: 20
       hub_url: https://hub.gke2.staging.mybinder.org
       badge_base_url: https://staging.mybinder.org
-      image_prefix: gcr.io/binderhub-288415/r2d-staging-g5b5b759-
-      # image_prefix: us-central1-docker.pkg.dev/binderhub-288415/staging/r2d-2023-04-
+      image_prefix: us-central1-docker.pkg.dev/binderhub-288415/staging/r2d-2023-04-
       sticky_builds: true
       build_memory_limit: "2G"
-    # DockerRegistry:
-    #   token_url: "https://us-central1-docker.pkg.dev/v2/token"
+    DockerRegistry:
+      token_url: "https://us-central1-docker.pkg.dev/v2/token"
 
-  # registry:
-  #   url: "https://us-central1-docker.pkg.dev"
-  #   username: "_json_key"
+  registry:
+    url: "https://us-central1-docker.pkg.dev"
+    username: "_json_key"
 
   extraEnv:
     EVENT_LOG_NAME: "binderhub-staging-events-text"

--- a/terraform/gcp/staging/main.tf
+++ b/terraform/gcp/staging/main.tf
@@ -19,7 +19,7 @@ module "mybinder" {
   source                = "../modules/mybinder"
   name                  = "staging"
   gke_master_version    = local.gke_version
-  use_artifact_registry = false
+  use_artifact_registry = true
   federation_members    = []
 }
 


### PR DESCRIPTION
I believe this will work after deploying https://github.com/jupyterhub/binderhub/pull/1663

I `kubectl exec`ed to the binder pod and the registry check worked when I passed the right image name as in https://github.com/jupyterhub/binderhub/pull/1663