### PR TITLE
buildkit-pruner: now it's max-used-space

### DIFF
--- a/mybinder/templates/buildkit-pruner.yaml
+++ b/mybinder/templates/buildkit-pruner.yaml
@@ -27,7 +27,7 @@ spec:
             - -c
             - |
               docker image prune --force --all --filter until={{ .Values.buildkitPruner.olderThanMinutes }}m && \
-              docker builder prune --force --all --max-storage={{ .Values.buildkitPruner.buildkitCacheSize }} && \
+              docker builder prune --force --all --max-used-space={{ .Values.buildkitPruner.buildkitCacheSize }} && \
               docker system df
             volumeMounts:
             - name: dind-socket


### PR DESCRIPTION
#3768 didn't quite work

naturally, while docker 27 deprecated `--keep-storage` in favor of `--max-storage`, leading to:

> Flag --keep-storage has been deprecated, keep-storage flag has been changed to max-storage

in docker 28, they removed `--max-storage` _without_ deprecation, now with:

```
      --max-used-space bytes   Maximum amount of disk space allowed to keep for cache
      --min-free-space bytes   Target amount of free disk space after pruning
      --reserved-space bytes   Amount of disk space always allowed to keep for cache
```

we can use these to perhaps have more control, but just update the upper-limit flag name for now