### PR TITLE
Set template config correctly

### DIFF
--- a/mybinder/files/etc/jupyter/jupyter_notebook_config.py
+++ b/mybinder/files/etc/jupyter/jupyter_notebook_config.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion as V
 
 import notebook
 
-c.NotebookApp.extra_template_paths.append("/etc/jupyter/templates")
+c.ServerApp.extra_template_paths.append("/etc/jupyter/templates")
 
 
 # For old notebook versions we have to explicitly enable the translation
@@ -21,7 +21,7 @@ repo_url = os.environ.get("BINDER_REPO_URL", "")
 # Disable JITSI integration for now
 jitsi_url = ""
 
-c.NotebookApp.jinja_template_vars.update(
+c.ServerApp.jinja_template_vars.update(
     {
         "binder_url": binder_launch_host + binder_request,
         "persistent_binder_url": binder_launch_host + binder_persistent_request,

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -42,7 +42,7 @@ tags: {}
 
 etcJupyter:
   jupyter_notebook_config.json:
-    NotebookApp:
+    ServerApp:
       allow_origin: "*"
       tornado_settings:
         trust_xheaders: true


### PR DESCRIPTION
Turns out just setting it on NotebookApp doesn't set it on ServerApp now, and so all of our templates were actually just no-ops for a while.

Discovered while testing https://github.com/jupyterhub/mybinder.org-deploy/pull/3178
