### PR TITLE
Restore GESIS contribution to the federation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://notebooks.gesis.org/binder
-      weight: 0
+      weight: 100
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#2723

BinderHub in GESIS' premise is running.

Closes https://github.com/jupyterhub/mybinder.org-deploy/issues/2722

Closes https://github.com/jupyterhub/mybinder.org-deploy/issues/2725