### PR TITLE
Add GESIS Server at Hetzner Online GmbH to federation

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -239,6 +239,12 @@ federationRedirect:
       weight: 0
       health: https://2i2c-bare.mybinder.org/health
       versions: https://2i2c-bare.mybinder.org/versions
+    hetzner-gesis:
+      prime: false
+      url: https://gesis.mybinder.org
+      weight: 5
+      health: https://gesis.mybinder.org/health
+      versions: https://gesis.mybinder.org/versions
     gesis:
       prime: false
       url: https://notebooks.gesis.org/binder

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -245,12 +245,6 @@ federationRedirect:
       weight: 5
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
-    gesis:
-      prime: false
-      url: https://notebooks.gesis.org/binder
-      weight: 50
-      health: https://notebooks.gesis.org/binder/health
-      versions: https://notebooks.gesis.org/binder/versions
     ovh2:
       prime: false
       url: https://ovh2.mybinder.org


### PR DESCRIPTION
Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/3264

In https://github.com/jupyterhub/mybinder.org-deploy/pull/3265, @yuvipanda said

> Hetzner's network abuse policy is that we must respond and take action often within 48 or 72h, or they will simply stop all network traffic to the server. So, I think we must have project access before we can take this into rotation.

cc @arnim 