### PR TITLE
Add section about GitHub Actions to watch dependencies

### DIFF
--- a/docs/source/deployment/prereqs.md
+++ b/docs/source/deployment/prereqs.md
@@ -46,5 +46,7 @@ We use [GitHub Actions](https://docs.github.com/en/actions) for doing all our de
 [`.github/workflows/cd.yml`](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/cd.yml) file
 contains the entire configuration for our **continuous** deployment.
 
+Because mybinder.org dependes on JupyterHub, BinderHub and repo2docker, we also use [GitHub Actions to watch those dependencies](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/watch-dependencies.yaml) once every day and, if needed, create a pull request. In some sporadically cases, the mybinder.org operators might manually trigger a dependencies check by clicking the "[Run workflow](https://github.com/jupyterhub/mybinder.org-deploy/actions/workflows/watch-dependencies.yaml)" button.
+
 [mybinder.org]: https://mybinder.org
 [staging.mybinder.org]: https://staging.mybinder.org

--- a/docs/source/deployment/prereqs.md
+++ b/docs/source/deployment/prereqs.md
@@ -46,7 +46,7 @@ We use [GitHub Actions](https://docs.github.com/en/actions) for doing all our de
 [`.github/workflows/cd.yml`](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/cd.yml) file
 contains the entire configuration for our **continuous** deployment.
 
-Because mybinder.org dependes on JupyterHub, BinderHub and repo2docker, we also use [GitHub Actions to watch those dependencies](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/watch-dependencies.yaml) once every day and, if needed, create a pull request. In some sporadically cases, the mybinder.org operators might manually trigger a dependencies check by clicking the "[Run workflow](https://github.com/jupyterhub/mybinder.org-deploy/actions/workflows/watch-dependencies.yaml)" button.
+Because mybinder.org dependes on JupyterHub, BinderHub and repo2docker, we also use [GitHub Actions to watch those dependencies](https://github.com/jupyterhub/mybinder.org-deploy/blob/main/.github/workflows/watch-dependencies.yaml) once every day and, if needed, create a pull request. mybinder.org operators can manually trigger a dependency check by clicking the "[Run workflow](https://github.com/jupyterhub/mybinder.org-deploy/actions/workflows/watch-dependencies.yaml)" button.
 
 [mybinder.org]: https://mybinder.org
 [staging.mybinder.org]: https://staging.mybinder.org


### PR DESCRIPTION
This improves the documentation based on the answer that @rgaiacs  received from @minrk on Zulip.