### PR TITLE
set sendTimeout on nginx provider

### DIFF
--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -719,6 +719,8 @@ traefik:
       # pick up nginx ingresses automatically
       # so we can migrate incrementally
       enabled: true
+      proxyReadTimeout: 600
+      proxySendTimeout: 600
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
default overrides entrypoint timeouts apparently

finishing the switch to traefik would probably also fix this.

cc @yuvipanda