### PR TITLE
Disable cryptnono.detectors.execwhacker.dockerHostPath

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -6,7 +6,8 @@ cryptnono:
       metrics:
         enabled: true
       containerdHostPath: /run/containerd
-      dockerHostPath: /run/dind
+      # TODO: Currently disabled as isn't present on all nodes, only on nodes running builders
+      # dockerHostPath: /run/dind
 
 imagePullSecrets:
 


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/2878#issuecomment-1877494294

`dockerHostPath` is is only present on build nodes. Since OVH2 uses separate pools this will fail on user nodes. K8s containerd detection should still work though.