### PR TITLE
finish moving to traefik kubernetesIngress provider from kuberntesIngresNGINX

### DIFF
--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -4,15 +4,6 @@ harbor:
   enabled: true
   expose:
     ingress:
-      annotations:
-        # increase a bunch of timeouts to avoid connections being dropped for large uploads
-        nginx.ingress.kubernetes.io/client-body-timeout: "600"
-        nginx.ingress.kubernetes.io/client-header-timeout: "600"
-        nginx.ingress.kubernetes.io/keep-alive: "600"
-        nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-        nginx.ingress.kubernetes.io/upstream-keepalive-timeout: "600"
       hosts:
         core: oci.2i2c.mybinder.org
   persistence:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -144,6 +144,7 @@ static:
     hosts:
       - static.staging.mybinder.org
       - static.ovh.staging.mybinder.org
+      - static22.staging.mybinder.org
 
 redirector:
   enabled: true

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -144,7 +144,6 @@ static:
     hosts:
       - static.staging.mybinder.org
       - static.ovh.staging.mybinder.org
-      - static22.staging.mybinder.org
 
 redirector:
   enabled: true

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -709,12 +709,6 @@ traefik:
       enabled: false
     kubernetesIngress:
       enabled: true
-    kubernetesIngressNGINX:
-      # pick up nginx ingresses automatically
-      # so we can migrate incrementally
-      enabled: false
-      proxyReadTimeout: 600
-      proxySendTimeout: 600
   resources:
     requests:
       cpu: 100m

--- a/mybinder/values.yaml
+++ b/mybinder/values.yaml
@@ -83,7 +83,7 @@ harbor:
     type: ingress
     ingress:
       annotations:
-        kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: traefik
         kubernetes.io/tls-acme: "true"
         traefik.ingress.kubernetes.io/router.middlewares: "harbor@file"
     tls:
@@ -433,7 +433,7 @@ binderhub:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: traefik
     https:
       enabled: true
       type: kube-lego
@@ -539,14 +539,8 @@ binderhub:
     ingress:
       enabled: true
       annotations:
-        # traefik (not used yet)
         traefik.ingress.kubernetes.io/router.middlewares: "hub@file"
-        # FIXME: ingress-nginx (on its way out)
-        ingress.kubernetes.io/proxy-body-size: 64m
-        # Increase for websockets (default is 60s)
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-        kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: traefik
         kubernetes.io/tls-acme: "true"
     scheduling:
       userScheduler:
@@ -718,7 +712,7 @@ traefik:
     kubernetesIngressNGINX:
       # pick up nginx ingresses automatically
       # so we can migrate incrementally
-      enabled: true
+      enabled: false
       proxyReadTimeout: 600
       proxySendTimeout: 600
   resources:


### PR DESCRIPTION
this finishes the move from traefik supporting nginx config annotations to traefik-native config

will test on staging first, specifically:

- request timeout, that uploads can take more than a minute
- cert-manager certificates by adding a domain to static.staging

part of #3639