### PR TITLE
Revert "federation-redirect: trade rendezvous for random"

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -791,7 +791,7 @@ federationRedirect:
     retries: 5
     timeout: 5
     failed_period: 90
-  load_balancer: "random"
+  load_balancer: "rendezvous"
   pod_headroom: 10
   hosts: {}
   nodeSelector: {}


### PR DESCRIPTION
Reverts jupyterhub/mybinder.org-deploy#3784

seems to be a problem in the redirector when random is used