### PR TITLE
Fix failures in watch-dependencies

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -157,7 +157,7 @@ jobs:
             chart_dep_app_changelog_url: "https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md"
             chart_dep_source_url: "https://github.com/traefik/traefik-helm-chart"
             chart_dep_devel_flag: ""
-            github_repo: "traefik/traefik-helm-chart"
+            github_repo: ""
 
           - chart_dep_name: prometheus
             chart_dep_chart_changelog_url: "https://github.com/prometheus-community/helm-charts/tree/HEAD/charts/prometheus#upgrading-chart"

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -145,13 +145,6 @@ jobs:
             chart_dep_devel_flag: "--devel"
             github_repo: jupyterhub/binderhub
 
-          - chart_dep_name: ingress-nginx
-            chart_dep_chart_changelog_url: "https://github.com/kubernetes/ingress-nginx/tree/HEAD/charts/ingress-nginx#upgrading-chart"
-            chart_dep_app_changelog_url: "https://github.com/kubernetes/ingress-nginx/blob/HEAD/Changelog.md"
-            chart_dep_source_url: "https://github.com/kubernetes/ingress-nginx/tree/HEAD/charts/ingress-nginx"
-            chart_dep_devel_flag: ""
-            github_repo: ""
-
           - chart_dep_name: traefik
             chart_dep_chart_changelog_url: "https://github.com/traefik/traefik-helm-chart/blob/HEAD/traefik/Changelog.md"
             chart_dep_app_changelog_url: "https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md"


### PR DESCRIPTION
traefik: The git tags have a `v` prefix but the helm chart versions don't, resulting in failure of the get-prs.py script. We only really care about PRs for jupyterhub related repos since we're installing dev versions

ingress-nginx: remove from watch-dependencies since it's been removed from Chart.yaml

E.g.
https://github.com/jupyterhub/mybinder.org-deploy/actions/runs/29227792271/job/86745461521
```
Comparing 40.2.0...41.0.2
Traceback (most recent call last):
  File "/home/runner/work/mybinder.org-deploy/mybinder.org-deploy/./scripts/get-prs.py", line 56, in <module>
    git_compare = r.compare(start, end)
...
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/commits/commits#compare-two-commits", "status": "404"}
```
https://github.com/jupyterhub/mybinder.org-deploy/actions/runs/29227792271/job/86745461541
