### PR TITLE
Use syslog tag `podlogs` instead of `podlog`

### DIFF
--- a/mybinder/templates/pod-logs/configmap.yaml
+++ b/mybinder/templates/pod-logs/configmap.yaml
@@ -36,7 +36,7 @@ data:
       type="imfile"
       # pods/podname/containername/0.txt
       file="/var/log/pods/*/*/*.log"
-      tag="podlog"
+      tag="podlogs"
     )
 
     ### Outputs


### PR DESCRIPTION
Discussed in Zulip, `podlogs` feels more intuitive than `podlog`