### PR TITLE
prod: make sure clusterEntrypoint sticks with new static ip

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,6 +7,12 @@ coreNodeSelector: &coreNodeSelector
 
 binderhubEnabled: false
 
+clusterEntrypoint:
+  annotations:
+    # preserve ip if service gets recreated
+    cloud.google.com/l4-rbs: "enabled"
+    networking.gke.io/load-balancer-ip-addresses: "cluster-entrypoint"
+
 cryptnono:
   enabled: false
 


### PR DESCRIPTION
part of #3639 

any recreation of the clusterEntrypoint Service will keep the same static IP. This is the current IP for `mybinder.org`