### PR TITLE
Revert "Updates binderhub chart to 1.0.0-0.dev.git.3228.h30733fe"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3228.h30733fe"
+    version: "1.0.0-0.dev.git.3199.h54522bc"
     repository: https://jupyterhub.github.io/helm-chart
     condition: binderhubEnabled
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#2770

Until we fix https://github.com/jupyterhub/nbgitpuller/issues/329
https://discourse.jupyter.org/t/nb-on-binder-with-parameters-now-resulting-in-404/21860