### PR TITLE
Run the buildkit image pruner more frequently

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -14,8 +14,8 @@ buildkitPruner:
   # Use the same image as we use for dind
   image: docker:27.5.1-dind
   buildkitCacheSize: 300GB
-  # Run this every 30min
-  schedule: "*/30 * * * *"
+  # Run this every 10min
+  schedule: "*/10 * * * *"
 
 registry:
   enabled: false


### PR DESCRIPTION
<img width="1852" alt="image" src="https://github.com/user-attachments/assets/ebfdff8e-c2aa-4672-a7ec-47ee1d500b3b" />

Looking at this graph, free space can drop a couple hundred gigs in 10-20min sometimes. Running this every 10min helps, as the image cleaner runs pretty frequently otherwise.