### PR TITLE
Revert "Updates cryptnono chart to 0.3.1-0.dev.git.149.h7397c3b"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
   # cryptnono, counters crypto mining
   # Source code: https://github.com/cryptnono/cryptnono/
   - name: cryptnono
-    version: "0.3.1-0.dev.git.149.h7397c3b"
+    version: "0.3.1-0.dev.git.143.hfc89744"
     repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled
 


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3054 which failed to deploy on ovh and curvenote 😢
https://github.com/jupyterhub/mybinder.org-deploy/actions/runs/11609330331
