### PR TITLE
federation-redirect: trade rendezvous for random

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -791,7 +791,7 @@ federationRedirect:
     retries: 5
     timeout: 5
     failed_period: 90
-  load_balancer: "rendezvous"
+  load_balancer: "random"
   pod_headroom: 10
   hosts: {}
   nodeSelector: {}


### PR DESCRIPTION
this will spread launches evenly across the federation instead of packing launches of one repo onto one node

this will have some downside for local (on-node) image cache hits, but with the new registry replication, the cost of that is much lower because it will be an in-datacenter pull rather than a fresh build.

We _will_ likely still get redundant builds when an image is built and launched a second time before replication completes, because I don't think the image shows up as pullable until replication has _finished_ which appears to typically take about one minute. This is something to keep an eye on. Because pull activity is not synchronized, retention will also not be identical, so it's possible for an older less popular image to fall out of use on one node when it's been recently pulled on another. The random routing should make this much _better_ than rendezvous for images launched at least ~5 times/month.
