### PR TITLE
Fixes for 2i2c hetzner member

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -2,7 +2,7 @@ projectName: hetzner-2i2c
 
 registry:
   enabled: true
-  replicas: 4
+  replicas: 1
   config:
     storage:
       # Uncomment this and comment out the s3 config to use filesystem

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -9,8 +9,8 @@ registry:
       # filesystem:
       #   rootdirectory: /var/lib/registry
       s3:
-        regionendpoint: https://fsn1.your-objectstorage.com
-        bucket: mybinder-2i2c-registry-hetzner
+        regionendpoint: https://nbg1.your-objectstorage.com
+        bucket: mybinder-2i2c-registry
         region: does-not-matter
   storage:
     filesystem:

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -52,7 +52,7 @@ binderhub:
     # DockerRegistry:
     # token_url: "https://2lmrrh8f.gra7.container-registry.ovh.net/service/token?service=harbor-registry"
 
-  replicas: 1
+  replicas: 2
 
   extraVolumes:
     - name: secrets

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -47,7 +47,7 @@ binderhub:
         - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
-      total_quota: 200
+      total_quota: 250
 
     # DockerRegistry:
     # token_url: "https://2lmrrh8f.gra7.container-registry.ovh.net/service/token?service=harbor-registry"

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -68,11 +68,11 @@ binderhub:
   dind:
     resources:
       requests:
-        cpu: "2"
+        cpu: "4"
         memory: 12Gi
       limits:
-        cpu: "6"
-        memory: 12Gi
+        cpu: "8"
+        memory: 16Gi
 
   ingress:
     hosts:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -231,7 +231,7 @@ federationRedirect:
     hetzner-2i2c:
       prime: true
       url: https://2i2c.mybinder.org
-      weight: 40
+      weight: 60
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     gesis:

--- a/mybinder/templates/registry/ingress.yaml
+++ b/mybinder/templates/registry/ingress.yaml
@@ -9,8 +9,10 @@ metadata:
     release: {{ .Release.Name }}
   annotations:
     kubernetes.io/tls-acme: "true"
-    # things be big yo
-    nginx.ingress.kubernetes.io/proxy-body-size: 4096m
+    # This has to accomodate the max size of a single docker layer, which can be huge.
+    # I had previously set this to 4G thinking 'that should be big enough' and was
+    # immediately proven wrong. This is set to 16G now
+    nginx.ingress.kubernetes.io/proxy-body-size: 16384m
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
- Put object storage in same DC as the server

  When I recreated the server, I had to do so in nuremberg
  rather than falkenstein because their nuremberg server was full.
  But the object storage for the images remained in the old location.

  I've created a new object storage bucket and moved that!


- Bring registry replicas back to 1

  It doesn't do much since the pulls go directly from hetzner I believe,
  and keeping it at 1 makes debugging easier for right now

- Increase the amount of resources dind has

  As this is a new member, there's gonna be a lot of builds to
  start with. Let's support that with higher resource limits.

- Increase binderhub replicas to 2

- Add suspicious but maybe useful nginx limit increase

- Increase 2i2c quota even more