### PR TITLE
Switch to using repo2docker with buildkit for building

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3688.h7031b344"
+    version: "1.0.0-0.dev.git.3704.h3883aac1"
     repository: https://jupyterhub.github.io/helm-chart
     condition: binderhubEnabled
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -217,9 +217,7 @@ binderhub:
             })();
           }
     KubernetesBuildExecutor:
-      build_image: quay.io/jupyterhub/repo2docker:2024.07.0-79.gb0cfd45
-      memory_limit: "6G"
-      memory_request: "2G"
+      build_image: quay.io/jupyterhub/repo2docker:2024.07.0-114.g80d186a
 
   extraConfig:
     # Send Events to StackDriver on Google Cloud


### PR DESCRIPTION
Brings in:

repo2docker (among others):
- https://github.com/jupyterhub/repo2docker/pull/1402
- https://github.com/jupyterhub/repo2docker/pull/1413

binderhub:
- https://github.com/jupyterhub/binderhub/pull/1929
- https://github.com/jupyterhub/binderhub/pull/1930

Note that this *could* cause some issues for the very few repos that depend on internal details of the non buildx old builder. For example, see https://github.com/scikit-learn/scikit-learn/pull/30835

We also remove memory limits, as those are not supported right now via the docker buildx build. We will need to add support for custom buildkit builders in binderhub, and then we can use those.

