### PR TITLE
Create GitLab actions to trigger update in GESIS

### DIFF
--- a/.github/workflows/gesis.yaml
+++ b/.github/workflows/gesis.yaml
@@ -1,4 +1,4 @@
-name: 'GESIS update dispatcher'
+name: "GESIS update dispatcher"
 
 on:
   push:

--- a/.github/workflows/gesis.yaml
+++ b/.github/workflows/gesis.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatcher
+        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         env:
           GESIS_TOKEN: ${{ secrets.GESIS_TOKEN }}
         run: |

--- a/.github/workflows/gesis.yaml
+++ b/.github/workflows/gesis.yaml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   update-gesis:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatcher
-        if: github.repository == 'jupyterhub/mybinder.org-deploy'
         env:
           GESIS_TOKEN: ${{ secrets.GESIS_TOKEN }}
         run: |

--- a/.github/workflows/gesis.yaml
+++ b/.github/workflows/gesis.yaml
@@ -1,0 +1,19 @@
+name: 'GESIS update dispatcher'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-gesis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatcher
+        env:
+          GESIS_TOKEN: ${{ secrets.GESIS_TOKEN }}
+        run: |
+          curl -X POST \
+          -F token=${GESIS_TOKEN} \
+          -F ref=main \
+          https://git.gesis.org/api/v4/projects/ilcm%2Forc2-upgrade-bot/trigger/pipeline


### PR DESCRIPTION
This pull request creates a GitHub action that will make a HTTP request to GESIS and trigger the update of GESIS Kubernetes cluster.

I prefer to have this as a GitHub action instead of [GitHub native webhook](https://docs.github.com/en/webhooks-and-events/webhooks/about-webhooks) for transparency.

This pull request requires a secret (`GESIS_TOKEN`) to be added to this repository. Can I be contacted in private to share the secret?