### PR TITLE
deploy traefik everywhere, enable only on bids-ovh

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -127,15 +127,14 @@ prometheus:
         - targets:
             - bids-ovh-harbor-jobservice:8001
 
+clusterEntrypoint:
+  target: traefik
+
 ingress-nginx:
   controller:
     replicas: 1
     scope:
       enabled: true
-    service:
-      # clusterEntrypoint is the only LoadBalancer Service
-      type: ClusterIP
-      externalTrafficPolicy:
 
 static:
   ingress:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -658,7 +658,7 @@ ingress-nginx:
       type: ClusterIP
 
 # values ref: https://github.com/traefik/traefik-helm-chart/blob/HEAD/traefik/VALUES.md
-traefikEnabled: false
+traefikEnabled: true
 traefik:
   api:
     dashboard: false


### PR DESCRIPTION
with this PR, every deployment will have two ingress controllers, one getting traffic and one idle. Only staging and bids-ovh will be using the new traefik ingress controller, while everyone else will still be in ingress-nginx

part of #3639