### PR TITLE
dependabot: set dependency-type: all for pip

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,12 @@ updates:
   # Maintain Python dependencies for building documentation
   - package-ecosystem: pip
     directory: /docs
+    allow:
+      dependency-type: all
+    groups:
+      docs:
+        patterns:
+          - "*"
     schedule:
       interval: monthly
       time: "05:00"
@@ -30,6 +36,8 @@ updates:
   # Python dependencies in our deployment environment (pip-compile)
   - package-ecosystem: pip
     directory: "/"
+    allow:
+      dependency-type: all
     schedule:
       interval: weekly
       time: "05:00"


### PR DESCRIPTION
[dependency-type: indirect](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow) is needed to check transitive dependencies, and it appears `direct` is the default (though this does not appear to be documented).

I think this will solve the "dependabot is not updating pip-compile" problem we've been seeing. If so, we should see a bunch of PRs shortly. We could bundle them, if we want. I elected to bundle everything on docs into a single PR, since monthly will mean a bunch of tiny PRs.

We could also bundle the weekly bump, if we want. There are pros and cons.