### PR TITLE
Temporarily disable curvenote pending upgrades, Make OVH prime

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -234,14 +234,14 @@ federationRedirect:
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:
-      prime: false
+      prime: true
       url: https://ovh2.mybinder.org
       weight: 60
       health: https://ovh2.mybinder.org/health
       versions: https://ovh2.mybinder.org/versions
     curvenote:
-      prime: true
+      prime: false
       url: https://binder.curvenote.dev
-      weight: 20
+      weight: 0
       health: https://binder.curvenote.dev/health
       versions: https://binder.curvenote.dev/versions


### PR DESCRIPTION
Will revert tomorrow assuming https://github.com/jupyterhub/mybinder.org-deploy/pull/2940 goes well