### PR TITLE
restore federation proxy behavior

### DIFF
--- a/images/federation-redirect/app.py
+++ b/images/federation-redirect/app.py
@@ -444,8 +444,6 @@ def make_app():
             ),
             (r"/active_hosts", ActiveHostsHandler, {"active_hosts": hosts}),
             (r"/metrics", MetricsHandler),
-            # temporary: redirect everything, no proxy
-            (r".*", RedirectHandler, {"load_balancer": CONFIG["load_balancer"]}),
             (r".*", ProxyHandler, {"host": prime_host}),
         ],
         hosts=hosts,


### PR DESCRIPTION
should work now that GESIS has standard HTML

reverts #3165 