### PR TITLE
Only prune-harbor on jupyterhub fork

### DIFF
--- a/.github/workflows/prune-harbor.yaml
+++ b/.github/workflows/prune-harbor.yaml
@@ -13,6 +13,7 @@ jobs:
   prune-harbor:
     name: Prune ${{ matrix.name }} harbor registry
     runs-on: ubuntu-22.04
+    if: github.repository_owner == 'jupyterhub'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The `prune-harbor` workflow is a production workflow that can only be run on the production (jupyterhub) fork. It will fail, and therefore lead to notifications, on any fork that has CI workflows enabled.