### PR TITLE
deploy.py update_networkbans: diff not supported

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -524,7 +524,7 @@ def main():
                 raise Exception("Cloud cluster not recognised!")
 
     if args.stage in ("all", "networkban"):
-        update_networkbans(cluster, args.dry_run, args.diff)
+        update_networkbans(cluster, args.dry_run)
     if args.stage in ("all", "system"):
         deploy_system_charts(args.release, args.name, args.dry_run, args.diff)
     if args.stage in ("all", "certmanager"):


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/2804

update_networkbans is entirely local, so `diff` isn't supported (though it could be in future by writing to a temp file and showing the diff).