### PR TITLE
Setting the OVH2 weight to 60 testing #2890

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -236,7 +236,7 @@ federationRedirect:
     ovh2:
       prime: false
       url: https://ovh2.mybinder.org
-      weight: 100
+      weight: 60
       health: https://ovh2.mybinder.org/health
       versions: https://ovh2.mybinder.org/versions
     curvenote:


### PR DESCRIPTION
This PR changes the weight of OVH2 in the federation redirector from 100 to 60, as discussed in issue #2890.