### PR TITLE
fix jsonl index for analytics archive

### DIFF
--- a/images/analytics-publisher/indexer.py
+++ b/images/analytics-publisher/indexer.py
@@ -50,8 +50,7 @@ def index_events(project, bucket, debug=False, dry_run=False):
     if debug:
         print(html_index)
 
-    for archive in archives:
-        jsonl_index = json.dumps(archive) + "\n"
+    jsonl_index = "\n".join(json.dumps(archive) for archive in archives)
 
     if not dry_run:
         html_blob = bucket.blob("index.html")


### PR DESCRIPTION
was only one line long because it kept reassigning from the last day instead of appending

lost a bit in the refactor in #3462