### PR TITLE
Re-write test_proxy_page() the simplest way possible

### DIFF
--- a/tests/test_federation_redirect.py
+++ b/tests/test_federation_redirect.py
@@ -13,4 +13,4 @@ def test_active_hosts(helm_config, federation_url):
 def test_proxy_page(helm_config, federation_url):
     r = requests.get(federation_url)
     r.raise_for_status()
-    assert "How it works" in r.text
+    assert '<div id="root"></div>' in r.text


### PR DESCRIPTION
Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/3188

A more robust way is to parse the HTML and check for the node instead of use the raw text representation.
