### PR TITLE
add traefik ingress controller

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -152,6 +152,13 @@ jobs:
             chart_dep_devel_flag: ""
             github_repo: ""
 
+          - chart_dep_name: traefik
+            chart_dep_chart_changelog_url: "https://github.com/traefik/traefik-helm-chart/blob/HEAD/traefik/Changelog.md"
+            chart_dep_app_changelog_url: "https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md"
+            chart_dep_source_url: "https://github.com/traefik/traefik-helm-chart"
+            chart_dep_devel_flag: ""
+            github_repo: "traefik/traefik-helm-chart"
+
           - chart_dep_name: prometheus
             chart_dep_chart_changelog_url: "https://github.com/prometheus-community/helm-charts/tree/HEAD/charts/prometheus#upgrading-chart"
             chart_dep_app_changelog_url: "https://github.com/prometheus/prometheus/blob/HEAD/CHANGELOG.md"

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -203,7 +203,13 @@ jobs:
           echo "version=$local_version" >> $GITHUB_OUTPUT
 
           chart_dep_repo=$(cat mybinder/Chart.yaml | yq e '.dependencies[] | select(.name == "${{ matrix.chart_dep_name }}") | .repository' -)
-          local_app_version=$(helm show chart --version=$local_version --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.appVersion' -)
+          if [[ "$chart_dep_repo" = oci:* ]]; then
+            chart_dep="${chart_dep_repo}/${{ matrix.chart_dep_name }}"
+          else
+            chart_dep="--repo=${chart_dep_repo} ${{ matrix.chart_dep_name }}"
+          fi
+
+          local_app_version=$(helm show chart --version=$local_version $chart_dep | yq e '.appVersion' -)
           echo "appVersion=$local_app_version" >> $GITHUB_OUTPUT
 
       - name: Fetch latest version/appVersion of ${{ matrix.chart_dep_name }} chart
@@ -213,9 +219,13 @@ jobs:
         # optionally passing `--devel` to get pre-releases as well.
         #
         run: |
-          chart_dep_repo=$(cat mybinder/Chart.yaml | yq e '.dependencies[] | select(.name == "${{ matrix.chart_dep_name }}") | .repository' -)
+          if [[ "$chart_dep_repo" = oci:* ]]; then
+            chart_dep="${chart_dep_repo}/${{ matrix.chart_dep_name }}"
+          else
+            chart_dep="--repo=${chart_dep_repo} ${{ matrix.chart_dep_name }}"
+          fi
 
-          latest_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.version' -)
+          latest_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} $chart_dep | yq e '.version' -)
           echo "version=$latest_version" >> $GITHUB_OUTPUT
 
           latest_app_version=$(helm show chart ${{ matrix.chart_dep_devel_flag }} --repo=$chart_dep_repo ${{ matrix.chart_dep_name }} | yq e '.appVersion' -)

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -124,6 +124,20 @@ ingress-nginx:
         cpu: 500m
         memory: 500Mi
 
+clusterEntrypoint:
+  target: traefik
+
+traefikEnabled: true
+
+traefik:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
+
 static:
   ingress:
     hosts:

--- a/mybinder/Chart.yaml
+++ b/mybinder/Chart.yaml
@@ -21,6 +21,14 @@ dependencies:
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
 
+  # traefik ingress controller
+  # Source: https://github.com/traefik/traefik-helm-chart
+  # Changelog: https://github.com/traefik/traefik-helm-chart/blob/HEAD/traefik/Changelog.md
+  - name: traefik
+    version: "40.2.0"
+    repository: oci://ghcr.io/traefik/helm
+    condition: traefikEnabled
+
   # Prometheus for collection of metrics.
   # Source code:   https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
   # App changelog: https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md

--- a/mybinder/templates/cluster-entrypoint/service.yaml
+++ b/mybinder/templates/cluster-entrypoint/service.yaml
@@ -26,6 +26,9 @@ spec:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: ingress-nginx
+    {{- else if eq .Values.clusterEntrypoint.target "traefik" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-{{ .Release.Namespace }}
+    app.kubernetes.io/name: traefik
     {{- else }}
     {{ fail "clusterEntrypoint.target must be 'ingress-nginx' or null" }}
     {{- end }}

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -657,6 +657,51 @@ ingress-nginx:
       # clusterEntrypoint is the public Service
       type: ClusterIP
 
+# values ref: https://github.com/traefik/traefik-helm-chart/blob/HEAD/traefik/VALUES.md
+traefikEnabled: false
+traefik:
+  api:
+    dashboard: false
+  deployment:
+    replicas: 2
+  logs:
+    access:
+      enabled: true
+      format: json
+      fields:
+        headers:
+          defaultMode: drop
+          names:
+            User-Agent: keep
+    general:
+      # TODO: remove when things are stable
+      level: DEBUG
+  ports:
+    web:
+      port: 80
+    websecure:
+      port: 443
+  priorityClassName: binderhub-core
+  providers:
+    kubernetesCRD:
+      enabled: false
+    kubernetesIngress:
+      enabled: true
+    kubernetesIngressNGINX:
+      # pick up nginx ingresses automatically
+      # so we can migrate incrementally
+      enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 2
+      memory: 4Gi
+  service:
+    # use clusterEntrypoint instead
+    enabled: false
+
 redirector:
   enabled: false
   nodeSelector: {}


### PR DESCRIPTION
enable kubernetesIngressNGINX to take over nginx ingresses without modification

not enabled by default yet, only on 

steps:

1. deploy traefik (gets no traffic)
2. point clusterEntrypoint at traefik
3. shutdown ingress-nginx
4. migrate ingresses to `kubernetesIngress` away from `kubernetesIngressNGINX` (no pressure, I think, plus there's very little)

rough plan: test traefik on staging; once happy, enable it on one federation member and see how it goes for a while, then switch the rest over

part of #3639