### PR TITLE
cd: install gke-gcloud-auth-plugin, also for deploy prod job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,6 +263,25 @@ jobs:
           pip install --upgrade setuptools pip
           pip install --upgrade -r requirements.txt
 
+      # Install pre-requisite for "gcloud container clusters get-credentials"
+      # command with a modern k8s client.
+      #
+      # A manual install step has been needed as they opted to not provide it in
+      # the github-runner image. See
+      # https://github.com/actions/runner-images/issues/5925#issuecomment-1216417721.
+      #
+      # Snippet based on
+      # https://github.com/actions/runner-images/blob/9753e7301e19e29b89b0622b811bbb9b3891d02e/images/linux/scripts/installers/google-cloud-sdk.sh#L9-L13.
+      #
+      - name: Install gke-gcloud-auth-plugin
+        if: matrix.federation_member == 'prod'
+        run: |
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+          sudo apt-get update -y
+          sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
       - name: "Stage 1: Install gcloud ${{ env.GCLOUD_SDK_VERION }}"
         if: matrix.federation_member == 'prod'
         uses: google-github-actions/setup-gcloud@v1


### PR DESCRIPTION
<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

<!-- BinderHub bump -->

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
