### PR TITLE
set buildkit cache size for staging

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -73,6 +73,9 @@ binderhub:
             memory: 100M
             cpu: 10m
 
+buildkitPruner:
+  buildkitCacheSize: 25GB
+
 minesweeper:
   resources:
     requests:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -76,7 +76,7 @@ def test_build_binder(binder_url):
                 if data.get("message"):
                     sys.stdout.write(data["message"])
                 if data.get("phase") == "ready":
-                    notebook_url = data["url"]
+                    notebook_url = data["url"].rstrip("/")
                     token = data["token"]
                     break
         else:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -20,7 +20,7 @@ def test_launch_binder(binder_url):
         if line.startswith("data:"):
             data = json.loads(line.split(":", 1)[1])
             if data.get("phase") == "ready":
-                notebook_url = data["url"]
+                notebook_url = data["url"].rstrip("/")
                 token = data["token"]
                 break
     else:


### PR DESCRIPTION
staging dind mount is 50G, so it's not getting pruned with the default 300G

I think this might fix the disk full on staging [here](https://github.com/jupyterhub/mybinder.org-deploy/pull/3804#issuecomment-4471008093). Latest cache-prune job:

current du:

```
/dev/sdb1        50G   50G  385M 100% /mnt/disk
```

but latest cache-prune job isn't pruning:

```
> kubectl logs build-cache-prune-29650720-7jhfh
Total reclaimed space: 0B
Total:	0B
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          0         0         0B        0B
Containers      0         0         0B        0B
Local Volumes   0         0         0B        0B
Build Cache     712       0         38.6GB    38.6GB
```

(not sure why 38.6G is taking up 49.6G, but 🤷 )


cc @manics 