### PR TITLE
Include BINDER_REF_URL BINDER_CLIENT_IP in cryptnono logs

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -10,11 +10,17 @@ cryptnono:
         FlowKiller:
           banned_ipv4_file_globs:
             - "/ban-config/*.txt"
+          log_container_envs:
+            - BINDER_CLIENT_IP
+            - BINDER_REF_URL
       containerdHostPath: /run/k3s/containerd/containerd.sock
       dockerHostPath: /run/dind/docker.sock
     execwhacker:
       containerdHostPath: /run/k3s/containerd/containerd.sock
       dockerHostPath: /run/dind/docker.sock
+      lookupEnvs:
+        - BINDER_CLIENT_IP
+        - BINDER_REF_URL
   metrics:
     enabled: true
     collector:


### PR DESCRIPTION
Log selected env vars from
https://github.com/jupyterhub/binderhub/blob/9695125979fd3e22e91ff1b42ba8799178369829/binderhub/binderspawner_mixin.py#L109-L113