### PR TITLE
Increase GESIS quota

### DIFF
--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -40,7 +40,7 @@ binderhub:
         - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
-      total_quota: 30
+      total_quota: 120
 
   replicas: 2
 


### PR DESCRIPTION
This is a partial revert of https://github.com/jupyterhub/mybinder.org-deploy/pull/3432

It increases the GESIS quota a little. Hopefully, `k3s` not get to the infinite disk pressure loop.

I'm merging this immediately.