### PR TITLE
K3s cryptnono: containerd.sock is in a different location

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -23,6 +23,8 @@ cryptnono:
   detectors:
     monero:
       enabled: false
+    execwhacker:
+      containerdHostPath: /run/k3s/containerd/containerd.sock
 
 binderhub:
   config:


### PR DESCRIPTION
Cryptnono container lookups are currently failing on 2i2c because containerd.sock is not in the default location:
https://github.com/jupyterhub/mybinder.org-deploy/blob/7f7aa7dd29556b3a19ffe5809f62f2f9ca32639f/mybinder/values.yaml#L10