### PR TITLE
document adding/removing from the federation

### DIFF
--- a/docs/source/operation_guide/federation.rst
+++ b/docs/source/operation_guide/federation.rst
@@ -4,104 +4,35 @@
 The mybinder.org Federation
 ===========================
 
-The following table lists BinderHub deployments in the mybinder.org
-federation, along with the status of each. For more information about
-the BinderHub federation, who is in it, how to join it, etc, see
-`the MyBinder federation page <https://mybinder.readthedocs.io/en/latest/about/federation.html>`_.
+The current status of the mybinder.org federation can be found `here <https://mybinder.readthedocs.io/en/latest/about/status.html>`_.
 
-==========================  ========  ===============  ==============  =============== =====
-  URL                       Response  Docker registry  JupyterHub API  User/Build Pods Quota
-==========================  ========  ===============  ==============  =============== =====
-gke.mybinder.org
-ovh.mybinder.org
-ovh2.mybinder.org
-gesis.mybinder.org
-==========================  ========  ===============  ==============  =============== =====
 
-.. raw:: html
+Adding or removing a federation member
+--------------------------------------
 
-   <script>
-   var fedUrls = [
-       "https://gke.mybinder.org",
-       "https://ovh.mybinder.org",
-       "https://ovh2.mybinder.org",
-       "https://gesis.mybinder.org",
-   ]
+The following files contain references to the federation,
+and should be updated when a federation member is added or removed:
 
-   // Use a dictionary to store the rows that should be updated
-   var urlRows = {};
-   fedUrls.forEach((url) => {
-      document.querySelectorAll('tr').forEach((tr) => {
-        if (tr.textContent.includes(url.replace('https://', ''))) {
-           urlRows[url] = tr;
-        };
-      });
-   });
+#. pages for https://mybinder.readthedocs.io: `status <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/about/status.rst>`_ and `federation info <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/_data/support/federation.yml`_
+#. `deployment to the cluster <https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/cd.yml>`_
+#. `testing of the cluster configuration <https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/test-helm-template.yaml>`_
+#. membership in `federationRedirect.hosts config for prod <https://github.com/jupyterhub/mybinder.org-deploy/blob/7aa58e033efe1ed1cee1b5cb7e789c1296deb36a/config/prod.yaml#L220>`_
 
-   fedUrls.forEach((url) => {
-       var urlHealth = url + '/health'
-       var urlPrefix = url.split('//')[1].split('.')[0]
 
-       // Query the endpoint and update health icon
-       var row = urlRows[url];
-       let [fieldUrl, fieldResponse, fieldRegistry, fieldHub, fieldPods, fieldQuota] = row.querySelectorAll('td')
-       $.getJSON(urlHealth, {})
-           .done((resp) => {
-               if (resp['ok'] == false) {
-                   setStatus(fieldResponse, 'fail')
-               } else {
-                   setStatus(fieldResponse, 'success')
-               }
-
-               let [respReg, respHub, respQuota] = resp['checks']
-
-               if (respReg == false) {
-                   setStatus(fieldRegistry, 'fail')
-               } else {
-                   setStatus(fieldRegistry, 'success')
-               }
-
-               if (respHub == false) {
-                   setStatus(fieldHub, 'fail')
-               } else {
-                   setStatus(fieldHub, 'success')
-               }
-
-               fieldPods.textContent = `${respQuota['user_pods']}/${respQuota['build_pods']}`
-               fieldQuota.textContent = `${respQuota['quota']}`
-           })
-           .fail((resp) => {
-                setStatus(fieldResponse, 'fail')
-       });
-   })
-
-   var setStatus = (td, kind) => {
-      if (kind == "success") {
-        td.textContent = "Success";
-        td.style.color = "green";
-      } else {
-        td.textContent = "Fail";
-        td.style.color = "red";
-      }
-   }
-
-   </script>
-
-Removing a Federation Member from Rotation
-------------------------------------------
+Temporarily removing a federation member from rotation
+------------------------------------------------------
 
 There are a few reasons why you may wish to remove a Federation member from
-rotation. For example, maintenence work, a problem with the deployment, and so
+rotation. For example, maintenance work, a problem with the deployment, and so
 on.
 
-There are 3 main files you may wish to edit in order to remove a cluster from
-the Federation:
+There are 3 main files you may wish to edit in order to remove a cluster from the Federation:
 
 #. *Required.* Set the ``binderhub.config.BinderHub.pod_quota`` key to ``0`` in the
    cluster's config file under the `config <https://github.com/jupyterhub/mybinder.org-deploy/tree/HEAD/config>`_
    directory
 #. *Recommended.* Set the ``weight`` key for the cluster to ``0`` in the
-   `helm chart values file <https://github.com/jupyterhub/mybinder.org-deploy/blob/4f42d791f92dcb3156e7c4ea92a236246bbf9135/mybinder/values.yaml#L494>`_
+   `helm chart values file <https://github.com/jupyterhub/mybinder.org-deploy/blob/7aa58e033efe1ed1cee1b5cb7e789c1296deb36a/config/prod.yaml#L220>`_
    in order to remove it from the redirector's pool
 #. *Optional.* Comment out the cluster from the
    `continuous deployment <https://github.com/jupyterhub/mybinder.org-deploy/blob/4f42d791f92dcb3156e7c4ea92a236246bbf9135/.github/workflows/cd.yml#L168>`_

--- a/docs/source/operation_guide/federation.rst
+++ b/docs/source/operation_guide/federation.rst
@@ -4,7 +4,7 @@
 The mybinder.org Federation
 ===========================
 
-The current status of the mybinder.org federation can be found `here <https://mybinder.readthedocs.io/en/latest/about/status.html>`_.
+The current status of the mybinder.org federation can be found `here <https://mybinder.readthedocs.io/en/latest/about/status.html>`__.
 
 
 Adding or removing a federation member
@@ -13,10 +13,16 @@ Adding or removing a federation member
 The following files contain references to the federation,
 and should be updated when a federation member is added or removed:
 
-#. pages for https://mybinder.readthedocs.io: `status <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/about/status.rst>`_ and `federation info <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/_data/support/federation.yml`_
+#. pages for https://mybinder.readthedocs.io: `status <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/about/status.rst>`_ and `federation info <https://github.com/jupyterhub/mybinder.org-user-guide/blob/HEAD/doc/_data/support/federation.yml>`_
 #. `deployment to the cluster <https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/cd.yml>`_
 #. `testing of the cluster configuration <https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/test-helm-template.yaml>`_
-#. membership in `federationRedirect.hosts config for prod <https://github.com/jupyterhub/mybinder.org-deploy/blob/7aa58e033efe1ed1cee1b5cb7e789c1296deb36a/config/prod.yaml#L220>`_
+#. membership in `federationRedirect.hosts config for prod <https://github.com/jupyterhub/mybinder.org-deploy/blob/7aa58e033efe1ed1cee1b5cb7e789c1296deb36a/config/prod.yaml#L220>`__
+#. add/remove data source for the cluster's prometheus at https://grafana.mybinder.org
+#. if outside the default Google Cloud project, make sure launches are published to the events archive:
+    - If not deployed from this repo, publishing events to the archive is configured `here <https://github.com/jupyterhub/mybinder.org-deploy/blob/339ccb1de8107dc7854cac45f0a5b6e99937a91b/mybinder/values.yaml#L200-L219>`__
+    - GKE clusters don't need further configuration, but outside GKE (or outside our GCP project, maybe?) need a service account.
+      These accounts are configured `in terraform <https://github.com/jupyterhub/mybinder.org-deploy/blob/339ccb1de8107dc7854cac45f0a5b6e99937a91b/terraform/gcp/prod/main.tf#L17>`__, and can be retrieved via `terraform output events_archiver_keys`.
+      For OVH, a secret is added to the chart `here <https://github.com/jupyterhub/mybinder.org-deploy/blob/main/mybinder/templates/events-archiver/secret.yaml>`__ and mounted in the binder pod `here <https://github.com/jupyterhub/mybinder.org-deploy/blob/339ccb1de8107dc7854cac45f0a5b6e99937a91b/config/ovh2.yaml#L25-L34>`__ (in our chart, the secret itself is added to `eventsArchiver.serviceAccountKey <https://github.com/jupyterhub/mybinder.org-deploy/blob/339ccb1de8107dc7854cac45f0a5b6e99937a91b/mybinder/values.yaml#L555-L557>`__ helm config, in secrets/config/ovh2.yaml).
 
 
 Temporarily removing a federation member from rotation


### PR DESCRIPTION
make sure we mention updating mybinder status pages, which haven't been updated after recent changes (https://github.com/jupyterhub/mybinder.org-user-guide/pull/277)

remove redundant federation status table, instead linking to the canonical one
