### PR TITLE
add cluster-entrypoint service

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -1,5 +1,8 @@
 projectName: bids-ovh
 
+clusterEntryPoint:
+  enabled: false
+
 harbor:
   enabled: true
   expose:

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -1,5 +1,8 @@
 projectName: hetzner-2i2c
 
+clusterEntryPoint:
+  enabled: false
+
 harbor:
   enabled: true
   expose:

--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -1,5 +1,8 @@
 projectName: hetzner-gesis
 
+clusterEntryPoint:
+  enabled: false
+
 binderhub:
   config:
     BinderHub:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,7 +1,5 @@
 projectName: staging
 
-# binderhubEnabled: false
-
 binderhub:
   config:
     BinderHub:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -118,8 +118,8 @@ prometheus:
 ingress-nginx:
   controller:
     replicaCount: 2
-    # service:
-    #   loadBalancerIP: 35.222.35.25
+    service:
+      type: ClusterIP
     resources:
       requests:
         cpu: 10m

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -120,6 +120,7 @@ ingress-nginx:
     replicaCount: 2
     service:
       type: ClusterIP
+      externalTrafficPolicy:
     resources:
       requests:
         cpu: 10m

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.clusterEntryPoint.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-entrypoint
+  annotations:
+    {{- with .Values.clusterEntryPoint.annotations }}
+    {{ . | toYaml | nindent 4 }}
+    {{- end }}
+  labels:
+    app: cluster-entrypoint
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  - port: 443
+    targetPort: 443
+  selector:
+    {{- if .Values.clusterEntryPoint.target }}
+    {{- if .Values.clusterEntryPoint.target == 'ingress-nginx' }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: ingress-nginx
+    {{- else }}
+    {{ fail "clusterEntryPoint.target must be 'ingress-nginx' or null" }}
+    {{- end }}
+    {{- else }}
+    {{ .Values.clusterEntryPoint.selector | toYaml | nindent 4 }}
+    {{- end }}
+  externalTrafficPolicy: Local
+{{- end }}

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -12,11 +12,14 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  externalTrafficPolicy: Local
   ports:
   - port: 80
     targetPort: 80
+    name: http
   - port: 443
     targetPort: 443
+    name: https
   selector:
     {{- if .Values.clusterEntryPoint.target }}
     {{- if eq .Values.clusterEntryPoint.target "ingress-nginx" }}
@@ -29,5 +32,5 @@ spec:
     {{- else }}
     {{ .Values.clusterEntryPoint.selector | toYaml | nindent 4 }}
     {{- end }}
-  externalTrafficPolicy: Local
+  type: LoadBalancer
 {{- end }}

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.clusterEntryPoint.enabled }}
+{{- if .Values.clusterEntrypoint.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: cluster-entrypoint
   annotations:
-    {{- with .Values.clusterEntryPoint.annotations }}
+    {{- with .Values.clusterEntrypoint.annotations }}
     {{ . | toYaml | nindent 4 }}
     {{- end }}
   labels:
@@ -21,16 +21,16 @@ spec:
     targetPort: 443
     name: https
   selector:
-    {{- if .Values.clusterEntryPoint.target }}
-    {{- if eq .Values.clusterEntryPoint.target "ingress-nginx" }}
+    {{- if .Values.clusterEntrypoint.target }}
+    {{- if eq .Values.clusterEntrypoint.target "ingress-nginx" }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: ingress-nginx
     {{- else }}
-    {{ fail "clusterEntryPoint.target must be 'ingress-nginx' or null" }}
+    {{ fail "clusterEntrypoint.target must be 'ingress-nginx' or null" }}
     {{- end }}
     {{- else }}
-    {{ .Values.clusterEntryPoint.selector | toYaml | nindent 4 }}
+    {{ .Values.clusterEntrypoint.selector | toYaml | nindent 4 }}
     {{- end }}
   type: LoadBalancer
 {{- end }}

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -19,7 +19,7 @@ spec:
     targetPort: 443
   selector:
     {{- if .Values.clusterEntryPoint.target }}
-    {{- if eq .Values.clusterEntryPoint.target 'ingress-nginx' }}
+    {{- if eq .Values.clusterEntryPoint.target "ingress-nginx" }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: ingress-nginx

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -19,7 +19,7 @@ spec:
     targetPort: 443
   selector:
     {{- if .Values.clusterEntryPoint.target }}
-    {{- if .Values.clusterEntryPoint.target == 'ingress-nginx' }}
+    {{- if eq .Values.clusterEntryPoint.target 'ingress-nginx' }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: ingress-nginx

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,3 +1,12 @@
+clusterEntryPoint:
+  enabled: true
+  annotations: {}
+  # specify target by name (known label combinations in template)
+  # only ingress-nginx or null for now
+  target: ingress-nginx
+  # allow specifying raw selector (if target is null)
+  selector:
+
 cryptnono:
   enabled: true
   detectors:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -1,4 +1,4 @@
-clusterEntryPoint:
+clusterEntrypoint:
   enabled: true
   annotations: {}
   # specify target by name (known label combinations in template)


### PR DESCRIPTION
preparation for shifting away from ingress-nginx

first step of #3811 

adapted from https://github.com/2i2c-org/infrastructure/pull/7728 (adds annotations required for stable IP on gcloud)

I don't actually know how this is going to work on k3s, we haven't had multiple LoadBalancer services on k3s nodes yet, and I think you can't have multiple load balancers on one port on one host. I think we'll have to switch over in one go, which is more disruptive than I would want it to be.