### PR TITLE
Set public_url

### DIFF
--- a/config/bids-ovh.yaml
+++ b/config/bids-ovh.yaml
@@ -65,6 +65,10 @@ binderhub:
     #         cpu: "1"
     #       limits:
     #         cpu: "1"
+    hub:
+      config:
+        JupyterHub:
+          public_url: https://hub.bids.mybinder.org/
     ingress:
       hosts:
         - hub.bids.mybinder.org

--- a/config/hetzner-2i2c.yaml
+++ b/config/hetzner-2i2c.yaml
@@ -66,6 +66,10 @@ binderhub:
     #         cpu: "1"
     #       limits:
     #         cpu: "1"
+    hub:
+      config:
+        JupyterHub:
+          public_url: https://hub.2i2c.mybinder.org/
     ingress:
       hosts:
         - hub.2i2c.mybinder.org

--- a/config/hetzner-gesis.yaml
+++ b/config/hetzner-gesis.yaml
@@ -47,6 +47,10 @@ binderhub:
     #         cpu: "1"
     #       limits:
     #         cpu: "1"
+    hub:
+      config:
+        JupyterHub:
+          public_url: https://hub.gesis.mybinder.org/
     ingress:
       hosts:
         - hub.gesis.mybinder.org

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -49,6 +49,7 @@ binderhub:
       config:
         JupyterHub:
           active_server_limit: 10
+          public_url: https://hub.staging.mybinder.org/
     singleuser:
       memory:
         guarantee: 400M


### PR DESCRIPTION
This should set JUPYTERHUB_PUBLIC_URL and JUPYTERHUB_PUBLIC_HUB_URL in user servers so they know which mybinder member they're on and can construct an absolute URL
