### PR TITLE
cryptnono: Fix indent to disable execwhacker

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,10 +1,11 @@
 # values ref: https://github.com/yuvipanda/cryptnono/blob/main/cryptnono/values.yaml
 cryptnono:
   enabled: true
-  execwhacker:
-    # Temporarily disable execwhacker until https://github.com/jupyterhub/mybinder.org-deploy/issues/2795
-    # is sorted
-    enabled: false
+  detectors:
+    execwhacker:
+      # Temporarily disable execwhacker until https://github.com/jupyterhub/mybinder.org-deploy/issues/2795
+      # is sorted
+      enabled: false
 
 imagePullSecrets:
 


### PR DESCRIPTION
A good reminder to setup the values schema on cryptnono!

Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/2796
