### PR TITLE
Revert "Revert "Temporarily stop sending traffic to 2i2c-bare""

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,13 +230,13 @@ federationRedirect:
     hetzner-2i2c:
       prime: true
       url: https://2i2c.mybinder.org
-      weight: 70
+      weight: 75
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-2i2c-bare:
       prime: false
       url: https://2i2c-bare.mybinder.org
-      weight: 5
+      weight: 0
       health: https://2i2c-bare.mybinder.org/health
       versions: https://2i2c-bare.mybinder.org/versions
     gesis:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3212

It went well! In the time traffic has been going there (~3 days), the disk size of the registry has grown to 134G. I put a 300G limit on that, so we'd have reached that in approximately a week.

So the outcomes are:

1. We *can* put the registry on disk
2. But we must implement GC of least used images
3. And the GC may have to be aggressive if the disk size allocated to registry is small