### PR TITLE
harbor: increase quotas to 15TB

### DIFF
--- a/terraform/hetzner/variables.tf
+++ b/terraform/hetzner/variables.tf
@@ -15,7 +15,7 @@ variable "name" {
 
 variable "registry_quota_gb" {
   type        = number
-  default     = 10000
+  default     = 15000
   description = <<-EOT
   harbor registry project quota size in gigabytes
   EOT

--- a/terraform/ovh/bids-ovh.tfvars
+++ b/terraform/ovh/bids-ovh.tfvars
@@ -8,6 +8,7 @@ zone         = "US-EAST-VA-1"
 name = "bids-ovh"
 
 registry_users = ["bids-ovh", "gesis-harbor"]
+registry_quota_gb = 15000
 
 push_mirrors = {
   hetzner_2i2c = {


### PR DESCRIPTION
baseline requirements increased with full circular mirroring

@rgaiacs is this okay? It is also an option to reduce retention.

I think we are _likely_ to pass 10TB. I don't think by _much_, but if we keep a 10T ceiling, we would need to watch carefully.

We are currently at around 1.4T new builds per week and half that deleted due to retention. I expect it to stabilize around 10-12 with current patterns