### PR TITLE
Increase new GESIS server weight again

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -242,7 +242,7 @@ federationRedirect:
     hetzner-gesis:
       prime: false
       url: https://gesis.mybinder.org
-      weight: 25
+      weight: 50
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     ovh2:


### PR DESCRIPTION
Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/3264

This brings the weight of the GESIS server to the same value of the 2i2c server.