### PR TITLE
add plausible

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -132,8 +132,7 @@ binderhub:
         - ^ajiBal/.*
         - ^wyattsanchez54/.*
         - ^walterpowell201/.*
-      high_quota_specs:
-        []
+      high_quota_specs: []
         # - ^jupyterlab/.*
         # - ^jupyter/.*
         # - ^jupyterhub/.*

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -132,7 +132,8 @@ binderhub:
         - ^ajiBal/.*
         - ^wyattsanchez54/.*
         - ^walterpowell201/.*
-      high_quota_specs: []
+      high_quota_specs:
+        []
         # - ^jupyterlab/.*
         # - ^jupyter/.*
         # - ^jupyterhub/.*
@@ -198,6 +199,11 @@ binderhub:
         For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a
         security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />
         For more information about the Binder Project, see <a href="https://mybinder.readthedocs.io/en/latest/about.html">the About Binder page</a></p>
+
+      extra_header_html:
+        01-plausible: |
+          <script defer data-domain="mybinder.org" src="https://plausible.io/js/script.file-downloads.outbound-links.js"></script>
+          <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 
       extra_footer_scripts:
         01-matomo: |


### PR DESCRIPTION
closes https://github.com/jupyterhub/team-compass/issues/803

Notably: this doesn't check DNT, unlike Matomo. You can see some discussion about why here: https://github.com/plausible/analytics/discussions/646

We could respect DNT ourselves, like we do for matomo, before loading the plausible scripts.