### PR TITLE
Temporarily reduce GESIS contribution to the federation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://notebooks.gesis.org/binder
-      weight: 100
+      weight: 0
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/2995

Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/3056

GESIS has been accumulating a huge (above 100) "Terminating" pods.

[![Screenshot 2024-08-08 at 13-32-58 Pod Activity - Dashboards - Grafana](https://github.com/user-attachments/assets/696fb829-866b-4004-a4f8-f916896fcbbc)](https://grafana.mybinder.org/d/fZWsQmnmz/pod-activity?orgId=1&var-cluster=000000002&from=1723030384898&to=1723116784900&viewPanel=3)

I want to reduce the contribution to allow the GESIS Kubernetes cluster to handle the pending queue of terminating pods.