### PR TITLE
Add cheaper core nodes to prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -119,9 +119,8 @@ prometheus:
         # 20Gi isn't enough to rebuild WAL on startup
         memory: 33Gi
     persistentVolume:
-      # Use a large SSD Volume in production
-      size: 2000Gi
-      storageClass: ssd
+      size: 50G
+      storageClass: balanced
     retention: 30d
     ingress:
       hosts:

--- a/terraform/gcp/modules/mybinder/resource.tf
+++ b/terraform/gcp/modules/mybinder/resource.tf
@@ -88,7 +88,16 @@ resource "google_sql_database_instance" "matomo" {
   settings {
     tier = var.sql_tier
     backup_configuration {
-      enabled = true
+      enabled  = true
+      location = "us"
+    }
+    database_flags {
+      name  = "table_open_cache"
+      value = "10000"
+    }
+    maintenance_window {
+        day = 1
+        hour = 1
     }
   }
 }


### PR DESCRIPTION
Adding e2-highmem-2. We'll see how things go.

For anyone unfamiliar, e2 is basically n1, but with slightly reduced capabilities at the same price as always-on n1 with sustained use discount, so there's no cost penalty to cycling/shutting down nodes.

Not removing anything yet, just getting ready to do so.

Updated a few fields in matomo, not to actually change things, but to ensure things _don't_ change from what's already deployed.