### PR TITLE
2i2c: try increasing docker client timeout

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -64,7 +64,14 @@ binderhub:
   extraEnv:
     GOOGLE_APPLICATION_CREDENTIALS: /secrets/service-account.json
 
-  dind: {}
+  dind:
+    resources:
+      requests:
+        cpu: "2"
+        memory: 12Gi
+      limits:
+        cpu: "6"
+        memory: 12Gi
 
   ingress:
     hosts:

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -39,6 +39,11 @@ binderhub:
     KubernetesBuildExecutor:
       memory_request: "2G"
       docker_host: /var/run/dind/docker.sock
+      repo2docker_extra_args:
+        # try to avoid timeout pushing to local registry
+        # default is 60
+        # this must have no spaces to be processed by repo2docker correctly
+        - '--DockerEngine.extra_init_args={"timeout":120}'
 
     LaunchQuota:
       total_quota: 20


### PR DESCRIPTION
I am not sure this is going to work, but maybe!

also increase dind resources because individual builds are getting OOMKilled

dind resources are super complicated because each build _reserves_ more resources while the dind pod is the only one that _uses_ them. We rely on the build pod allocations to spread builds across nodes, but for a single-node cluster, I think we can have a more static allocation for builds.