### PR TITLE
cryptnono: Bump version

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source code: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono
-    version: "0.2.0"
+    version: "0.2.1"
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled
 


### PR DESCRIPTION
Sets imagePullPolicy to "IfNotPresent", which seems to alleviate some issues with ovh
