### PR TITLE
enable harbor prometheus metrics

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -124,6 +124,19 @@ prometheus:
         - hosts:
             - prometheus.bids.mybinder.org
           secretName: kubelego-tls-prometheus
+  extraScrapeConfigs: |
+    - job_name: 'harbor-exporter'
+      static_configs:
+        - targets:
+            - bids-ovh-harbor-exporter:8001
+    - job_name: 'harbor-registry'
+      static_configs:
+        - targets:
+            - bids-ovh-harbor-registry:8001
+    - job_name: 'harbor-jobservice'
+      static_configs:
+        - targets:
+            - bids-ovh-harbor-jobservice:8001
 
 ingress-nginx:
   controller:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -69,10 +69,17 @@ harbor:
       certSource: secret
       secret:
         secretName: tls-harbor
+  metrics:
+    enabled: true
+
   persistence:
     imageChartStorage:
       type: s3
       s3: {}
+  core:
+    serviceAnnotations:
+      prometheus.io/port: "8001"
+      prometheus.io/scrape: "true"
   trivy:
     enabled: false
 


### PR DESCRIPTION
harbor chart only supports prometheus _operator_ CRDs, and doesn't expose serviceAnnotations for all services, so we need extraScrapeConfig to tell prometheus what to scrape.

Alternative: install prometheus CRDs