### PR TITLE
Set nginx-ingress timeout to 10 minutes to improve support for websockets

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -420,6 +420,9 @@ binderhub:
       enabled: true
       annotations:
         ingress.kubernetes.io/proxy-body-size: 64m
+        # Increase for websockets (default is 60s)
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
         kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
     scheduling:


### PR DESCRIPTION
The default [nginx-ingress timeout is 60 seconds](https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets). This means Jupyter desktops will disconnect if there are no changes on screen for 60 seconds. There's a race condition here between the nginx timeout and the desktop clock which updates every minute which is why
https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop
doesn't always timeout after 1 minute.

If you use a desktop without a clock:
https://mybinder.org/v2/gh/manics/jupyter-desktop-mate/HEAD?urlpath=desktop
the timeout is more reproducible.

I've set it to 10 minutes, though maybe we should lower it to 5 minutes?