### PR TITLE
Stop using intermediate files in analytics publisher

### DIFF
--- a/images/analytics-publisher/indexer.py
+++ b/images/analytics-publisher/indexer.py
@@ -10,7 +10,6 @@ import argparse
 import json
 import mimetypes
 import os
-import tempfile
 from datetime import datetime
 from glob import glob
 


### PR DESCRIPTION
Hopefully sorts out issue listed in
https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/topic/Binder.20Analytics.20Archive.20isn't.20publishing/with/544826847
