### PR TITLE
Reduce GESIS quota to 10%

### DIFF
--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -40,7 +40,7 @@ binderhub:
         - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
-      total_quota: 300
+      total_quota: 30
 
   replicas: 2
 


### PR DESCRIPTION
Based on https://github.com/jupyterhub/mybinder.org-deploy/issues/3387#issuecomment-3317565994

My understanding is that GESIS server is on a infinite disk pressure loop.

Kubernetes will remove old container images but not as fast as new ones are created / downloaded. This means that every couple of minutes the server goes into disk pressure mode and the site becomes unavailable.

This temporary pull request reduces the GESIS server quota to 30 users. This should help the server to have time to clean the disk.

I'm merging this immediately.