### PR TITLE
Revert "Switch to using repo2docker with buildkit for building"

### DIFF
--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   # Source code:    https://github.com/jupyterhub/binderhub/tree/main/helm-chart
   # App changelog:  https://github.com/jupyterhub/binderhub/blob/main/CHANGES.md
   - name: binderhub
-    version: "1.0.0-0.dev.git.3704.h3883aac1"
+    version: "1.0.0-0.dev.git.3688.h7031b344"
     repository: https://jupyterhub.github.io/helm-chart
     condition: binderhubEnabled
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -224,7 +224,9 @@ binderhub:
             })();
           }
     KubernetesBuildExecutor:
-      build_image: quay.io/jupyterhub/repo2docker:2024.07.0-114.g80d186a
+      build_image: quay.io/jupyterhub/repo2docker:2024.07.0-79.gb0cfd45
+      memory_limit: "6G"
+      memory_request: "2G"
 
   extraConfig:
     # Send Events to StackDriver on Google Cloud


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3225

We were running out of disk space, causing issues: https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/mybinder.2Eorg.20outage