### PR TITLE
stop the prod binderhub

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -5,6 +5,8 @@ userNodeSelector: &userNodeSelector
 coreNodeSelector: &coreNodeSelector
   mybinder.org/pool-type: core
 
+binderhubEnabled: false
+
 binderhub:
   config:
     BinderHub:


### PR DESCRIPTION
OVH seems to be handling okay as prime, so we can actually try turning off prod