### PR TITLE
Run a cronJob every 30m to cleanup docker buildkit cache

### DIFF
--- a/mybinder/templates/buildkit-pruner.yaml
+++ b/mybinder/templates/buildkit-pruner.yaml
@@ -1,0 +1,31 @@
+{{ if .Values.buildkitPruner.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: {{ .Values.buildkitPruner.schedule | quote }}
+  # If the previous run is still going, replace it with our new one
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: dind-socket
+            hostPath:
+              path: /var/run/dind/docker.sock
+          containers:
+          - name: pruner
+            image: {{ .Values.buildkitPruner.image }}
+            cmd:
+            - docker
+            - builder
+            - prune
+            - --all
+            - --keep-storage={{ .Values.buildkitPruner.buildkitCacheSize }}
+            volumeMounts:
+            - name: dind-socket
+              mountPath: /var/run/dind/docker.sock
+{{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,4 +1,3 @@
-# values ref: https://github.com/yuvipanda/cryptnono/blob/main/cryptnono/values.yaml
 cryptnono:
   enabled: true
   detectors:
@@ -9,6 +8,14 @@ cryptnono:
       # Override if K8s uses a different path for containerd
       containerdHostPath: /run/containerd/containerd.sock
       dockerHostPath: /run/dind/docker.sock
+
+buildkitPruner:
+  enabled: true
+  # Use the same image as we use for dind
+  image: docker:27.5.1-dind
+  buildkitCacheSize: 300G
+  # Run this every 30min
+  schedule: "*/30 * * * *"
 
 registry:
   enabled: false


### PR DESCRIPTION
https://github.com/docker/buildx/issues/1065#issuecomment-1098357043 is the best documentation on this command, and it should fully be able to replace what our imageCleaner currently does. And it's necessary, as I think imageCleaner doesn't actually clean up buildkit cache anymore.

This should be upstreamed into the helm chart, and imageCleaner deprecated / removed. However, I want to merge https://github.com/2i2c-org/binderhub-service/ into binderhub and turn that into the chart first, so we don't have to keep repeating work there. So in the meantime, this cronjob is here so we don't have mybinder.org outages (as happened in https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/mybinder.2Eorg.20outage)
