### PR TITLE
Increase and centralize build memory limits

### DIFF
--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -35,12 +35,7 @@ binderhub:
       image_prefix: registry.2i2c-bare.mybinder.org/i-
       # image_prefix: quay.io/mybinder-hetzner-2i2c/image-
       # build_docker_host: /var/run/dind/docker.sock
-    # TODO: we should have CPU requests, too
-    # use this to limit the number of builds per node
-    # complicated: dind memory request + KubernetesBuildExecutor.memory_request * builds_per_node ~= node memory
     KubernetesBuildExecutor:
-      memory_request: "2G"
-      memory_limit: "4G"
       docker_host: /var/run/dind/docker.sock
       repo2docker_extra_args:
         # try to avoid timeout pushing to local registry

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -35,12 +35,7 @@ binderhub:
       image_prefix: registry.2i2c.mybinder.org/i-
       # image_prefix: quay.io/mybinder-hetzner-2i2c/image-
       # build_docker_host: /var/run/dind/docker.sock
-    # TODO: we should have CPU requests, too
-    # use this to limit the number of builds per node
-    # complicated: dind memory request + KubernetesBuildExecutor.memory_request * builds_per_node ~= node memory
     KubernetesBuildExecutor:
-      memory_request: "2G"
-      memory_limit: "4G"
       docker_host: /var/run/dind/docker.sock
       repo2docker_extra_args:
         # try to avoid timeout pushing to local registry

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -10,7 +10,6 @@ binderhub:
       badge_base_url: https://staging.mybinder.org
       image_prefix: us-central1-docker.pkg.dev/binderhub-288415/staging/r2d-2023-04-
       sticky_builds: true
-      build_memory_limit: "2G"
     DockerRegistry:
       token_url: "https://us-central1-docker.pkg.dev/v2/token"
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -218,8 +218,8 @@ binderhub:
           }
     KubernetesBuildExecutor:
       build_image: quay.io/jupyterhub/repo2docker:2024.07.0-68.gdd097a2
-      memory_limit: "3G"
-      memory_request: "1G"
+      memory_limit: "6G"
+      memory_request: "2G"
 
   extraConfig:
     # Send Events to StackDriver on Google Cloud


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/3204, which failed because it removed the limit, which caused it to be lower than the request. All the reasons given in that PR still apply.

Here I bump up the limit enough until the super popular https://github.com/jupyterlab/jupyterlab-demo is able to build. It's not a functionally super complex environment.yml, and even with simplifications in https://github.com/jupyterlab/jupyterlab-demo/pull/147, it fails to build without the memory increase limit. As mentioned in the other PR, https://github.com/jupyterhub/repo2docker/pull/1402 will get rid of this kind of limit anyway, so it's ok to raise this.
