### PR TITLE
Increase hetzner-2i2c to weight 50

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -230,7 +230,7 @@ federationRedirect:
     hetzner-2i2c:
       prime: false
       url: https://2i2c.mybinder.org
-      weight: 30
+      weight: 50
       health: https://2i2c.mybinder.org/health
       versions: https://2i2c.mybinder.org/versions
     hetzner-gesis:


### PR DESCRIPTION
Increase hetzner-2i2c to weight 50, still keep gesis as prime