### PR TITLE
only deploy buildKitPruner if binderhub is enabled

### DIFF
--- a/mybinder/templates/buildkit-pruner.yaml
+++ b/mybinder/templates/buildkit-pruner.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.buildkitPruner.enabled }}
+{{ if and .Values.binderhubEnabled .Values.buildkitPruner.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:


### PR DESCRIPTION
avoids extra config to disable multiple related things (e.g. on prod where binderhub is disabled)

only change will be that prod will stop running a failing buildkit pruner