### PR TITLE
Add 2i2c back with weight 10

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
     hetzner-2i2c:
       prime: false
       url: https://2i2c.mybinder.org
-      weight: 0
+      weight: 10
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-gesis:


### PR DESCRIPTION
Adds 2i2c back with a small weight: 10 instead of 50. gesis is still kept as prime.