### PR TITLE
Move cryptnono container lookup config into individual deployments

### DIFF
--- a/config/curvenote.yaml
+++ b/config/curvenote.yaml
@@ -199,6 +199,10 @@ binderhub:
 cryptnono:
   enabled: true
   priorityClassName: binderhub-core
+  detectors:
+    execwhacker:
+      containerdHostPath: /run/containerd
+      dockerHostPath: /run/dind
 
 grafana:
   enabled: false

--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -91,6 +91,13 @@ binderhub:
     imageGCThresholdLow: 30e9
     imageGCThresholdType: "absolute"
 
+cryptnono:
+  detectors:
+    execwhacker:
+      containerdHostPath: /run/containerd
+      # TODO: Currently disabled as isn't present on all nodes, only on nodes running builders
+      # dockerHostPath: /run/dind
+
 grafana:
   nodeSelector: *coreNodeSelector
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -5,8 +5,9 @@ cryptnono:
     execwhacker:
       metrics:
         enabled: true
-      containerdHostPath: /run/containerd
-      # TODO: Currently disabled as isn't present on all nodes, only on nodes running builders
+      # execwhacker needs access to containerd, and docker on build hosts, to lookup the container.
+      # Set these in the configurations for each deployment
+      # containerdHostPath: /run/containerd
       # dockerHostPath: /run/dind
 
 imagePullSecrets:


### PR DESCRIPTION
It's dependent on whether build and user nodes are combined or separate, since docker is only present on build nodes
