### PR TITLE
Disable `jupyterhub.scheduling`

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -61,9 +61,6 @@ binderhub:
         - secretName: kubelego-tls-jupyterhub-staging
           hosts:
             - hub.ovh.staging.mybinder.org
-    scheduling:
-      userPlaceholder:
-        replicas: 1
 
     proxy:
       chp:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -434,13 +434,9 @@ binderhub:
         kubernetes.io/tls-acme: "true"
     scheduling:
       userScheduler:
-        enabled: true
-        replicas: 2
-      podPriority:
-        enabled: true
+        enabled: false
       userPlaceholder:
-        enabled: true
-        # replicas set in config/<deployment>
+        enabled: false
     singleuser:
       # clear singleuser.defaultUrl config from chart
       defaultUrl:


### PR DESCRIPTION
We now only have fixed sized clusters, the autoscaling clusters have been removed.
