### PR TITLE
Reduce retention of Prometheus data on staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -110,7 +110,7 @@ prometheus:
     persistentVolume:
       size: 12G
     # reduce retention for staging
-    retention: 30d
+    retention: 15d
 
 ingress-nginx:
   controller:


### PR DESCRIPTION
https://github.com/jupyterhub/mybinder.org-deploy/issues/3775 looks a re-occurrence of https://github.com/jupyterhub/mybinder.org-deploy/issues/3266.

Based on https://github.com/jupyterhub/mybinder.org-deploy/pull/3273, this pull request reduces the data retention period in half. For the staging server, 2 weeks should be enough.

I will go ahead and merge this.