### PR TITLE
repo2docker 2025.12.1.dev6-gc8b2679fa

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -243,7 +243,7 @@ binderhub:
           <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 
     KubernetesBuildExecutor:
-      build_image: quay.io/jupyterhub/repo2docker:2025.12.0
+      build_image: quay.io/jupyterhub/repo2docker:2025.12.1.dev6-gc8b2679fa
 
   extraConfig:
     # Send Events to StackDriver on Google Cloud


### PR DESCRIPTION
This is a manual repo2docker version bump to bring in https://github.com/jupyterhub/repo2docker/pull/1499 since our repo2docker image updates are broken: https://github.com/jupyterhub/mybinder.org-deploy/issues/3595

https://github.com/jupyterhub/repo2docker/compare/2025.12.0...c8b2679fa
