### PR TITLE
Add tcpflowkiller.containerdHostPath for hetzner-{2i2c,gesis}

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -25,6 +25,8 @@ cryptnono:
       enabled: false
     execwhacker:
       containerdHostPath: /run/k3s/containerd/containerd.sock
+    tcpflowkiller:
+      containerdHostPath: /run/k3s/containerd/containerd.sock
 
 binderhub:
   config:

--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -23,6 +23,8 @@ cryptnono:
       enabled: false
     execwhacker:
       containerdHostPath: /run/k3s/containerd/containerd.sock
+    tcpflowkiller:
+      containerdHostPath: /run/k3s/containerd/containerd.sock
 
 binderhub:
   config:


### PR DESCRIPTION
This is needed so we can lookup which pod is killed by cryptnono flowkiller