### PR TITLE
fix ordering of repo2docker image tags

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -62,16 +62,8 @@ jobs:
 
       - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
         id: latest
-        # The skopeo image helps us list tags consistently from different docker
-        # registries. We use jq to filter out tags of the x.y.z(-a) format, and
-        # then sort based on the numerical x, y, z, and a values. Finally, we
-        # pick the last value in the list.
-        #
         run: |
-          latest_tag=$(
-              docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
-            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+"))] | max_by(. | scan("\\d+") | tonumber? // 0)'
-          )
+          latest_tag=$(python3 scripts/latest_tag.py ${{ matrix.registry }}/${{ matrix.repository }})
           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 
       - name: Update values.yaml pinned tag

--- a/scripts/latest_tag.py
+++ b/scripts/latest_tag.py
@@ -1,0 +1,79 @@
+"""get the latest tag for a docker repo
+
+Sorts parsed versions.
+
+Expects valid Python version strings,
+but accepts normalizing `-build` suffix back to `+build`,
+since `+build` isn't valid in docker tags (repo2docker does this).
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def get_tags(repo: str) -> list[str]:
+    """return tags for repo as a list
+
+    Calls skopeo list-tags
+    """
+    out = subprocess.check_output(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "quay.io/skopeo/stable",
+            "list-tags",
+            f"docker://{repo}",
+        ],
+        text=True,
+    )
+    return json.loads(out)["Tags"]
+
+
+likely_version_pat = re.compile(r"v?\d", re.IGNORECASE)
+
+
+def version_key(tag: str) -> Version:
+    """never-fails sort-key for sorting version tags
+
+    Uses packaging.version to parse version strings.
+
+    re-normalizes build string suffixes that may have been
+    manged to be valid docker tags.
+
+    Ignores any tag that doesn't start `[v]N`, e.g. 'latest'.
+    """
+    if not likely_version_pat.match(tag):
+        # ignore branch names, etc.
+        return Version("0.0")
+
+    try:
+        # first, try as-is
+        return Version(tag)
+    except InvalidVersion:
+        # reverse the +/- substitution for the build tag
+        # because `+` is not legal in docker tags
+        try:
+            return Version(tag.replace("-", "+"))
+        except InvalidVersion:
+            print(f"Ignoring invalid version: {tag}", file=sys.stderr)
+            return Version("0.0")
+
+
+def main(repo: str):
+    tags = get_tags(repo)
+    sorted_tags = sorted(tags, key=version_key)
+    # send full sorted list to stderr
+    for tag in sorted_tags:
+        print(f"  {tag}", file=sys.stderr)
+
+    # send only latest tag to stdout for piping purposes
+    print(sorted_tags[-1])
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])


### PR DESCRIPTION
dev version suffix changed

we should really be using version parsing

closes #3595