### PR TITLE
Reduce size, cost of prod prometheus

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -119,9 +119,8 @@ prometheus:
         # 20Gi isn't enough to rebuild WAL on startup
         memory: 33Gi
     persistentVolume:
-      # Use a large SSD Volume in production
-      size: 2000Gi
-      storageClass: ssd
+      size: 50G
+      storageClass: balanced
     retention: 30d
     ingress:
       hosts:


### PR DESCRIPTION
5 GB of balanced storage is $5/month

Without a BinderHub, prod has drastically reduced storage and access requirements

Deploying this will lose data (will require manual intervention to clear the old volume), but since prometheus data is ephemeral by definition, I think that's okay.

It would be nice to deploy this reduction now, so we have _some_ data before GKE drops out of the federation.

I could try to migrate the data ([following this](https://stackoverflow.com/questions/72316567/shrink-kubernetes-persistent-volumes)), if folks think this is worth it, but it would take some time.