### PR TITLE
Block singleuser outbound by default

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -340,6 +340,8 @@ binderhub:
       networkPolicy:
         enabled: true
         egress: []
+        egressAllowRules:
+          nonPrivateIPs: false
       memory:
         guarantee: 450M
         limit: 2G


### PR DESCRIPTION
An unfortunate side effect of the Z2JH 3.0.0-beta* update was that `singleuser.networkPolicy.egress: []` no longer disables all egress by default, since there is a new property `singleuser.networkPolicy.egressAllowRules.nonPrivateIPs: true`

This can be easily verified using http://portquiz.net/ which listens on nearly all ports.
