### PR TITLE
OVH: run builds on dedicated node pool

### DIFF
--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -11,7 +11,8 @@ binderhub:
       pod_quota: 200
       hub_url: https://hub.ovh2.mybinder.org
       badge_base_url: https://mybinder.org
-      build_node_selector: *userNodeSelector
+      build_node_selector:
+        mybinder.org/pool-type: builds
       sticky_builds: true
       image_prefix: 2lmrrh8f.gra7.container-registry.ovh.net/mybinder-builds/r2d-g5b5b759
     DockerRegistry:

--- a/terraform/ovh/main.tf
+++ b/terraform/ovh/main.tf
@@ -127,6 +127,30 @@ resource "ovh_cloud_project_kube_nodepool" "user-a" {
   }
 }
 
+resource "ovh_cloud_project_kube_nodepool" "builds" {
+  service_name = local.service_name
+  kube_id      = ovh_cloud_project_kube.cluster.id
+  name         = "builds-2304"
+  # b2-30 is 8-core, 30GB
+  flavor_name = "b2-30"
+  max_nodes   = 3
+  min_nodes   = 1
+  autoscale   = true
+  template {
+    metadata {
+      labels = {
+        "mybinder.org/pool-type" = "builds"
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      # don't interfere with autoscaling
+      desired_nodes
+    ]
+  }
+}
+
 # outputs
 
 output "kubeconfig" {


### PR DESCRIPTION
should avoid most full-disk problems

OVH nodes don't allow mounting additional local disks for builds, which helps the two image pools avoid messing with each other.

Plus, the disks are just small and not configurable, making these issues more likely to happen.