### PR TITLE
Bump cryptnono version

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -53,7 +53,7 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source code: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono
-    version: "0.1.0"
+    version: "0.1.2"
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled
 


### PR DESCRIPTION
Changes from 0.1.0:

- Turn off debug logging by default
- Docker image is slightly smaller

Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/2792
