### PR TITLE
ci: allow repo2docker bumps to stable / non-dev releases

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           latest_tag=$(
               docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
-            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+(-\\d+\\..*)$"))] | sort_by(split(".-") | map(tonumber? // 0)) | last'
+            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+(-\\d+\\..*)?$"))] | sort_by(split(".-") | map(tonumber? // 0)) | last'
           )
           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Tested locally to work. A one character addition PR :)

Will make #2656 bump correctly to 2023.06.0 instead of an older dev commit.