### PR TITLE
Revert "Downgrade Docker dind from 28.3.3-dind to 27.5.1-dind"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -352,10 +352,6 @@ binderhub:
   imageBuilderType: dind
   dind:
     daemonset:
-      image:
-        # Investigating https://github.com/jupyterhub/mybinder.org-deploy/issues/3387#issuecomment-3239287733
-        # Downgrade dind, reverts https://github.com/jupyterhub/binderhub/pull/1937
-        tag: 27.5.1-dind
       extraArgs:
         # Allow for concurrent pushes so pushes are faster
         - --max-concurrent-uploads=32


### PR DESCRIPTION
Following up with [conversation on Zulip](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/mybinder.2Eorg.20is.20down/near/538019619).

Investigating https://github.com/jupyterhub/mybinder.org-deploy/issues/3387#issuecomment-3239287733

Reverts jupyterhub/mybinder.org-deploy#3413, i.e. restoring https://github.com/jupyterhub/binderhub/pull/1937

I will merge this and follow up during the day today.
