### PR TITLE
Increase total quota of GESIS server

### DIFF
--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -40,7 +40,7 @@ binderhub:
         - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
-      total_quota: 120
+      total_quota: 180
 
   replicas: 2
 


### PR DESCRIPTION
This partially reverts https://github.com/jupyterhub/mybinder.org-deploy/pull/3432

I'm planning to merge this at 15:00 UTC.