### PR TITLE
Restore GESIS contribution to mybinder.org federation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
       versions: https://gke.mybinder.org/versions
     gesis:
       url: https://notebooks.gesis.org/binder
-      weight: 0
+      weight: 100
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
Reverts https://github.com/jupyterhub/mybinder.org-deploy/pull/3060.

Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/2995

Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/3056

# Example 1 - Launch

1. Visit https://notebooks.gesis.org/binder/
2. Fill URL with https://github.com/serhatcevikel/advanced_r
3. Click "Launch"

I can**not** tell what is wrong with the GESIS server.

## Kubernetes Event Log

Kubernetes assigned a pod at 2024-08-08T15:24:00+02:00 and Kubernetes immediately (2024-08-08T15:24:01+02:00) started to pull the image. Kubernetes successfully pulled the image at 2024-08-08T15:29:37+02:00.

The time to pull the image was around 5min with **zero** waiting time.

```
0s                      Normal    Scheduled            Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Successfully assigned gesis/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu to spko-css-app03
0s                      Normal    Pulled               Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Container image "quay.io/jupyterhub/k8s-network-tools:3.3.7" already present on machine
0s                      Normal    Created              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Created container block-cloud-metadata
0s                      Normal    Started              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Started container block-cloud-metadata
0s                      Normal    Pulling              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Pulling image "gesiscss/binder-r2d-g5b5b759-serhatcevikel-2dadvanced-5fr-6c9dce:c10809dccefe1611078b433a52dcda7e0d3d2448"
0s                      Normal    Pulled               Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Successfully pulled image "gesiscss/binder-r2d-g5b5b759-serhatcevikel-2dadvanced-5fr-6c9dce:c10809dccefe1611078b433a52dcda7e0d3d2448" in 5m35.922s (5m35.922s including waiting)
0s                      Normal    Created              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Created container notebook
0s                      Normal    Started              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Started container notebook
0s                      Normal    Killing              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2dq5an5bzu              Stopping container notebook
0s                      Normal    Scheduled            Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Successfully assigned gesis/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk to spko-css-app03
0s                      Normal    Pulled               Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Container image "quay.io/jupyterhub/k8s-network-tools:3.3.7" already present on machine
0s                      Normal    Created              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Created container block-cloud-metadata
0s                      Normal    Started              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Started container block-cloud-metadata
0s                      Normal    Pulled               Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Container image "gesiscss/binder-r2d-g5b5b759-serhatcevikel-2dadvanced-5fr-6c9dce:c10809dccefe1611078b433a52dcda7e0d3d2448" already present on machine
0s                      Normal    Created              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Created container notebook
0s                      Normal    Started              Pod/jupyter-serhatcevikel-2dadvanced-5fr-2djgdzd0xk              Started container notebook
```

# Example 2 - Build and Launch

1. Visit https://notebooks.gesis.org/binder/
2. Fill URL with https://github.com/ClassicalKooz/GhostPopulationSimulation
3. Click "Launch"

## Kubernetes Event Log

Kubernetes assigned a **build** pod at 2024-08-08T15:42:24+02:00 and Kubernetes immediately (2024-08-08T15:42:25+02:00) started the build pod. to pull the image. After image is built, Kubernetes assigned a pod at 2024-08-08T15:44:48+02:00 and Kubernetes immediately (2024-08-08T15:44:49+02:00) started pulling the image. Kubernetes successfully pulled the image at 2024-08-08T15:45:04+02:00.

The time to build and push the image was around 3min. And the time to pull the image was around 15s with **zero** waiting time.

```
0s                      Normal    Scheduled            Pod/build-classicalkooz-2dghostpopulationsimulation-a1f042-a6c-c8   Successfully assigned gesis/build-classicalkooz-2dghostpopulationsimulation-a1f042-a6c-c8 to spko-css-app03
0s                      Normal    Pulled               Pod/build-classicalkooz-2dghostpopulationsimulation-a1f042-a6c-c8   Container image "quay.io/jupyterhub/repo2docker:2024.07.0-5.g82713f3" already present on machine
0s                      Normal    Created              Pod/build-classicalkooz-2dghostpopulationsimulation-a1f042-a6c-c8   Created container builder
0s                      Normal    Started              Pod/build-classicalkooz-2dghostpopulationsimulation-a1f042-a6c-c8   Started container builder
0s                      Normal    Scheduled            Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Successfully assigned gesis/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx to spko-css-app03
0s                      Normal    Pulled               Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Container image "quay.io/jupyterhub/k8s-network-tools:3.3.7" already present on machine
0s                      Normal    Created              Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Created container block-cloud-metadata
0s                      Normal    Started              Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Started container block-cloud-metadata
0s                      Normal    Pulling              Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Pulling image "gesiscss/binder-r2d-g5b5b759-classicalkooz-2dghostpopulationsimulation-a1f042:a6c1864a4ed95b1623feee1ec5fe22d17a259440"
0s                      Normal    Pulled               Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Successfully pulled image "gesiscss/binder-r2d-g5b5b759-classicalkooz-2dghostpopulationsimulation-a1f042:a6c1864a4ed95b1623feee1ec5fe22d17a259440" in 15.388s (15.388s including waiting)
0s                      Normal    Created              Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Created container notebook
0s                      Normal    Started              Pod/jupyter-classicalkooz-2dg-2dationsimulation-2d2206vwcx          Started container notebook
```
