### PR TITLE
Revert "Updates cryptnono chart to 0.3.1-0.dev.git.146.h6bdf5b7"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source code: https://github.com/cryptnono/cryptnono/
   - name: cryptnono
-    version: "0.3.1-0.dev.git.146.h6bdf5b7"
+    version: "0.3.1-0.dev.git.143.hfc89744"
     repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3051
which breaks OVH (cryptnono pods are started, then fail)