### PR TITLE
ignore a few paths that don't affect CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,12 @@ on:
     branches:
       - main
       - test-this-pr/**
+    paths-ignore:
+      - terraform/**
+      - docs/**
+      - .pre-commit-config.yaml
+      - .github/**
+      - "!.github/workflows/cd.yml"
   pull_request:
     types: [labeled]
 


### PR DESCRIPTION
Don't trigger expensive CD workflow when it won't do anything

Not an exact list, which would be a pain to maintain, but helps with a few common categories of PR that don't need to trigger slow redeploys.