### PR TITLE
increase bids quota to 60

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -33,7 +33,7 @@ binderhub:
         - '--DockerEngine.extra_init_args={"timeout":1200}'
 
     LaunchQuota:
-      total_quota: 30
+      total_quota: 60
 
   replicas: 2
 


### PR DESCRIPTION
federation-redirect headroom means members only get assigned pods up to 10 below this (to leave room for about-to-launch pods), so 30 is 20, 60 is 50, etc. Makes a bigger difference for small quotas.