### PR TITLE
update cert-manager from 1.8.0 to 1.12.0, and helm/kubectl/gcloud

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,15 +33,15 @@ env:
   # gcloud versions at https://cloud.google.com/sdk/docs/release-notes, update
   # to latest when updating.
   #
-  GCLOUD_SDK_VERION: "387.0.0"
+  GCLOUD_SDK_VERION: "432.0.0"
   # kubectl versions at https://github.com/kubernetes/kubernetes/tags, update to
   # second latest minor for a broad compatibility range when updating.
   #
-  KUBECTL_VERSION: "v1.23.7"
+  KUBECTL_VERSION: "v1.25.10"
   # helm versions at https://github.com/helm/helm/tags, use latest when
   # updating.
   #
-  HELM_VERSION: "v3.9.0"
+  HELM_VERSION: "v3.12.0"
   # cert-mangaer versions at https://cert-manager.io/docs/release-notes/, update
   # to latest when updating and make sure to read upgrade notes. "kubectl apply"
   # will be done on CRDs but sometimes more is needed.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ env:
   # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the
   #       test-helm-template.yaml workflow.
   #
-  CERT_MANAGER_VERSION: "v1.8.0"
+  CERT_MANAGER_VERSION: "v1.12.0"
 
   # These variables influence git directly
   # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing

--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -44,7 +44,7 @@ jobs:
           - release: staging
             k3s-channel: "v1.24"
           - release: prod
-            k3s-channel: "v1.23"
+            k3s-channel: "v1.24"
           - release: ovh2
             k3s-channel: "v1.24"
 


### PR DESCRIPTION
- cd tooling: update helm, kubectl, gcloud
- ci: test against k8s 1.24 for prod, which is now used
- cert-manager: upgrade from 1.8.0 to 1.12.0

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

<!-- BinderHub bump -->

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
