### PR TITLE
back to nginx for now

### DIFF
--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,5 +1,8 @@
 projectName: staging
 
+clusterEntrypoint:
+  target: traefik
+
 binderhub:
   config:
     BinderHub:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -2,8 +2,8 @@ clusterEntrypoint:
   enabled: true
   annotations: {}
   # specify target by name (known label combinations in template)
-  # only ingress-nginx or null for now
-  target: traefik
+  # only ingress-nginx or traefik for now
+  target: ingress-nginx
   # allow specifying raw selector (if target is null)
   selector:
 
@@ -672,14 +672,14 @@ traefik:
     access:
       enabled: true
       # use json for most detailed access logs
-      # format: json
+      format: json
       fields:
         headers:
           defaultMode: drop
           names:
             User-Agent: keep
     general:
-      level: INFO
+      level: DEBUG
   ports:
     web:
       port: 80


### PR DESCRIPTION
traefik is preventing builds pushing to harbor

hairpin connections aren't working (testable in a notebook on staging)

not discovered on staging because staging doesn't host its own harbor, it uses bids. Testable on staging with `requests.get("https://staging.mybinder.org")` which gets connection refused.

re-enable debug logging

part of #3639
