### PR TITLE
curvenote: Set launch quota to 100

### DIFF
--- a/config/curvenote.yaml
+++ b/config/curvenote.yaml
@@ -17,7 +17,7 @@ binderhub:
       memory_request: "2G"
 
     LaunchQuota:
-      total_quota: 50
+      total_quota: 100
 
     ExternalRegistryHelper:
       service_url: http://curvenote-binderhub-container-registry-helper:8080


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/2940

It should be possible to increase this further if all goes well, maybe to 150? Probably best to check resource usage after running for a week or two at 100.