### PR TITLE
pause gesis

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -226,7 +226,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://notebooks.gesis.org/binder/
-      weight: 100
+      weight: 0
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
pausing gesis due to 'invalid token' errors

likely due to proxy headers.