### PR TITLE
Use single source for cert-manager version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,14 +42,6 @@ env:
   # updating.
   #
   HELM_VERSION: "v3.12.0"
-  # cert-mangaer versions at https://cert-manager.io/docs/release-notes/, update
-  # to latest when updating and make sure to read upgrade notes. "kubectl apply"
-  # will be done on CRDs but sometimes more is needed.
-  #
-  # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the
-  #       test-helm-template.yaml workflow.
-  #
-  CERT_MANAGER_VERSION: "v1.12.0"
 
   # These variables influence git directly
   # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing

--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -3,12 +3,6 @@
 #
 name: Test helm template --validate
 
-env:
-  # NOTE: Updates to CERT_MANAGER_VERSION should also be done in the cd.yaml
-  #       workflow.
-  #
-  CERT_MANAGER_VERSION: "v1.8.0"
-
 on:
   pull_request:
     paths:
@@ -74,10 +68,13 @@ jobs:
       # from cert-manager.
       #
       - name: Install cert-manager CRDs
-        run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
+        run: |
+          . cert-manager.env
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
 
       - name: "helm template --validate (cert-manager chart)"
         run: |
+          . cert-manager.env
           echo "cert-manager version: ${CERT_MANAGER_VERSION}"
 
           helm template --validate cert-manager cert-manager \

--- a/cert-manager.env
+++ b/cert-manager.env
@@ -1,0 +1,5 @@
+# cert-manager versions at https://cert-manager.io/docs/release-notes/, update
+# to latest when updating and make sure to read upgrade notes. "kubectl apply"
+# will be done on CRDs but sometimes more is needed.
+
+export CERT_MANAGER_VERSION=v1.12.0

--- a/deploy.py
+++ b/deploy.py
@@ -227,7 +227,9 @@ def setup_certmanager():
     additional upgrade notes, see https://cert-manager.io/docs/release-notes/
     before you upgrade to a new version.
     """
-    version = os.environ["CERT_MANAGER_VERSION"]
+    version = os.getenv("CERT_MANAGER_VERSION")
+    if not version:
+        raise RuntimeError("CERT_MANAGER_VERSION not set. Source cert-manager.env")
 
     manifest_url = f"https://github.com/jetstack/cert-manager/releases/download/{version}/cert-manager.crds.yaml"
     print(BOLD + GREEN + f"Installing cert-manager CRDs {version}" + NC, flush=True)


### PR DESCRIPTION
Uses an env file that can be sourced in multiple places instead of defining the version in multiple GitHub workflows, and requiring the version to be manually set when running `deploy.py` outside CI
- `deploy.py` now outputs an informative error message if `CERT_MANAGER_VERSION` not set
