### PR TITLE
ease hetzner in more gently

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -40,7 +40,7 @@ binderhub:
       docker_host: /var/run/dind/docker.sock
 
     LaunchQuota:
-      total_quota: 300
+      total_quota: 20
 
     # DockerRegistry:
     # token_url: "https://2lmrrh8f.gra7.container-registry.ovh.net/service/token?service=harbor-registry"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -229,13 +229,13 @@ federationRedirect:
       health: https://gke.mybinder.org/health
       versions: https://gke.mybinder.org/versions
     hetzner-2i2c:
-      prime: true
+      prime: false
       url: https://2i2c.mybinder.org
-      weight: 60
+      weight: 10
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     gesis:
-      prime: false
+      prime: true
       url: https://notebooks.gesis.org/binder
       weight: 40
       health: https://notebooks.gesis.org/binder/health


### PR DESCRIPTION
too many fresh builds at once, leading to 

> Failed to create fsnotify watcher: too many open files
