### PR TITLE
temporary: redirect all instead of proxying mybinder.org to GESIS

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -444,6 +444,8 @@ def make_app():
             ),
             (r"/active_hosts", ActiveHostsHandler, {"active_hosts": hosts}),
             (r"/metrics", MetricsHandler),
+            # temporary: redirect everything, no proxy
+            (r".*", RedirectHandler, {"load_balancer": CONFIG["load_balancer"]}),
             (r".*", ProxyHandler, {"host": prime_host}),
         ],
         hosts=hosts,


### PR DESCRIPTION
should avoid CORS issues with mismatched GESIS page templates