### PR TITLE
make curevenote prime

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -234,12 +234,13 @@ federationRedirect:
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:
-      prime: true
+      prime: false
       url: https://ovh2.mybinder.org
       weight: 100
       health: https://ovh2.mybinder.org/health
       versions: https://ovh2.mybinder.org/versions
     curvenote:
+      prime: true
       url: https://binder.curvenote.dev
       weight: 20
       health: https://binder.curvenote.dev/health


### PR DESCRIPTION
main effect: it serves the main page (needs to be curvenote, not gesis which has a custom main page)

ovh cluster appears to be fully down
