### PR TITLE
Revert "Temporarily reduce GESIS weight to federation"

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -236,7 +236,7 @@ federationRedirect:
     hetzner-gesis:
       prime: false
       url: https://gesis.mybinder.org
-      weight: 0
+      weight: 50
       health: https://gesis.mybinder.org/health
       versions: https://gesis.mybinder.org/versions
     ovh2:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3358

Please note that changes will not be deployed because of https://github.com/jupyterhub/mybinder.org-deploy/issues/3359.