### PR TITLE
Revert "Updates binderhub chart to 1.0.0-0.dev.git.3177.h0ffed53"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3177.h0ffed53"
+    version: "1.0.0-0.dev.git.3171.h88669a1"
     repository: https://jupyterhub.github.io/helm-chart
     condition: binderhubEnabled
 


### PR DESCRIPTION
Revert https://github.com/jupyterhub/mybinder.org-deploy/pull/2746

https://github.com/jupyterhub/binderhub/pull/1741
causes a JavaScript failure on mybinder.org:
```
Uncaught TypeError: URL constructor: /build/gh/binder-examples/conda/HEAD is not a valid URL.
```
The browser debugger indicates
https://github.com/jupyterhub/binderhub/blob/527ac45a377d2470dfa101823fbd8d3a00193bc5/js/packages/binderhub-client/lib/index.js#L28
is the source