### PR TITLE
point cluster-issuer at traefik

### DIFF
--- a/mybinder/templates/cluster-issuer.yaml
+++ b/mybinder/templates/cluster-issuer.yaml
@@ -13,7 +13,7 @@ spec:
     solvers:
       - http01:
           ingress:
-            class: nginx
+            class: traefik
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -28,5 +28,5 @@ spec:
     solvers:
       - http01:
           ingress:
-            class: nginx
+            class: traefik
 {{- end }}


### PR DESCRIPTION
make sure new provider is used for certificate requests.

should make sure to test cluster issuing one more time after turning off nginx compatibility layer. I think I've verified it works, but good to be 100% sure.