### PR TITLE
try to enable proxy protocol for OVH ingress

### DIFF
--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -117,6 +117,11 @@ ingress-nginx:
       enabled: true
     service:
       loadBalancerIP: 162.19.17.37
+      annotations:
+        service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: v2
+    config:
+      use-proxy-protocol: "true"
+      real-ip-header: proxy_protocol
 
 static:
   ingress:


### PR DESCRIPTION
per [ovh documentation](https://help.ovhcloud.com/csm/en-gb-public-cloud-kubernetes-getting-source-ip-behind-loadbalancer) the proxy protocol is not enabled by default for load balancers.

One piece that's missing, and I can't tell how important it is, is the 'egress-ips' annotation they describe for getting the load balancer IP doesn't exist. I'm not sure it's critical, though. We'll see.

I believe this is the source of rate limit errors on OVH, because everybody looks like they are coming from the load balancer (10.0.0.160, 10.0.0.164)