### PR TITLE
Increase the timeout even more

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -44,7 +44,7 @@ binderhub:
         # try to avoid timeout pushing to local registry
         # default is 60
         # this must have no spaces to be processed by repo2docker correctly
-        - '--DockerEngine.extra_init_args={"timeout":120}'
+        - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
       total_quota: 200


### PR DESCRIPTION
This seems to be required for repos with particularly large layers

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

<!-- BinderHub bump -->

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
