### PR TITLE
2i2c: specify memory limit for builds

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -38,6 +38,7 @@ binderhub:
     # complicated: dind memory request + KubernetesBuildExecutor.memory_request * builds_per_node ~= node memory
     KubernetesBuildExecutor:
       memory_request: "2G"
+      memory_limit: "4G"
       docker_host: /var/run/dind/docker.sock
       repo2docker_extra_args:
         # try to avoid timeout pushing to local registry


### PR DESCRIPTION
not having a limit may result in getting killed without using too much (not sure)

we are seeing builds of old environments (especially jupyterlab-demo) failing during solve with 137, which I think is OOM.