### PR TITLE
turn off ingress-nginx

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -604,7 +604,7 @@ binderhub:
 
 # values ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
 ingress-nginx:
-  enabled: true
+  enabled: false
   rbac:
     create: true
   defaultBackend:


### PR DESCRIPTION
it's not serving any traffic, this just stops the idle pods and removes the resources

don't remove it yet so we can turn it back on without too much difficulty

part of #3639