### PR TITLE
AWS Curvenote: deploy without networkbans for now

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -322,9 +322,22 @@ jobs:
           chartpress ${{ matrix.chartpress_args || '--skip-build' }}
 
       - name: "Stage 4: Deploy to ${{ matrix.federation_member }}"
+        if: matrix.federation_member != 'curvenote'
         run: |
           . cert-manager.env
           python ./deploy.py ${{ matrix.federation_member }} ${{ matrix.cluster_name || matrix.federation_member }} --name ${{ matrix.release_name || matrix.federation_member }}
+        env:
+          TERM: xterm
+
+      - name: "Stage 4: Deploy to ${{ matrix.federation_member }}"
+        # TODO: fix ban.py to work on AWS/curvenote
+        if: matrix.federation_member == 'curvenote'
+        run: |
+          . cert-manager.env
+          for stage in auth kubesystem certmanager mybinder; do
+            echo $stage
+            python ./deploy.py ${{ matrix.federation_member }} ${{ matrix.cluster_name || matrix.federation_member }} --name ${{ matrix.release_name || matrix.federation_member }} --stage $stage
+          done
         env:
           TERM: xterm
 

--- a/deploy.py
+++ b/deploy.py
@@ -398,7 +398,7 @@ def main():
         action="store_true",
         help="Print commands, but don't run them",
     )
-    stages = ["all", "auth", "networkbans", "kubesystem", "certmanager", "mybinder"]
+    stages = ["all", "auth", "networkban", "kubesystem", "certmanager", "mybinder"]
     argparser.add_argument(
         "--stage",
         choices=stages,


### PR DESCRIPTION
The current `ban.py` doesn't work against the AWS Curvenote EKS cluster.

Commit 00198a719a35709748053c6b207a123993c01da4 should be reverted when it's updated.