### PR TITLE
back to traefik on prod

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -8,7 +8,6 @@ coreNodeSelector: &coreNodeSelector
 binderhubEnabled: false
 
 clusterEntrypoint:
-  target: ingress-nginx
   annotations:
     # preserve ip if service gets recreated
     cloud.google.com/l4-rbs: "enabled"


### PR DESCRIPTION
ancient kubelego secrets with empty (but defined!) ca.crt caused traefik to choke.

traefik logs had errors like:

```
prod-traefik-6b6c6cf66c-b4mn9 prod-traefik 2026-05-21T15:20:25Z WRN Error loading TLS certificates, defaulting to default certificate error="getting certificate blocks: secret contains an empty CA certificate" ingress=redirector namespace=prod providerName=kubernetesingressnginx
```

TLS secrets contained:

```yaml
data:
  ca.crt: ""
```

likely a leftover of some really old version. tls secrets on newer clusters don't have this field at all. traefik errors out on this as invalid rather than falsy. Manually deleting the empty `ca.crt` field in the kubelego secrets fixed them.