### PR TITLE
Revert "Bump requests from 2.31.0 to 2.32.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ pyyaml==6.0.2
     # via
     #   -r requirements.in
     #   kubernetes
-requests==2.32.4
+requests==2.31.0
     # via
     #   -r requirements.in
     #   docker


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3307

That PR fails due to `requests.exceptions.InvalidURL: Not supported URL scheme http+docker`
https://github.com/jupyterhub/mybinder.org-deploy/actions/runs/15560432595/job/43811095012

[logs.txt](https://github.com/user-attachments/files/20673844/logs.txt)
