### PR TITLE
ease 2i2c in more

### DIFF
--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -41,6 +41,8 @@ jobs:
             k3s-channel: "v1.24"
           - release: ovh2
             k3s-channel: "v1.24"
+          - release: hetzner-2i2c
+            k3s-channel: "v1.24"
 
     steps:
       - uses: actions/checkout@v4

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -2,6 +2,7 @@ projectName: hetzner-2i2c
 
 registry:
   enabled: true
+  replicas: 4
   config:
     storage:
       # Uncomment this and comment out the s3 config to use filesystem

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -229,13 +229,13 @@ federationRedirect:
       health: https://gke.mybinder.org/health
       versions: https://gke.mybinder.org/versions
     hetzner-2i2c:
-      prime: false
+      prime: true
       url: https://2i2c.mybinder.org
-      weight: 10
+      weight: 20
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     gesis:
-      prime: true
+      prime: false
       url: https://notebooks.gesis.org/binder
       weight: 40
       health: https://notebooks.gesis.org/binder/health

--- a/config/test-secrets.yaml
+++ b/config/test-secrets.yaml
@@ -17,3 +17,8 @@ matomo:
 
 analyticsPublisher:
   serviceAccountKey: "abc123"
+
+registry:
+  auth:
+    username: abc123
+    password: def456


### PR DESCRIPTION
gesis prime seems to cause proxy path issues

increase registry replica count (#3173)

make 2i2c prime, keep 2i2c quota low, slightly increase weight
