### PR TITLE
Reduce GESIS contribution to the federation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://notebooks.gesis.org/binder
-      weight: 100
+      weight: 0
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
This will **temporary** remove the GESIS server from the federation until I and @arnim have a reply from IT regarding https://github.com/jupyterhub/mybinder.org-deploy/issues/3027 and https://github.com/jupyterhub/mybinder.org-deploy/issues/3033.

We will only have a reply after 16h.