### PR TITLE
Don't set a per-build memory limit

### DIFF
--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -40,7 +40,6 @@ binderhub:
     # complicated: dind memory request + KubernetesBuildExecutor.memory_request * builds_per_node ~= node memory
     KubernetesBuildExecutor:
       memory_request: "2G"
-      memory_limit: "4G"
       docker_host: /var/run/dind/docker.sock
       repo2docker_extra_args:
         # try to avoid timeout pushing to local registry

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -40,7 +40,6 @@ binderhub:
     # complicated: dind memory request + KubernetesBuildExecutor.memory_request * builds_per_node ~= node memory
     KubernetesBuildExecutor:
       memory_request: "2G"
-      memory_limit: "4G"
       docker_host: /var/run/dind/docker.sock
       repo2docker_extra_args:
         # try to avoid timeout pushing to local registry

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -10,7 +10,6 @@ binderhub:
       badge_base_url: https://staging.mybinder.org
       image_prefix: us-central1-docker.pkg.dev/binderhub-288415/staging/r2d-2023-04-
       sticky_builds: true
-      build_memory_limit: "2G"
     DockerRegistry:
       token_url: "https://us-central1-docker.pkg.dev/v2/token"
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -218,7 +218,6 @@ binderhub:
           }
     KubernetesBuildExecutor:
       build_image: quay.io/jupyterhub/repo2docker:2024.07.0-68.gdd097a2
-      memory_limit: "3G"
       memory_request: "1G"
 
   extraConfig:


### PR DESCRIPTION
Trying to fix https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/try.20mybinder.20jupyterleab.20demo.20broken, which is breaking because mamba gets OOM killed. We have memory limits set on dind as a whole, and memory_limit for builds (in its current, per-build form) is going away as part of https://github.com/jupyterhub/repo2docker/pull/1402 as well. So let's remove it and see.

<!-- If this PR is a bump to either BinderHub or repo2docker,
use the template below in your PR description. If it is not,
(e.g., a docs PR) then you can delete the template below. -->

<!-- BinderHub bump -->

This is a BinderHub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/<OLD-HASH>...<NEW-HASH>

<!-- repo2docker bump -->

This is a repo2docker version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/repo2docker/compare/<OLD-HASH>...<NEW-HASH>
