### PR TITLE
Run imagecleaner more aggressively

### DIFF
--- a/config/curvenote.yaml
+++ b/config/curvenote.yaml
@@ -188,13 +188,6 @@ binderhub:
     #   # maxAge: 1 hour since we're just testing
     #   maxAge: 3600
 
-  imageCleaner:
-    # TODO: priorityClassName: binderhub-core
-    enabled: true
-    # Use 40GB as upper limit, size is given in bytes
-    imageGCThresholdHigh: 40e9
-    imageGCThresholdLow: 30e9
-    imageGCThresholdType: "absolute"
 
 cryptnono:
   enabled: true

--- a/config/curvenote.yaml
+++ b/config/curvenote.yaml
@@ -188,7 +188,6 @@ binderhub:
     #   # maxAge: 1 hour since we're just testing
     #   maxAge: 3600
 
-
 cryptnono:
   enabled: true
   priorityClassName: binderhub-core

--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -103,14 +103,6 @@ binderhub:
           hosts:
             - hub.2i2c-bare.mybinder.org
 
-  imageCleaner:
-    # Use 300GB as upper limit, size is given in bytes
-    imageGCThresholdHigh: 300e9
-    imageGCThresholdLow: 100e9
-    imageGCThresholdType: "absolute"
-    # don't cordon single-node cluster while cleaning
-    cordon: false
-
 grafana:
   ingress:
     hosts:

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -97,10 +97,6 @@ binderhub:
             - hub.2i2c.mybinder.org
 
   imageCleaner:
-    # Use 300GB as upper limit, size is given in bytes
-    imageGCThresholdHigh: 300e9
-    imageGCThresholdLow: 100e9
-    imageGCThresholdType: "absolute"
     # don't cordon single-node cluster while cleaning
     cordon: false
 

--- a/config/ovh2.yaml
+++ b/config/ovh2.yaml
@@ -85,12 +85,6 @@ binderhub:
       userScheduler:
         nodeSelector: *coreNodeSelector
 
-  imageCleaner:
-    # Use 40GB as upper limit, size is given in bytes
-    imageGCThresholdHigh: 40e9
-    imageGCThresholdLow: 30e9
-    imageGCThresholdType: "absolute"
-
 grafana:
   nodeSelector: *coreNodeSelector
   ingress:


### PR DESCRIPTION
The reason we had to revert https://github.com/jupyterhub/mybinder.org-deploy/pull/3228 was that the image cache was growing big, and so was the buildkit cache. So this meant images were being stored in *three* places:

1. the buildkit cache (dind)
2. the image cache (dind)
3. the containerd store (by kubernetes, when it pulls)

1 and 2 were both set to about 300, so this caused the disk to fill up.

Here, I more aggressively prune the image cache, as it is simply not used when buildkit is used. Once I verify this works ok, I'll turn on buildkit building again and we see how it goes.

