### PR TITLE
Test K8s 1.33

### DIFF
--- a/.github/workflows/test-helm-template.yaml
+++ b/.github/workflows/test-helm-template.yaml
@@ -36,11 +36,11 @@ jobs:
           #        idea on how to get that version dynamically.
           #
           - release: staging
-            k3s-channel: "v1.24"
+            k3s-channel: "v1.33"
           - release: prod
-            k3s-channel: "v1.24"
+            k3s-channel: "v1.33"
           - release: hetzner-2i2c
-            k3s-channel: "v1.24"
+            k3s-channel: "v1.33"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
action-k3s-helm is failing with K8S 1.24 in our CI.

Our clusters are more modern than that 😄 