### PR TITLE
Bring GESIS server back to rotation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
     hetzner-2i2c:
       prime: true
       url: https://2i2c.mybinder.org
-      weight: 100
+      weight: 50
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-2i2c-bare:
@@ -242,7 +242,7 @@ federationRedirect:
     gesis:
       prime: false
       url: https://notebooks.gesis.org/binder
-      weight: 0
+      weight: 50
       health: https://notebooks.gesis.org/binder/health
       versions: https://notebooks.gesis.org/binder/versions
     ovh2:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3254

GESIS server was out of rotation because of https://github.com/jupyterhub/mybinder.org-deploy/issues/3253. With the issue fixed, we can bring GESIS server back.