### PR TITLE
Add a JupyterCon sign-up link to the mybinder banner

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -186,9 +186,9 @@ binderhub:
             🤍 Donate to mybinder.org!
         </a>
         <div style="text-align:center;">
-        🚀 JupyterCon 2025 is on November 5th in San Diego, CA!
-        See the <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">JupyterCon schedule</a>
-        and <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">register here</a>
+        🚀 JupyterCon 2025 is November 5th in San Diego, CA!
+        See the <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">JupyterCon schedule here</a>.
+        <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463"><button class="btn btn-primary">Register for JupyterCon</button></a>
         </div>
         <!-- Un-comment when we are past JupyterCon
         <div style="text-align:center;">

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -199,7 +199,7 @@ binderhub:
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />
         The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>.
         Donations are managed by <a href="https://lf-charities.org">LF Charities</a>, a US 501c3 non-profit.<br /><br />
-        Fohttps://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463r abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a
+        For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a
         security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />
         For more information about the Binder Project, see <a href="https://mybinder.readthedocs.io/en/latest/about.html">the About Binder page</a></p>
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -186,16 +186,20 @@ binderhub:
             🤍 Donate to mybinder.org!
         </a>
         <div style="text-align:center;">
+        🚀 JupyterCon 2025 is on November 5th in San Diego, CA!
+        See the <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">JupyterCon schedule</a>
+        and <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">register here</a>
+        </div>
+        <!-- Un-comment when we are past JupyterCon
+        <div style="text-align:center;">
         Thanks to <a href="https://www.gesis.org">GESIS</a> and <a href="https://2i2c.org">2i2c</a> for supporting us! 🎉
         </div>
-        <div style="text-align:center;">
-        mybinder.org has updated the base image to Ubuntu 22.04! See the <a href="https://repo2docker.readthedocs.io/en/latest/howto/breaking_changes.html">upgrade guide</a> for details.
-        </div>
+        -->
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />
         The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>.
         Donations are managed by <a href="https://lf-charities.org">LF Charities</a>, a US 501c3 non-profit.<br /><br />
-        For abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a
+        Fohttps://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463r abuse please email: <a href="mailto:binder-team@googlegroups.com">binder-team@googlegroups.com</a>, to report a
         security vulnerability please see: <a href="https://mybinder.readthedocs.io/en/latest/faq.html#where-can-i-report-a-security-issue">Where can I report a security issue</a><br /><br />
         For more information about the Binder Project, see <a href="https://mybinder.readthedocs.io/en/latest/about.html">the About Binder page</a></p>
 

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -186,15 +186,11 @@ binderhub:
             🤍 Donate to mybinder.org!
         </a>
         <div style="text-align:center;">
-        🚀 JupyterCon 2025 is November 5th in San Diego, CA!
-        See the <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">JupyterCon schedule here</a>.
-        <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463"><button class="btn btn-primary">Register for JupyterCon</button></a>
+        Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">REGISTER NOW</a>
         </div>
-        <!-- Un-comment when we are past JupyterCon
         <div style="text-align:center;">
-        Thanks to <a href="https://www.gesis.org">GESIS</a> and <a href="https://2i2c.org">2i2c</a> for supporting us! 🎉
+        Thanks to <a href="https://www.gesis.org">GESIS</a> and <a href="https://2i2c.org">2i2c</a> for supporting mybinder.org! 🎉
         </div>
-        -->
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />
         The Binder Project is a member of <a href="https://jupyter.org">Project Jupyter</a>.


### PR DESCRIPTION
This is a temporary change to add a link to JupyterCon. Could we add this to mybinder.org for a few months in the lead-up to JupyterCon?

I did my best to figure out what the HTML would look like, and made the "register" call to action a button, I'm happy to change that if folks think it's not done properly!

Here's how it looks:

<img width="654" height="111" alt="CleanShot 2025-09-19 at 10 23 25" src="https://github.com/user-attachments/assets/52fd1ff9-589c-4bad-a327-aadb2d75b2ea" />
