### PR TITLE
Downgrade Docker dind from 28.3.3-dind to 27.5.1-dind

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -352,6 +352,10 @@ binderhub:
   imageBuilderType: dind
   dind:
     daemonset:
+      image:
+        # Investigating https://github.com/jupyterhub/mybinder.org-deploy/issues/3387#issuecomment-3239287733
+        # Downgrade dind, reverts https://github.com/jupyterhub/binderhub/pull/1937
+        tag: 27.5.1-dind
       extraArgs:
         # Allow for concurrent pushes so pushes are faster
         - --max-concurrent-uploads=32


### PR DESCRIPTION
Following up with [conversation on Zulip](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/mybinder.2Eorg.20is.20down/near/538019619).

Investigating https://github.com/jupyterhub/mybinder.org-deploy/issues/3387

Reverts https://github.com/jupyterhub/binderhub/pull/1937 after report by [Kaustubh_Patil](https://discourse.jupyter.org/u/kaustubh_patil) and [JuliusEnBW](https://github.com/JuliusEnBW) that the problem appear again.

I will merge this.