### PR TITLE
update build-cache-prune image, reduce bids-ovh build cache size

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -77,6 +77,9 @@ binderhub:
     # handled by buildkit pruner
     enabled: false
 
+buildkitPruner:
+  buildkitCacheSize: 200GB
+
 grafana:
   ingress:
     hosts:

--- a/mybinder/templates/buildkit-pruner.yaml
+++ b/mybinder/templates/buildkit-pruner.yaml
@@ -27,7 +27,7 @@ spec:
             - -c
             - |
               docker image prune --force --all --filter until={{ .Values.buildkitPruner.olderThanMinutes }}m && \
-              docker builder prune --force --all --keep-storage={{ .Values.buildkitPruner.buildkitCacheSize }} && \
+              docker builder prune --force --all --max-storage={{ .Values.buildkitPruner.buildkitCacheSize }} && \
               docker system df
             volumeMounts:
             - name: dind-socket

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -52,7 +52,7 @@ k8s-log-alerter-zulip:
 buildkitPruner:
   enabled: true
   # Use the same image as we use for dind
-  image: docker:27.5.1-dind
+  image: docker:28.3.3-dind
   buildkitCacheSize: 300GB
   # Only prune images older than
   olderThanMinutes: 120


### PR DESCRIPTION
bids-ovh has a 500G disk for dind, while hetzner has 700. Reduce the size allocated to build cache from 300 to 200.

Also updates image to match dind (28.3.3), and updates according to the deprecation message we've been getting:

```
Flag --keep-storage has been deprecated, keep-storage flag has been changed to max-storage
```