### PR TITLE
Centralize and keep 3 months of metrics

### DIFF
--- a/config/curvenote.yaml
+++ b/config/curvenote.yaml
@@ -227,7 +227,6 @@ prometheus:
     priorityClassName: binderhub-core
     persistentVolume:
       size: 50Gi
-    retention: 30d
     ingress:
       hosts:
         - prometheus.binder.curvenote.dev

--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -138,7 +138,6 @@ prometheus:
     persistentVolume:
       size: 50Gi
       storageClass: openebs-hostpath
-    retention: 30d
     ingress:
       hosts:
         - prometheus.2i2c-bare.mybinder.org

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -130,7 +130,6 @@ prometheus:
   server:
     persistentVolume:
       size: 50Gi
-    retention: 30d
     ingress:
       hosts:
         - prometheus.2i2c.mybinder.org

--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -119,7 +119,6 @@ prometheus:
     nodeSelector: *coreNodeSelector
     persistentVolume:
       size: 50Gi
-    retention: 30d
     ingress:
       hosts:
         - prometheus.ovh2.mybinder.org

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -126,7 +126,6 @@ prometheus:
     persistentVolume:
       size: 50G
       storageClass: standard
-    retention: 30d
     ingress:
       hosts:
         - prometheus.mybinder.org

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -606,6 +606,8 @@ prometheus:
       # mounted on one pod, so we need to use Recreate that first shut down the
       # pod and then starts it up during updates.
       type: Recreate
+    # Keep 3 months of metrics
+    retention: 90d
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
I checked hetzner-2i2c, and it had about 10G of usage for 30d of metrics. Let's bump to 90. Eventually I wanna keep at least a year or two
