### PR TITLE
Revert "Temporarily disable curvenote pending upgrades, Make OVH prime"

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -234,14 +234,14 @@ federationRedirect:
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:
-      prime: true
+      prime: false
       url: https://ovh2.mybinder.org
       weight: 60
       health: https://ovh2.mybinder.org/health
       versions: https://ovh2.mybinder.org/versions
     curvenote:
-      prime: false
+      prime: true
       url: https://binder.curvenote.dev
-      weight: 0
+      weight: 20
       health: https://binder.curvenote.dev/health
       versions: https://binder.curvenote.dev/versions


### PR DESCRIPTION
Upgrade is done https://github.com/jupyterhub/mybinder.org-deploy/pull/2940
Reverts jupyterhub/mybinder.org-deploy#2941

Changing the weight and the total_quota to take advantage of the increased capacity will be done separately.