### PR TITLE
Explicitly set docker's MTU to 1450

### DIFF
--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -65,11 +65,6 @@ binderhub:
     GOOGLE_APPLICATION_CREDENTIALS: /secrets/service-account.json
 
   dind:
-    daemonset:
-      extraArgs:
-        # Increase limit from default of 5, as we have only one builder node
-        # But there are enough resources on the node to handle it
-        - --max-concurrent-uploads=32
     resources:
       requests:
         cpu: "4"

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -63,11 +63,6 @@ binderhub:
     GOOGLE_APPLICATION_CREDENTIALS: /secrets/service-account.json
 
   dind:
-    daemonset:
-      extraArgs:
-        # Increase limit from default of 5, as we have only one builder node
-        # But there are enough resources on the node to handle it
-        - --max-concurrent-uploads=32
     resources:
       requests:
         cpu: "4"

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -345,6 +345,14 @@ binderhub:
 
   imageBuilderType: dind
   dind:
+    daemonset:
+      extraArgs:
+        # Allow for concurrent pushes so pushes are faster
+        - --max-concurrent-uploads=32
+        # Set mtu explicitly to 1450, as sometimes docker sets it to 1500
+        # instead and that breaks *some* websites randomly *some* of the time
+        # See https://discourse.jupyter.org/t/error-in-mybinder-org-there-is-no-package-called-irkernel/32478/17
+        - --mtu=1450
     resources:
       requests:
         cpu: "0.5"


### PR DESCRIPTION
Debugging https://discourse.jupyter.org/t/error-in-mybinder-org-there-is-no-package-called-irkernel/32478/17, I discovered that docker sometimes sets its MTU to 1500, and this breaks *some* websites *some* of the time. And this is not an uncommon issue: https://www.civo.com/learn/fixing-networking-for-docker

Explicitly setting it to 1450 seems to fix this!
