### PR TITLE
Raise the number of concurrent uploads dind can do

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -66,6 +66,11 @@ binderhub:
     GOOGLE_APPLICATION_CREDENTIALS: /secrets/service-account.json
 
   dind:
+    daemonset:
+      extraArgs:
+        # Increase limit from default of 5, as we have only one builder node
+        # But there are enough resources on the node to handle it
+        - --max-concurrent-uploads=32
     resources:
       requests:
         cpu: "4"


### PR DESCRIPTION
This was the cause of the build backups
