### PR TITLE
Remove JupyterCon 2025 banner from mybinder.org

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -195,10 +195,10 @@ binderhub:
             🤍 Donate to mybinder.org!
         </a>
         <div style="text-align:center;">
-        Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">REGISTER NOW</a>
+        Thanks to <a href="https://www.gesis.org">GESIS</a> and <a href="https://2i2c.org">2i2c</a> for supporting us! 🎉
         </div>
         <div style="text-align:center;">
-        Thanks to <a href="https://www.gesis.org">GESIS</a> and <a href="https://2i2c.org">2i2c</a> for supporting mybinder.org! 🎉
+        mybinder.org has updated the base image to Ubuntu 22.04! See the <a href="https://repo2docker.readthedocs.io/en/latest/howto/breaking_changes.html">upgrade guide</a> for details.
         </div>
       about_message: |
         <p>mybinder.org is public infrastructure operated by the <a href="https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team">Binder Project team</a>.<br /><br />


### PR DESCRIPTION
This reverts the JupyterCon promotional message from the mybinder.org banner and restores the original messages about GESIS/2i2c support and Ubuntu 22.04 upgrade information.

Reverts PR #3431
See jupyter-governance/ec-team-compass#146

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by @jasongrout
