### PR TITLE
increase memory limit on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -48,10 +48,13 @@ binderhub:
         requests:
           memory: 100M
           cpu: "10m"
+      config:
+        JupyterHub:
+          active_server_limit: 10
     singleuser:
       memory:
-        guarantee: 100M
-        limit: 256M
+        guarantee: 400M
+        limit: 500M
       cpu:
         guarantee: .01
         limit: 0.5


### PR DESCRIPTION
256 isn't enough for some test repos

apply active_server_limit to avoid resource exhaustion

cc @manics 
