### PR TITLE
Fix logo in documentation website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,20 +44,6 @@ html_theme_options = {
     "use_edit_page_button": True,
     "github_url": "https://github.com/jupyterhub/binderhub",
     "twitter_url": "https://twitter.com/mybinderteam",
-    "icon_links": [
-        {
-            "name": "Discourse",
-            "url": "https://discourse.jupyter.org/",
-            "icon": "fa-brands fa-discourse",
-            "type": "fontawesome",
-        },
-        {
-            "name": "Team Compass",
-            "url": "https://jupyterhub-team-compass.readthedocs.io/en/latest/",
-            "icon": "fa-solid fa-compass",
-            "type": "fontawesome",
-        },
-    ],
 }
 html_context = {
     "github_user": "jupyterhub",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@ default_role = "literal"
 extensions = [
     "myst_parser",
     "sphinx_copybutton",
-    "jupyterhub_sphinx_theme",
 ]
 
 # The suffix(es) of source filenames.
@@ -39,21 +38,30 @@ exclude_patterns = []
 # -- Options for HTML output ----------------------------------------------
 # ref: http://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 #
-html_theme = "jupyterhub_sphinx_theme"
+html_theme = "pydata_sphinx_theme"
 html_theme_options = {
+    "use_edit_page_button": True,
+    "github_url": "https://github.com/jupyterhub/binderhub",
+    "twitter_url": "https://twitter.com/mybinderteam",
     "icon_links": [
         {
-            "name": "GitHub",
-            "url": "https://github.com/jupyterhub/mybinder.org-deploy",
-            "icon": "fa-brands fa-github",
+            "name": "Discourse",
+            "url": "https://discourse.jupyter.org/",
+            "icon": "fa-brands fa-discourse",
+            "type": "fontawesome"
         },
-    ],
-    "use_edit_page_button": True,
+        {
+            "name": "Team Compass",
+            "url": "https://jupyterhub-team-compass.readthedocs.io/en/latest/",
+            "icon": "fa-solid fa-compass",
+            "type": "fontawesome"
+        }
+  ]
 }
 html_context = {
     "github_user": "jupyterhub",
     "github_repo": "mybinder.org-deploy",
-    "github_version": "HEAD",
+    "github_version": "main",
     "doc_path": "docs/source",
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ html_context = {
 
 html_static_path = ["_static"]
 html_logo = "_static/images/logo.png"
-html_favicon = "_static/images/favicon.ico"
+html_favicon = "_static/images/favicon.png"
 
 
 # -- Options for linkcheck builder -------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,15 +48,15 @@ html_theme_options = {
             "name": "Discourse",
             "url": "https://discourse.jupyter.org/",
             "icon": "fa-brands fa-discourse",
-            "type": "fontawesome"
+            "type": "fontawesome",
         },
         {
             "name": "Team Compass",
             "url": "https://jupyterhub-team-compass.readthedocs.io/en/latest/",
             "icon": "fa-solid fa-compass",
-            "type": "fontawesome"
-        }
-  ]
+            "type": "fontawesome",
+        },
+    ],
 }
 html_context = {
     "github_user": "jupyterhub",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ exclude_patterns = []
 html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
     "use_edit_page_button": True,
-    "github_url": "https://github.com/jupyterhub/binderhub",
+    "github_url": "https://github.com/jupyterhub/mybinder.org-deploy",
     "twitter_url": "https://twitter.com/mybinderteam",
 }
 html_context = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ default_role = "literal"
 extensions = [
     "myst_parser",
     "sphinx_copybutton",
+    "jupyterhub_sphinx_theme",
 ]
 
 # The suffix(es) of source filenames.
@@ -38,7 +39,7 @@ exclude_patterns = []
 # -- Options for HTML output ----------------------------------------------
 # ref: http://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 #
-html_theme = "pydata_sphinx_theme"
+html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
     "use_edit_page_button": True,
     "github_url": "https://github.com/jupyterhub/binderhub",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,7 @@ html_theme_options = {
 html_context = {
     "github_user": "jupyterhub",
     "github_repo": "mybinder.org-deploy",
+    # Branch name is needed to ensure the `Edit on GitHub` button works
     "github_version": "main",
     "doc_path": "docs/source",
 }


### PR DESCRIPTION
Before

![Site Reliability Guide for mybinder org before](https://github.com/jupyterhub/mybinder.org-deploy/assets/1506457/f797cb0b-947a-4fa0-bfa5-385e37cf9d60)

After

![Site Reliability Guide for mybinder org after](https://github.com/jupyterhub/mybinder.org-deploy/assets/1506457/fadb2465-c1d0-43af-96cf-68d5028bcadd)

BinderHub documentation (https://binderhub.readthedocs.io/en/latest/)

![Screenshot 2023-06-14 at 09-38-36 BinderHub](https://github.com/jupyterhub/mybinder.org-deploy/assets/1506457/45570230-a36a-4996-a2c5-8ed7dbb8df21)

