### PR TITLE
Revert "Temporarily stop sending traffic to 2i2c-bare"

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -231,13 +231,13 @@ federationRedirect:
     hetzner-2i2c:
       prime: true
       url: https://2i2c.mybinder.org
-      weight: 75
+      weight: 70
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-2i2c-bare:
       prime: false
       url: https://2i2c-bare.mybinder.org
-      weight: 0
+      weight: 5
       health: https://2i2c-bare.mybinder.org/health
       versions: https://2i2c-bare.mybinder.org/versions
     gesis:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3203

Now that https://github.com/jupyterhub/mybinder.org-deploy/pull/3208 has landed, let's start sending a tiny amount of traffic back and see how it goes.