### PR TITLE
Reduce prod resources (Friday)

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -116,7 +116,9 @@ prometheus:
         memory: 4Gi
       limits:
         cpu: "1"
-        # 20Gi isn't enough to rebuild WAL on startup
+        # before stopping prod binderhub
+        # 20Gi wasn't enough to rebuild WAL on startup
+        # keep an eye on this
         memory: 16Gi
     persistentVolume:
       size: 50G

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -77,10 +77,10 @@ grafana:
   nodeSelector: *coreNodeSelector
   resources:
     requests:
-      cpu: "0"
+      cpu: 10m
       memory: 128Mi
     limits:
-      cpu: "0.25"
+      cpu: 250m
       memory: 128Mi
   ingress:
     hosts:
@@ -112,12 +112,12 @@ prometheus:
     livenessProbeInitialDelay: 800
     resources:
       requests:
-        cpu: "4"
-        memory: 30Gi
+        cpu: 100m
+        memory: 4Gi
       limits:
-        cpu: "4"
+        cpu: "1"
         # 20Gi isn't enough to rebuild WAL on startup
-        memory: 33Gi
+        memory: 16Gi
     persistentVolume:
       size: 50G
       storageClass: balanced
@@ -176,7 +176,7 @@ redirector:
 
 matomo:
   enabled: true
-  replicas: 3
+  replicas: 2
   nodeSelector: *coreNodeSelector
   db:
     instanceName: binderhub-288415:us-central1:matomo-prod
@@ -191,10 +191,10 @@ matomo:
       - gke2.mybinder.org
   resources:
     requests:
-      cpu: 0.1
+      cpu: 10m
       memory: 256Mi
     limits:
-      cpu: 1
+      cpu: 200m
       memory: 1Gi
 
 analyticsPublisher:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -385,10 +385,10 @@ ingress-nginx:
       enabled: false
     resources:
       requests:
-        cpu: 0.5
-        memory: 440Mi
+        cpu: 100m
+        memory: 150Mi
       limits:
-        cpu: 0.8
+        cpu: 800m
         memory: 500Mi
     tolerations:
       - key: "node.kubernetes.io/unschedulable"
@@ -546,10 +546,10 @@ analyticsPublisher:
   nodeSelector: {}
   resources:
     requests:
-      cpu: 0.2
-      memory: 200Mi
+      cpu: 10m
+      memory: 150Mi
     limits:
-      cpu: 0.2
+      cpu: 100m
       memory: 300Mi
 
 # this is defined in secrets/ for the OVH cluster
@@ -561,11 +561,11 @@ federationRedirect:
   host: mybinder.org
   resources:
     requests:
-      cpu: 0.2
-      memory: 200Mi
+      cpu: 10m
+      memory: 50Mi
     limits:
-      cpu: 0.2
-      memory: 300Mi
+      cpu: 100m
+      memory: 250Mi
   image:
     name: jupyterhub/mybinder.org-federation-redirect
     tag: "set-by-chartpress"


### PR DESCRIPTION
To be deployed after shutting down prod BinderHub

[Snapshot of component resource usage]( https://snapshots.raintank.io/dashboard/snapshot/eZBW6PGLeGULWghRSDzqGx4hmTqII7ie) used to compute some of the new numbers.

By far the biggest change is prometheus. We'll have to see how that goes, since it's currently unclear what the drop in resource requirements will be after shutting down prod binderhub