### PR TITLE
enable clusterEntrypoint on all remaining clusters

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -1,8 +1,5 @@
 projectName: hetzner-2i2c
 
-clusterEntryPoint:
-  enabled: false
-
 harbor:
   enabled: true
   expose:
@@ -142,8 +139,6 @@ ingress-nginx:
     replicas: 1
     scope:
       enabled: true
-    service:
-      loadBalancerIP: 116.203.245.43
 
 static:
   ingress:

--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -1,8 +1,5 @@
 projectName: hetzner-gesis
 
-clusterEntryPoint:
-  enabled: false
-
 binderhub:
   config:
     BinderHub:
@@ -133,8 +130,6 @@ ingress-nginx:
     replicas: 1
     scope:
       enabled: true
-    service:
-      loadBalancerIP: 116.203.245.43
 
 static:
   ingress:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -140,11 +140,6 @@ prometheus:
             - prometheus.gke2.mybinder.org
           secretName: kubelego-tls-prometheus
 
-ingress-nginx:
-  controller:
-    service:
-      loadBalancerIP: 35.239.125.45
-
 static:
   ingress:
     hosts:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -116,9 +116,6 @@ prometheus:
 ingress-nginx:
   controller:
     replicaCount: 2
-    service:
-      type: ClusterIP
-      externalTrafficPolicy:
     resources:
       requests:
         cpu: 10m

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -654,8 +654,8 @@ ingress-nginx:
           prometheus.io/scrape: "true"
           prometheus.io/port: "10254"
     service:
-      # Preserve client IPs
-      externalTrafficPolicy: Local
+      # clusterEntrypoint is the public Service
+      type: ClusterIP
 
 redirector:
   enabled: false


### PR DESCRIPTION
no hiccups on 2 other k3s clusters or GKE

this moves the config to default instead of copied on every cluster, and removes public ingress-nginx Service leaving clusterEntrypoint as the only public LoadBalancer Service.

Will wait to merge this one until tomorrow, to make sure mybinder.org DNS has had a chance to propagate everywhere (it should have already done so by now, but who knows with DNS).

Next step: add traefik ingress controller, also without LoadBalancer Service

part of #3639