### PR TITLE
don't cordon single-node hetzner-2i2c while cleaning

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -102,10 +102,12 @@ binderhub:
             - hub.2i2c.mybinder.org
 
   imageCleaner:
-    # Use 40GB as upper limit, size is given in bytes
+    # Use 300GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 300e9
     imageGCThresholdLow: 100e9
     imageGCThresholdType: "absolute"
+    # don't cordon single-node cluster while cleaning
+    cordon: false
 
 grafana:
   ingress:


### PR DESCRIPTION
applies https://github.com/jupyterhub/binderhub/pull/1913