### PR TITLE
fix ordering of repo2docker versions

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           latest_tag=$(
               docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
-            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+(-\\d+\\..*)?$"))] | sort_by(split(".-") | map(tonumber? // 0)) | last'
+            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+(-\\d+\\..*)?$"))] | max_by(scan("[^-.]+") | tonumber? // 0)'
           )
           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
previous sorting didn't parse version suffixes as numbers, so only the version part was sorted by number, the rest was sorted as strings so "2024.07.0-9.gafaa6e3" came after "2024.07.0-12.ga61ec54"

a simpler scan turns `"2024.07.0-9.gafaa6e3"` into `(2024, 7, 0, 9)`, which is how we want to sort them.