### PR TITLE
Disable imageCleaner only on single node members

### DIFF
--- a/config/hetzner-2i2c-bare.yaml
+++ b/config/hetzner-2i2c-bare.yaml
@@ -29,6 +29,9 @@ cryptnono:
       containerdHostPath: /run/k3s/containerd/containerd.sock
 
 binderhub:
+  imageCleaner:
+    # handled by buildkit pruner
+    enabled: false
   config:
     BinderHub:
       hub_url: https://hub.2i2c-bare.mybinder.org

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -92,8 +92,8 @@ binderhub:
             - hub.2i2c.mybinder.org
 
   imageCleaner:
-    # don't cordon single-node cluster while cleaning
-    cordon: false
+    # handled by buildkit pruner
+    enabled: false
 
 grafana:
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -362,7 +362,7 @@ binderhub:
         memory: 4Gi
 
   imageCleaner:
-    enabled: false
+    enabled: true
     # Use 40GB as upper limit, size is given in bytes
     imageGCThresholdHigh: 40e9
     imageGCThresholdLow: 10e9


### PR DESCRIPTION
This is practically a no-op, but we want imageCleaner enabled still on multi-node instances

See https://github.com/jupyterhub/mybinder.org-deploy/pull/3249#issuecomment-2709730473
