### PR TITLE
Revert "Add 2i2c back with weight 10"

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
     hetzner-2i2c:
       prime: false
       url: https://2i2c.mybinder.org
-      weight: 10
+      weight: 0
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-gesis:


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3402

The deployment is [failing](https://github.com/jupyterhub/mybinder.org-deploy/actions/runs/17278384152/job/49042202327):
```
Starting helm upgrade for hetzner-2i2c
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/runner/work/mybinder.org-deploy/mybinder.org-deploy/secrets/hetzner-2i2c-kubeconfig.yml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/runner/work/mybinder.org-deploy/mybinder.org-deploy/secrets/hetzner-2i2c-kubeconfig.yml
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
Traceback (most recent call last):
  File "/home/runner/work/mybinder.org-deploy/mybinder.org-deploy/./deploy.py", line 585, in <module>
    main()
    ~~~~^^
  File "/home/runner/work/mybinder.org-deploy/mybinder.org-deploy/./deploy.py", line 574, in main
    deploy(
    ~~~~~~^
        args.release,
        ^^^^^^^^^^^^^
    ...<4 lines>...
        args.additional_helm_args,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/runner/work/mybinder.org-deploy/mybinder.org-deploy/./deploy.py", line 268, in deploy
    check_call(helm, dry_run)
    ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/runner/work/mybinder.org-deploy/mybinder.org-deploy/./deploy.py", line 57, in check_call
    subprocess.check_call(cmd)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['helm', 'upgrade', '--install', '--cleanup-on-fail', '--create-namespace', '--namespace=hetzner-2i2c', 'hetzner-2i2c', 'mybinder', '-f', 'secrets/config/common/bans.yaml', '-f', 'secrets/config/common/common.yaml', '-f', 'secrets/config/common/cryptnono.yaml', '-f', 'config/hetzner-2i2c.yaml', '-f', 'secrets/config/hetzner-2i2c.yaml']' returned non-zero exit status 1.
```