### PR TITLE
watch-dependencies: exit on subshell error

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -19,6 +19,11 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+defaults:
+  run:
+    # Propagate errors in subshells and pipes to the parent shell
+    shell: bash -e -E -o pipefail {0}
+
 jobs:
   update-image-dependencies:
     name: update ${{ matrix.name }} image


### PR DESCRIPTION
If a subshell fails this should cause the workflow to fail, instead of the subshell returning null, causing incorrect PRs like https://github.com/jupyterhub/mybinder.org-deploy/pull/3656