### PR TITLE
Add another smaller 2i2c federation member + k3s docs

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -234,10 +234,16 @@ federationRedirect:
       weight: 70
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
+    hetzner-2i2c-bare:
+      prime: false
+      url: https://2i2c-bare.mybinder.org
+      weight: 5
+      health: https://2i2c-bare.mybinder.org/health
+      versions: https://2i2c-bare.mybinder.org/versions
     gesis:
       prime: false
       url: https://notebooks.gesis.org/binder
-      weight: 30
+      weight: 25
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:

--- a/deploy.py
+++ b/deploy.py
@@ -437,7 +437,10 @@ def main():
     argparser.add_argument(
         "release",
         help="Release to deploy",
-        choices=list(KUBECONFIG_CLUSTERS) + list(GCP_PROJECTS.keys()) + list(AWS_DEPLOYMENTS.keys()) + list(AZURE_RGs.keys())
+        choices=list(KUBECONFIG_CLUSTERS)
+        + list(GCP_PROJECTS.keys())
+        + list(AWS_DEPLOYMENTS.keys())
+        + list(AZURE_RGs.keys()),
     )
     argparser.add_argument(
         "--name",

--- a/deploy.py
+++ b/deploy.py
@@ -31,7 +31,7 @@ GCP_ZONES = {
 }
 
 # Projects using raw KUBECONFIG files
-KUBECONFIG_CLUSTERS = {"ovh2", "hetzner-2i2c"}
+KUBECONFIG_CLUSTERS = {"ovh2", "hetzner-2i2c", "hetzner-2i2c-bare"}
 
 # Mapping of config name to cluster name for AWS EKS deployments
 AWS_DEPLOYMENTS = {"curvenote": "binderhub"}
@@ -437,7 +437,7 @@ def main():
     argparser.add_argument(
         "release",
         help="Release to deploy",
-        choices=["staging", "prod", "ovh", "ovh2", "curvenote", "hetzner-2i2c"],
+        choices=list(KUBECONFIG_CLUSTERS) + list(GCP_PROJECTS.keys()) + list(AWS_DEPLOYMENTS.keys()) + list(AZURE_RGs.keys())
     )
     argparser.add_argument(
         "--name",

--- a/docs/source/deployment/k3s.md
+++ b/docs/source/deployment/k3s.md
@@ -117,6 +117,7 @@ We also need a secrets file, so let's copy `secrets/config/hetzner-2i2c.yaml` to
 Let's tell `deploy.py` script that we have a new cluster by adding `<cluster-name>` to `KUBECONFIG_CLUSTERS` variable in `deploy.py`.
 
 Once done, you can do a deployment with `./deploy.py <cluster-name>`! If it errors out, tweak and debug until it works.
+
 ## Test and validate
 
 ## Add to the redirector


### PR DESCRIPTION
I wanted to understand what it would take to run a federation member on a small machine that does *not* have object storage nearby (I'm trying to get some new members where this is true). I also wanted to run through adding a new k3s member one more time so I can document it appropriately

Sooooooo I bought a small server (16 cores AMD Ryzen with 64G of RAM and 1TB RAID1 SSD) via the wonderful [hetzner auction](https://www.hetzner.com/sb/) system. They sell older systems that are decomissioned from 'production' users but those are perfect for us. This costs 2i2c approximately 60$ a month in costs. If the server dies (because this is a physical object that has physical faults), we can just stop paying for it or try to ressurect it as we wish.

I installed Ubuntu 24.04 and ran through k3s setup again, documenting every step I did! This helps future people joining the federation this way.

Since this is in the same datacenter as the regular bigger 2i2c federation member, we can reuse the same object store backend for the registry! I can experiment with using filesystem for the registry in a future separate commit.

I've added this to the federation with a 5% weight so it gets a little traffic but not much.

Thanks to 2i2c for sponsoring this!