### PR TITLE
ci: bump to use ubuntu 24.04 based runners

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
       (github.event.label.name == 'test-staging') ||
       ((github.event_name == 'push') && (github.ref == 'refs/heads/main')) ||
       ((github.event_name == 'push') && contains(github.ref, 'test-this-pr'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -207,7 +207,7 @@ jobs:
     # Only run job if the event is a push to main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -25,7 +25,7 @@ jobs:
   # matching version of where we look to deploy.
   #
   helm-template:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-yamllint.yml
+++ b/.github/workflows/test-yamllint.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   yamllint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -27,7 +27,7 @@ jobs:
     # workflow_dispatch for CI development purposes.
     if: github.repository == 'jupyterhub/mybinder.org-deploy' || github.event_name != 'schedule'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: watch-dependencies-env
 
     strategy:
@@ -125,7 +125,7 @@ jobs:
     # workflow_dispatch for CI development purposes.
     if: github.repository == 'jupyterhub/mybinder.org-deploy' || github.event_name != 'schedule'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: watch-dependencies-env
 
     strategy:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Ubuntu 20.04 runners on GitHub Actions now experience brownouts, so let's move away from using them.

![image](https://github.com/user-attachments/assets/0299ad5a-8dbc-4646-b333-49cd93858003)