### PR TITLE
Fix another typo that broke staging

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -220,7 +220,7 @@ binderhub:
           # for now. Should be fixed in https://github.com/googleapis/google-cloud-python/pull/6293
           name = os.environ.get("EVENT_LOG_NAME") or "binderhub-events-text")
           get_logger().info("Sending event logs to %s/logs/%s", client.project, name)
-          return [JSONCloudLoggingHandler(client, name=name]
+          return [JSONCloudLoggingHandler(client, name=name)]
       c.EventLog.handlers_maker = _make_eventsink_handler
 
   registry:


### PR DESCRIPTION
Solves

```
Loading /etc/binderhub/config/values.yaml
Loading extra config: 01-eventlog
[BinderHub] ERROR | Exception while loading config file /etc/binderhub/config/binderhub_config.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/traitlets/config/application.py", line 909, in _load_config_files
    config = loader.load_config()
             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/traitlets/config/loader.py", line 626, in load_config
    self._read_file_as_dict()
  File "/usr/local/lib/python3.11/site-packages/traitlets/config/loader.py", line 659, in _read_file_as_dict
    exec(compile(f.read(), conf_filename, "exec"), namespace, namespace)  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/etc/binderhub/config/binderhub_config.py", line 68, in <module>
    exec(snippet)
  File "<string>", line 23
    return [JSONCloudLoggingHandler(client, name=name]
                                                     ^
SyntaxError: closing parenthesis ']' does not match opening parenthesis '('
```