### PR TITLE
include labels in PR summary

### DIFF
--- a/scripts/get-prs.py
+++ b/scripts/get-prs.py
@@ -62,7 +62,7 @@ else:
             # Chartpress ignores merge commits when generating the Helm chart SHA
             prs.update(c.get_pulls())
     pr_summaries = [
-        f"- [#{pr.number}]({pr.html_url}) {pr.title}"
+        f"- [#{pr.number}]({pr.html_url}) {pr.title} ({', '.join(label.name for label in pr.labels)})"
         for pr in sorted(prs, key=lambda pr: pr.number)
     ]
 


### PR DESCRIPTION
for easier highlighting of deployment impact.

Output looks like:

# PRs
- [#1283](https://github.com/jupyterhub/repo2docker/pull/1283) Relax pins to major versions and refreeze, introduce explicit jupyter_server v1 pin (maintenance)
- [#1285](https://github.com/jupyterhub/repo2docker/pull/1285) Microsoft killed MRAN, stop relying on it (bug, maintenance, breaking)
- [#1286](https://github.com/jupyterhub/repo2docker/pull/1286) Add changelog for 2023.06.0 (documentation)

https://github.com/jupyterhub/repo2docker/compare/e1051c3cb88bbd6a2d9fd265cadb451e75b4fee4...fd22a4f49c2db925feaa7bad556bbd0ce56eb9fd