### PR TITLE
Disable image cleaner

### DIFF
--- a/mybinder/templates/buildkit-pruner.yaml
+++ b/mybinder/templates/buildkit-pruner.yaml
@@ -26,6 +26,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              docker image prune ---force -all && \
               docker builder prune --force --all --keep-storage={{ .Values.buildkitPruner.buildkitCacheSize }} && \
               docker system df
             volumeMounts:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -362,7 +362,7 @@ binderhub:
         memory: 4Gi
 
   imageCleaner:
-    enabled: true
+    enabled: false
     # Use 40GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 40e9
     imageGCThresholdLow: 10e9


### PR DESCRIPTION
As part of https://github.com/jupyterhub/binderhub/pull/1941, I want to not port imageCleaner to the new chart. Since the image store is not really used to push anymore (since https://github.com/jupyterhub/repo2docker/pull/1421) and we will be able to disregard it completely in the future, we can simply just prune the entire image store than do any complex logic here.