### PR TITLE
everything on regular traefik ingress except the key ones: hub, binderhub, harbor

### DIFF
--- a/mybinder/templates/federation-redirect/ingress.yaml
+++ b/mybinder/templates/federation-redirect/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
 spec:
   rules:

--- a/mybinder/templates/gcs-proxy/ingress.yaml
+++ b/mybinder/templates/gcs-proxy/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
 spec:
   rules:

--- a/mybinder/templates/matomo/ingress.yaml
+++ b/mybinder/templates/matomo/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
 spec:
   rules:

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -83,6 +83,7 @@ harbor:
     type: ingress
     ingress:
       annotations:
+        kubernetes.io/ingress.class: nginx
         kubernetes.io/tls-acme: "true"
         traefik.ingress.kubernetes.io/router.middlewares: "harbor@file"
     tls:
@@ -735,7 +736,7 @@ redirector:
   redirects: []
   ingress:
     annotations:
-      kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: traefik
       kubernetes.io/tls-acme: "true"
     tls:
       secretName: kubelego-tls-redirector


### PR DESCRIPTION
adds to traefik provider:

- federation-redirect (mybinder.org)
- gcs-proxy (archive.analytics)
- redirector (docs.mybinder.org)
- matomo (not used, should probably be removed)

part of #3639