### PR TITLE
Add GitHub Action to push to GESIS

### DIFF
--- a/.github/workflows/gesis-methods-hub.yaml
+++ b/.github/workflows/gesis-methods-hub.yaml
@@ -1,0 +1,26 @@
+name: "GESIS update dispatcher"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-methods-hub-at-gesis:
+    if: github.repository == 'jupyterhub/mybinder.org-deploy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create remote
+        run: |
+          if [ -z "$(git remote | grep methodshub)" ]
+          then
+          git remote add methodshub https://git.gesis.org/methods-hub/interactive-environment.git
+          fi
+      - name: Update remote
+        env:
+          GESIS_METHODS_HUB_TOKEN: ${{ secrets.GESIS_METHODS_HUB_TOKEN }}
+        run: |
+          git remote set-url methodshub https://jupyterhub-mybinder-org-deploy:${GESIS_METHODS_HUB_TOKEN}@git.gesis.org/methods-hub/interactive-environment.git
+      - name: Push main
+        run: |
+          git push methodshub ${GITHUB_SHA}:main

--- a/.github/workflows/gesis-orc.yaml
+++ b/.github/workflows/gesis-orc.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  update-gesis:
+  update-orc-at-gesis:
     if: github.repository == 'jupyterhub/mybinder.org-deploy'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is related to https://github.com/jupyterhub/mybinder.org-deploy/issues/2797.

The final workflow when https://github.com/jupyterhub/mybinder.org-deploy/issues/2797 is complete will be

1. PR in https://github.com/jupyterhub/mybinder.org-deploy is merged into `main` branch
2. GitHub Actions starts [continuous deployment](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/cd.yml) of https://mybinder.org
3. GitHub Actions push merged PR to https://git.gesis.org/methods-hub/interactive-environment
4. GESIS GitLab CI/CD starts continuous deployment of https://notebooks.gesis.org/

This PR requires a new secret named `GESIS_METHODS_HUB_TOKEN ` that I'm sending in private to

- [ ] @manics 
- [ ] @minrk